### PR TITLE
Corrige codificação do arquivo coordenadas.csv para UTF-8

### DIFF
--- a/Conversao_banco_Python/Cidades_Estados_Paises/coordenadas.csv
+++ b/Conversao_banco_Python/Cidades_Estados_Paises/coordenadas.csv
@@ -1,395 +1,395 @@
 codigo_ibge;municipio;latitude;longitude;capital;codigo_uf;estado;siafi_id;ddd;fuso_horario
-5200050;Abadia de Goi·s;-167573;-494412;0;52;Goi·s;1050;62;America/Sao_Paulo
+5200050;Abadia de Goi√°s;-167573;-494412;0;52;Goi√°s;1050;62;America/Sao_Paulo
 3100104;Abadia dos Dourados;-184831;-473916;0;31;Minas Gerais;4001;34;America/Sao_Paulo
-5200100;Abadi‚nia;-16197;-487057;0;52;Goi·s;9201;62;America/Sao_Paulo
-3100203;AbaetÈ;-191551;-454444;0;31;Minas Gerais;4003;37;America/Sao_Paulo
-1500107;Abaetetuba;-172183;-488788;0;15;Par·;401;91;America/Sao_Paulo
-2300101;Abaiara;-734588;-390416;0;23;Cear·;1301;88;America/Sao_Paulo
-2900108;AbaÌra;-132488;-416619;0;29;Bahia;3301;77;America/Sao_Paulo
-2900207;AbarÈ;-872073;-391162;0;29;Bahia;3303;75;America/Sao_Paulo
-4100103;Abati·;-233049;-503133;0;41;Paran·;7401;43;America/Sao_Paulo
+5200100;Abadi√¢nia;-16197;-487057;0;52;Goi√°s;9201;62;America/Sao_Paulo
+3100203;Abaet√©;-191551;-454444;0;31;Minas Gerais;4003;37;America/Sao_Paulo
+1500107;Abaetetuba;-172183;-488788;0;15;Par√°;401;91;America/Sao_Paulo
+2300101;Abaiara;-734588;-390416;0;23;Cear√°;1301;88;America/Sao_Paulo
+2900108;Aba√≠ra;-132488;-416619;0;29;Bahia;3301;77;America/Sao_Paulo
+2900207;Abar√©;-872073;-391162;0;29;Bahia;3303;75;America/Sao_Paulo
+4100103;Abati√°;-233049;-503133;0;41;Paran√°;7401;43;America/Sao_Paulo
 4200051;Abdon Batista;-276126;-510233;0;42;Santa Catarina;9939;49;America/Sao_Paulo
-1500131;Abel Figueiredo;-495333;-483933;0;15;Par·;375;94;America/Sao_Paulo
+1500131;Abel Figueiredo;-495333;-483933;0;15;Par√°;375;94;America/Sao_Paulo
 4200101;Abelardo Luz;-265716;-523229;0;42;Santa Catarina;8001;49;America/Sao_Paulo
 3100302;Abre Campo;-202996;-424743;0;31;Minas Gerais;4005;31;America/Sao_Paulo
 2600054;Abreu e Lima;-790072;-348984;0;26;Pernambuco;2631;81;America/Sao_Paulo
-1700251;Abreul‚ndia;-962101;-491518;0;17;Tocantins;337;63;America/Sao_Paulo
+1700251;Abreul√¢ndia;-962101;-491518;0;17;Tocantins;337;63;America/Sao_Paulo
 3100401;Acaiaca;-20359;-431439;0;31;Minas Gerais;4007;31;America/Sao_Paulo
-2100055;AÁail‚ndia;-494714;-475004;0;21;Maranh„o;961;99;America/Sao_Paulo
+2100055;A√ßail√¢ndia;-494714;-475004;0;21;Maranh√£o;961;99;America/Sao_Paulo
 2900306;Acajutiba;-116575;-380197;0;29;Bahia;3305;75;America/Sao_Paulo
-1500206;Acar·;-195383;-481985;0;15;Par·;403;91;America/Sao_Paulo
-2300150;Acarape;-422083;-387055;0;23;Cear·;1231;85;America/Sao_Paulo
-2300200;Acara˙;-288769;-401183;0;23;Cear·;1303;88;America/Sao_Paulo
+1500206;Acar√°;-195383;-481985;0;15;Par√°;403;91;America/Sao_Paulo
+2300150;Acarape;-422083;-387055;0;23;Cear√°;1231;85;America/Sao_Paulo
+2300200;Acara√∫;-288769;-401183;0;23;Cear√°;1303;88;America/Sao_Paulo
 2400109;Acari;-64282;-366347;0;24;Rio Grande do Norte;1601;84;America/Sao_Paulo
-2200053;Acau„;-821954;-410831;0;22;PiauÌ;266;89;America/Sao_Paulo
-4300034;Acegu·;-318665;-541615;0;43;Rio Grande do Sul;1118;53;America/Sao_Paulo
-2300309;Acopiara;-608911;-39448;0;23;Cear·;1305;88;America/Sao_Paulo
+2200053;Acau√£;-821954;-410831;0;22;Piau√≠;266;89;America/Sao_Paulo
+4300034;Acegu√°;-318665;-541615;0;43;Rio Grande do Sul;1118;53;America/Sao_Paulo
+2300309;Acopiara;-608911;-39448;0;23;Cear√°;1305;88;America/Sao_Paulo
 5100102;Acorizal;-15194;-563632;0;51;Mato Grosso;9001;65;America/Porto_Velho
-1200013;Acrel‚ndia;-982581;-668972;0;12;Acre;643;68;America/Rio_Branco
-5200134;Acre˙na;-17396;-503749;0;52;Goi·s;9645;64;America/Sao_Paulo
-2400208;AÁu;-558362;-36914;0;24;Rio Grande do Norte;1603;84;America/Sao_Paulo
-3100500;AÁucena;-190671;-425419;0;31;Minas Gerais;4009;33;America/Sao_Paulo
-3500105;Adamantina;-21682;-510737;0;35;S„o Paulo;6101;18;America/Sao_Paulo
-5200159;Adel‚ndia;-164127;-501657;0;52;Goi·s;9769;64;America/Sao_Paulo
-3500204;Adolfo;-212325;-496451;0;35;S„o Paulo;6103;17;America/Sao_Paulo
-4100202;AdrianÛpolis;-246606;-489922;0;41;Paran·;7403;41;America/Sao_Paulo
+1200013;Acrel√¢ndia;-982581;-668972;0;12;Acre;643;68;America/Rio_Branco
+5200134;Acre√∫na;-17396;-503749;0;52;Goi√°s;9645;64;America/Sao_Paulo
+2400208;A√ßu;-558362;-36914;0;24;Rio Grande do Norte;1603;84;America/Sao_Paulo
+3100500;A√ßucena;-190671;-425419;0;31;Minas Gerais;4009;33;America/Sao_Paulo
+3500105;Adamantina;-21682;-510737;0;35;S√£o Paulo;6101;18;America/Sao_Paulo
+5200159;Adel√¢ndia;-164127;-501657;0;52;Goi√°s;9769;64;America/Sao_Paulo
+3500204;Adolfo;-212325;-496451;0;35;S√£o Paulo;6103;17;America/Sao_Paulo
+4100202;Adrian√≥polis;-246606;-489922;0;41;Paran√°;7403;41;America/Sao_Paulo
 2900355;Adustina;-105437;-381113;0;29;Bahia;3253;75;America/Sao_Paulo
 2600104;Afogados da Ingazeira;-774312;-37631;0;26;Pernambuco;2301;87;America/Sao_Paulo
 2400307;Afonso Bezerra;-549229;-365075;0;24;Rio Grande do Norte;1605;84;America/Sao_Paulo
-3200102;Afonso Cl·udio;-200778;-411261;0;32;EspÌrito Santo;5601;27;America/Sao_Paulo
-2100105;Afonso Cunha;-413631;-433275;0;21;Maranh„o;701;98;America/Sao_Paulo
-2600203;Afr‚nio;-851136;-410095;0;26;Pernambuco;2303;87;America/Sao_Paulo
-1500305;Afu·;-154874;-503861;0;15;Par·;405;91;America/Sao_Paulo
+3200102;Afonso Cl√°udio;-200778;-411261;0;32;Esp√≠rito Santo;5601;27;America/Sao_Paulo
+2100105;Afonso Cunha;-413631;-433275;0;21;Maranh√£o;701;98;America/Sao_Paulo
+2600203;Afr√¢nio;-851136;-410095;0;26;Pernambuco;2303;87;America/Sao_Paulo
+1500305;Afu√°;-154874;-503861;0;15;Par√°;405;91;America/Sao_Paulo
 2600302;Agrestina;-845966;-359447;0;26;Pernambuco;2305;81;America/Sao_Paulo
-2200103;Agricol‚ndia;-579676;-426664;0;22;PiauÌ;1001;86;America/Sao_Paulo
-4200200;Agrol‚ndia;-274087;-49822;0;42;Santa Catarina;8003;47;America/Sao_Paulo
-4200309;AgronÙmica;-272662;-49708;0;42;Santa Catarina;8005;47;America/Sao_Paulo
-1500347;¡gua Azul do Norte;-679053;-504791;0;15;Par·;383;94;America/Sao_Paulo
-3100609;¡gua Boa;-179914;-423806;0;31;Minas Gerais;4011;33;America/Sao_Paulo
-5100201;¡gua Boa;-14051;-521601;0;51;Mato Grosso;9191;66;America/Porto_Velho
-2200202;¡gua Branca;-588856;-42637;0;22;PiauÌ;1003;86;America/Sao_Paulo
-2500106;¡gua Branca;-751144;-376357;0;25;ParaÌba;1901;83;America/Sao_Paulo
-2700102;¡gua Branca;-9262;-37938;0;27;Alagoas;2701;82;America/Sao_Paulo
-5000203;¡gua Clara;-204452;-52879;0;50;Mato Grosso do Sul;9003;67;America/Porto_Velho
-3100708;¡gua Comprida;-200576;-481069;0;31;Minas Gerais;4013;34;America/Sao_Paulo
-4200408;¡gua Doce;-269985;-515528;0;42;Santa Catarina;8007;49;America/Sao_Paulo
-2100154;¡gua Doce do Maranh„o;-284048;-421189;0;21;Maranh„o;104;98;America/Sao_Paulo
-3200169;¡gua Doce do Norte;-185482;-409854;0;32;EspÌrito Santo;5717;27;America/Sao_Paulo
-2900405;¡gua Fria;-118618;-387639;0;29;Bahia;3307;75;America/Sao_Paulo
-5200175;¡gua Fria de Goi·s;-149778;-477823;0;52;Goi·s;9771;62;America/Sao_Paulo
-5200209;¡gua Limpa;-180771;-487603;0;52;Goi·s;9203;64;America/Sao_Paulo
-2400406;¡gua Nova;-620351;-382941;0;24;Rio Grande do Norte;1607;84;America/Sao_Paulo
-2600401;¡gua Preta;-870609;-355263;0;26;Pernambuco;2307;81;America/Sao_Paulo
-4300059;¡gua Santa;-281672;-52031;0;43;Rio Grande do Sul;8499;54;America/Sao_Paulo
-3500303;AguaÌ;-220572;-469735;0;35;S„o Paulo;6105;19;America/Sao_Paulo
+2200103;Agricol√¢ndia;-579676;-426664;0;22;Piau√≠;1001;86;America/Sao_Paulo
+4200200;Agrol√¢ndia;-274087;-49822;0;42;Santa Catarina;8003;47;America/Sao_Paulo
+4200309;Agron√¥mica;-272662;-49708;0;42;Santa Catarina;8005;47;America/Sao_Paulo
+1500347;√Ågua Azul do Norte;-679053;-504791;0;15;Par√°;383;94;America/Sao_Paulo
+3100609;√Ågua Boa;-179914;-423806;0;31;Minas Gerais;4011;33;America/Sao_Paulo
+5100201;√Ågua Boa;-14051;-521601;0;51;Mato Grosso;9191;66;America/Porto_Velho
+2200202;√Ågua Branca;-588856;-42637;0;22;Piau√≠;1003;86;America/Sao_Paulo
+2500106;√Ågua Branca;-751144;-376357;0;25;Para√≠ba;1901;83;America/Sao_Paulo
+2700102;√Ågua Branca;-9262;-37938;0;27;Alagoas;2701;82;America/Sao_Paulo
+5000203;√Ågua Clara;-204452;-52879;0;50;Mato Grosso do Sul;9003;67;America/Porto_Velho
+3100708;√Ågua Comprida;-200576;-481069;0;31;Minas Gerais;4013;34;America/Sao_Paulo
+4200408;√Ågua Doce;-269985;-515528;0;42;Santa Catarina;8007;49;America/Sao_Paulo
+2100154;√Ågua Doce do Maranh√£o;-284048;-421189;0;21;Maranh√£o;104;98;America/Sao_Paulo
+3200169;√Ågua Doce do Norte;-185482;-409854;0;32;Esp√≠rito Santo;5717;27;America/Sao_Paulo
+2900405;√Ågua Fria;-118618;-387639;0;29;Bahia;3307;75;America/Sao_Paulo
+5200175;√Ågua Fria de Goi√°s;-149778;-477823;0;52;Goi√°s;9771;62;America/Sao_Paulo
+5200209;√Ågua Limpa;-180771;-487603;0;52;Goi√°s;9203;64;America/Sao_Paulo
+2400406;√Ågua Nova;-620351;-382941;0;24;Rio Grande do Norte;1607;84;America/Sao_Paulo
+2600401;√Ågua Preta;-870609;-355263;0;26;Pernambuco;2307;81;America/Sao_Paulo
+4300059;√Ågua Santa;-281672;-52031;0;43;Rio Grande do Sul;8499;54;America/Sao_Paulo
+3500303;Agua√≠;-220572;-469735;0;35;S√£o Paulo;6105;19;America/Sao_Paulo
 3100807;Aguanil;-209439;-453915;0;31;Minas Gerais;4015;35;America/Sao_Paulo
-2600500;¡guas Belas;-911125;-371226;0;26;Pernambuco;2309;87;America/Sao_Paulo
-3500402;¡guas da Prata;-219319;-467176;0;35;S„o Paulo;6107;19;America/Sao_Paulo
-4200507;¡guas de ChapecÛ;-270754;-529808;0;42;Santa Catarina;8009;49;America/Sao_Paulo
-3500501;¡guas de LindÛia;-224733;-466314;0;35;S„o Paulo;6109;19;America/Sao_Paulo
-3500550;¡guas de Santa B·rbara;-228812;-492421;0;35;S„o Paulo;7019;14;America/Sao_Paulo
-3500600;¡guas de S„o Pedro;-225977;-478734;0;35;S„o Paulo;6111;19;America/Sao_Paulo
-3100906;¡guas Formosas;-170802;-409384;0;31;Minas Gerais;4017;33;America/Sao_Paulo
-4200556;¡guas Frias;-268794;-528568;0;42;Santa Catarina;5577;49;America/Sao_Paulo
-5200258;¡guas Lindas de Goi·s;-157617;-482816;0;52;Goi·s;1052;61;America/Sao_Paulo
-4200606;¡guas Mornas;-276963;-488243;0;42;Santa Catarina;8011;48;America/Sao_Paulo
-3101003;¡guas Vermelhas;-157431;-414571;0;31;Minas Gerais;4019;33;America/Sao_Paulo
+2600500;√Åguas Belas;-911125;-371226;0;26;Pernambuco;2309;87;America/Sao_Paulo
+3500402;√Åguas da Prata;-219319;-467176;0;35;S√£o Paulo;6107;19;America/Sao_Paulo
+4200507;√Åguas de Chapec√≥;-270754;-529808;0;42;Santa Catarina;8009;49;America/Sao_Paulo
+3500501;√Åguas de Lind√≥ia;-224733;-466314;0;35;S√£o Paulo;6109;19;America/Sao_Paulo
+3500550;√Åguas de Santa B√°rbara;-228812;-492421;0;35;S√£o Paulo;7019;14;America/Sao_Paulo
+3500600;√Åguas de S√£o Pedro;-225977;-478734;0;35;S√£o Paulo;6111;19;America/Sao_Paulo
+3100906;√Åguas Formosas;-170802;-409384;0;31;Minas Gerais;4017;33;America/Sao_Paulo
+4200556;√Åguas Frias;-268794;-528568;0;42;Santa Catarina;5577;49;America/Sao_Paulo
+5200258;√Åguas Lindas de Goi√°s;-157617;-482816;0;52;Goi√°s;1052;61;America/Sao_Paulo
+4200606;√Åguas Mornas;-276963;-488243;0;42;Santa Catarina;8011;48;America/Sao_Paulo
+3101003;√Åguas Vermelhas;-157431;-414571;0;31;Minas Gerais;4019;33;America/Sao_Paulo
 4300109;Agudo;-296447;-532515;0;43;Rio Grande do Sul;8501;55;America/Sao_Paulo
-3500709;Agudos;-224694;-489863;0;35;S„o Paulo;6113;14;America/Sao_Paulo
-4100301;Agudos do Sul;-259899;-493343;0;41;Paran·;7405;41;America/Sao_Paulo
-3200136;¡guia Branca;-189846;-407437;0;32;EspÌrito Santo;5733;27;America/Sao_Paulo
-2500205;Aguiar;-70918;-381681;0;25;ParaÌba;1903;83;America/Sao_Paulo
-1700301;AguiarnÛpolis;-655409;-474702;0;17;Tocantins;72;63;America/Sao_Paulo
-3101102;AimorÈs;-195007;-410746;0;31;Minas Gerais;4021;33;America/Sao_Paulo
+3500709;Agudos;-224694;-489863;0;35;S√£o Paulo;6113;14;America/Sao_Paulo
+4100301;Agudos do Sul;-259899;-493343;0;41;Paran√°;7405;41;America/Sao_Paulo
+3200136;√Åguia Branca;-189846;-407437;0;32;Esp√≠rito Santo;5733;27;America/Sao_Paulo
+2500205;Aguiar;-70918;-381681;0;25;Para√≠ba;1903;83;America/Sao_Paulo
+1700301;Aguiarn√≥polis;-655409;-474702;0;17;Tocantins;72;63;America/Sao_Paulo
+3101102;Aimor√©s;-195007;-410746;0;31;Minas Gerais;4021;33;America/Sao_Paulo
 2900603;Aiquara;-141269;-398937;0;29;Bahia;3311;73;America/Sao_Paulo
-2300408;Aiuaba;-657122;-401178;0;23;Cear·;1307;88;America/Sao_Paulo
+2300408;Aiuaba;-657122;-401178;0;23;Cear√°;1307;88;America/Sao_Paulo
 3101201;Aiuruoca;-219736;-446042;0;31;Minas Gerais;4023;35;America/Sao_Paulo
 4300208;Ajuricaba;-282342;-537757;0;43;Rio Grande do Sul;8503;55;America/Sao_Paulo
 3101300;Alagoa;-22171;-446413;0;31;Minas Gerais;4025;35;America/Sao_Paulo
-2500304;Alagoa Grande;-703943;-356206;0;25;ParaÌba;1905;83;America/Sao_Paulo
-2500403;Alagoa Nova;-705377;-357591;0;25;ParaÌba;1907;83;America/Sao_Paulo
-2500502;Alagoinha;-694657;-355332;0;25;ParaÌba;1909;83;America/Sao_Paulo
+2500304;Alagoa Grande;-703943;-356206;0;25;Para√≠ba;1905;83;America/Sao_Paulo
+2500403;Alagoa Nova;-705377;-357591;0;25;Para√≠ba;1907;83;America/Sao_Paulo
+2500502;Alagoinha;-694657;-355332;0;25;Para√≠ba;1909;83;America/Sao_Paulo
 2600609;Alagoinha;-84665;-367788;0;26;Pernambuco;2311;87;America/Sao_Paulo
-2200251;Alagoinha do PiauÌ;-700039;-409282;0;22;PiauÌ;9767;89;America/Sao_Paulo
+2200251;Alagoinha do Piau√≠;-700039;-409282;0;22;Piau√≠;9767;89;America/Sao_Paulo
 2900702;Alagoinhas;-121335;-384208;0;29;Bahia;3313;75;America/Sao_Paulo
-3500758;Alambari;-235503;-47898;0;35;S„o Paulo;2995;15;America/Sao_Paulo
+3500758;Alambari;-235503;-47898;0;35;S√£o Paulo;2995;15;America/Sao_Paulo
 3101409;Albertina;-222018;-466139;0;31;Minas Gerais;4027;35;America/Sao_Paulo
-2100204;Alc‚ntara;-239574;-444062;0;21;Maranh„o;703;98;America/Sao_Paulo
-2300507;Alc‚ntaras;-358537;-405479;0;23;Cear·;1309;88;America/Sao_Paulo
-2500536;Alcantil;-773668;-360511;0;25;ParaÌba;440;83;America/Sao_Paulo
-5000252;AlcinÛpolis;-183255;-537042;0;50;Mato Grosso do Sul;141;67;America/Porto_Velho
-2900801;AlcobaÁa;-175195;-392036;0;29;Bahia;3315;73;America/Sao_Paulo
-2100303;Aldeias Altas;-462621;-434689;0;21;Maranh„o;705;99;America/Sao_Paulo
+2100204;Alc√¢ntara;-239574;-444062;0;21;Maranh√£o;703;98;America/Sao_Paulo
+2300507;Alc√¢ntaras;-358537;-405479;0;23;Cear√°;1309;88;America/Sao_Paulo
+2500536;Alcantil;-773668;-360511;0;25;Para√≠ba;440;83;America/Sao_Paulo
+5000252;Alcin√≥polis;-183255;-537042;0;50;Mato Grosso do Sul;141;67;America/Porto_Velho
+2900801;Alcoba√ßa;-175195;-392036;0;29;Bahia;3315;73;America/Sao_Paulo
+2100303;Aldeias Altas;-462621;-434689;0;21;Maranh√£o;705;99;America/Sao_Paulo
 4300307;Alecrim;-276579;-547649;0;43;Rio Grande do Sul;8505;55;America/Sao_Paulo
-3200201;Alegre;-20758;-415382;0;32;EspÌrito Santo;5603;28;America/Sao_Paulo
+3200201;Alegre;-20758;-415382;0;32;Esp√≠rito Santo;5603;28;America/Sao_Paulo
 4300406;Alegrete;-297902;-557949;0;43;Rio Grande do Sul;8507;55;America/Sao_Paulo
-2200277;Alegrete do PiauÌ;-724196;-408566;0;22;PiauÌ;2269;89;America/Sao_Paulo
+2200277;Alegrete do Piau√≠;-724196;-408566;0;22;Piau√≠;2269;89;America/Sao_Paulo
 4300455;Alegria;-278345;-540557;0;43;Rio Grande do Sul;8497;55;America/Sao_Paulo
-3101508;AlÈm ParaÌba;-218797;-427176;0;31;Minas Gerais;4029;32;America/Sao_Paulo
-1500404;Alenquer;-194623;-547384;0;15;Par·;407;93;America/Sao_Paulo
+3101508;Al√©m Para√≠ba;-218797;-427176;0;31;Minas Gerais;4029;32;America/Sao_Paulo
+1500404;Alenquer;-194623;-547384;0;15;Par√°;407;93;America/Sao_Paulo
 2400505;Alexandria;-640533;-380142;0;24;Rio Grande do Norte;1609;84;America/Sao_Paulo
-5200308;Alex‚nia;-160834;-485076;0;52;Goi·s;9205;62;America/Sao_Paulo
+5200308;Alex√¢nia;-160834;-485076;0;52;Goi√°s;9205;62;America/Sao_Paulo
 3101607;Alfenas;-214256;-459477;0;31;Minas Gerais;4031;35;America/Sao_Paulo
-3200300;Alfredo Chaves;-206396;-407543;0;32;EspÌrito Santo;5605;27;America/Sao_Paulo
-3500808;Alfredo Marcondes;-219527;-51414;0;35;S„o Paulo;6115;18;America/Sao_Paulo
+3200300;Alfredo Chaves;-206396;-407543;0;32;Esp√≠rito Santo;5605;27;America/Sao_Paulo
+3500808;Alfredo Marcondes;-219527;-51414;0;35;S√£o Paulo;6115;18;America/Sao_Paulo
 3101631;Alfredo Vasconcelos;-211535;-437718;0;31;Minas Gerais;2681;32;America/Sao_Paulo
 4200705;Alfredo Wagner;-277001;-493273;0;42;Santa Catarina;8013;48;America/Sao_Paulo
-2500577;Algod„o de JandaÌra;-689292;-360129;0;25;ParaÌba;442;83;America/Sao_Paulo
-2500601;Alhandra;-742977;-349057;0;25;ParaÌba;1911;83;America/Sao_Paulo
-2600708;AlianÁa;-760398;-352227;0;26;Pernambuco;2313;81;America/Sao_Paulo
-1700350;AlianÁa do Tocantins;-113056;-489361;0;17;Tocantins;9441;63;America/Sao_Paulo
+2500577;Algod√£o de Janda√≠ra;-689292;-360129;0;25;Para√≠ba;442;83;America/Sao_Paulo
+2500601;Alhandra;-742977;-349057;0;25;Para√≠ba;1911;83;America/Sao_Paulo
+2600708;Alian√ßa;-760398;-352227;0;26;Pernambuco;2313;81;America/Sao_Paulo
+1700350;Alian√ßa do Tocantins;-113056;-489361;0;17;Tocantins;9441;63;America/Sao_Paulo
 2900900;Almadina;-147089;-396415;0;29;Bahia;3317;73;America/Sao_Paulo
 1700400;Almas;-115706;-471792;0;17;Tocantins;9207;63;America/Sao_Paulo
-1500503;Almeirim;-152904;-525788;0;15;Par·;409;93;America/Sao_Paulo
+1500503;Almeirim;-152904;-525788;0;15;Par√°;409;93;America/Sao_Paulo
 3101706;Almenara;-161785;-406942;0;31;Minas Gerais;4033;33;America/Sao_Paulo
 2400604;Almino Afonso;-61475;-377636;0;24;Rio Grande do Norte;1611;84;America/Sao_Paulo
-4100400;Almirante TamandarÈ;-253188;-493037;0;41;Paran·;7407;41;America/Sao_Paulo
-4300471;Almirante TamandarÈ do Sul;-281149;-529142;0;43;Rio Grande do Sul;1120;54;America/Sao_Paulo
-5200506;Alo‚ndia;-177292;-494769;0;52;Goi·s;9209;64;America/Sao_Paulo
+4100400;Almirante Tamandar√©;-253188;-493037;0;41;Paran√°;7407;41;America/Sao_Paulo
+4300471;Almirante Tamandar√© do Sul;-281149;-529142;0;43;Rio Grande do Sul;1120;54;America/Sao_Paulo
+5200506;Alo√¢ndia;-177292;-494769;0;52;Goi√°s;9209;64;America/Sao_Paulo
 3101805;Alpercata;-18974;-4197;0;31;Minas Gerais;4035;33;America/Sao_Paulo
 4300505;Alpestre;-272502;-530341;0;43;Rio Grande do Sul;8509;55;America/Sao_Paulo
-3101904;AlpinÛpolis;-208631;-463878;0;31;Minas Gerais;4037;35;America/Sao_Paulo
+3101904;Alpin√≥polis;-208631;-463878;0;31;Minas Gerais;4037;35;America/Sao_Paulo
 5100250;Alta Floresta;-986674;-560867;0;51;Mato Grosso;8987;66;America/Porto_Velho
-1100015;Alta Floresta D'Oeste;-119283;-619953;0;11;RondÙnia;33;69;America/Porto_Velho
-3500907;Altair;-205242;-490571;0;35;S„o Paulo;6117;17;America/Sao_Paulo
-1500602;Altamira;-320407;-5221;0;15;Par·;411;93;America/Sao_Paulo
-2100402;Altamira do Maranh„o;-416598;-454706;0;21;Maranh„o;707;98;America/Sao_Paulo
-4100459;Altamira do Paran·;-247983;-527128;0;41;Paran·;8455;44;America/Sao_Paulo
-2300606;Altaneira;-699837;-397356;0;23;Cear·;1311;88;America/Sao_Paulo
+1100015;Alta Floresta D'Oeste;-119283;-619953;0;11;Rond√¥nia;33;69;America/Porto_Velho
+3500907;Altair;-205242;-490571;0;35;S√£o Paulo;6117;17;America/Sao_Paulo
+1500602;Altamira;-320407;-5221;0;15;Par√°;411;93;America/Sao_Paulo
+2100402;Altamira do Maranh√£o;-416598;-454706;0;21;Maranh√£o;707;98;America/Sao_Paulo
+4100459;Altamira do Paran√°;-247983;-527128;0;41;Paran√°;8455;44;America/Sao_Paulo
+2300606;Altaneira;-699837;-397356;0;23;Cear√°;1311;88;America/Sao_Paulo
 3102001;Alterosa;-212488;-461387;0;31;Minas Gerais;4039;35;America/Sao_Paulo
 2600807;Altinho;-848482;-360644;0;26;Pernambuco;2315;81;America/Sao_Paulo
-3501004;AltinÛpolis;-210214;-473712;0;35;S„o Paulo;6119;16;America/Sao_Paulo
-3501103;Alto Alegre;-215811;-50168;0;35;S„o Paulo;6121;18;America/Sao_Paulo
+3501004;Altin√≥polis;-210214;-473712;0;35;S√£o Paulo;6119;16;America/Sao_Paulo
+3501103;Alto Alegre;-215811;-50168;0;35;S√£o Paulo;6121;18;America/Sao_Paulo
 1400050;Alto Alegre;298858;-613072;0;14;Roraima;305;95;America/Porto_Velho
 4300554;Alto Alegre;-287769;-529893;0;43;Rio Grande do Sul;8495;54;America/Sao_Paulo
-2100436;Alto Alegre do Maranh„o;-4213;-44446;0;21;Maranh„o;106;99;America/Sao_Paulo
-2100477;Alto Alegre do PindarÈ;-366689;-458421;0;21;Maranh„o;108;98;America/Sao_Paulo
-1100379;Alto Alegre dos Parecis;-12132;-61835;0;11;RondÙnia;2;69;America/Porto_Velho
+2100436;Alto Alegre do Maranh√£o;-4213;-44446;0;21;Maranh√£o;106;99;America/Sao_Paulo
+2100477;Alto Alegre do Pindar√©;-366689;-458421;0;21;Maranh√£o;108;98;America/Sao_Paulo
+1100379;Alto Alegre dos Parecis;-12132;-61835;0;11;Rond√¥nia;2;69;America/Porto_Velho
 5100300;Alto Araguaia;-173153;-532181;0;51;Mato Grosso;9005;66;America/Porto_Velho
 4200754;Alto Bela Vista;-274333;-519044;0;42;Santa Catarina;886;49;America/Sao_Paulo
 5100359;Alto Boa Vista;-116732;-513883;0;51;Mato Grosso;127;66;America/Porto_Velho
-3102050;Alto CaparaÛ;-20431;-418738;0;31;Minas Gerais;564;32;America/Sao_Paulo
+3102050;Alto Capara√≥;-20431;-418738;0;31;Minas Gerais;564;32;America/Sao_Paulo
 2400703;Alto do Rodrigues;-528186;-3675;0;24;Rio Grande do Norte;1613;84;America/Sao_Paulo
 4300570;Alto Feliz;-293919;-513123;0;43;Rio Grande do Sul;6045;51;America/Sao_Paulo
-5100409;Alto GarÁas;-169462;-535272;0;51;Mato Grosso;9007;66;America/Porto_Velho
-5200555;Alto Horizonte;-141978;-493378;0;52;Goi·s;85;62;America/Sao_Paulo
-3153509;Alto Jequitib·;-204208;-41967;0;31;Minas Gerais;5069;33;America/Sao_Paulo
-2200301;Alto Long·;-525634;-422096;0;22;PiauÌ;1005;86;America/Sao_Paulo
+5100409;Alto Gar√ßas;-169462;-535272;0;51;Mato Grosso;9007;66;America/Porto_Velho
+5200555;Alto Horizonte;-141978;-493378;0;52;Goi√°s;85;62;America/Sao_Paulo
+3153509;Alto Jequitib√°;-204208;-41967;0;31;Minas Gerais;5069;33;America/Sao_Paulo
+2200301;Alto Long√°;-525634;-422096;0;22;Piau√≠;1005;86;America/Sao_Paulo
 5100508;Alto Paraguai;-145137;-564776;0;51;Mato Grosso;9009;65;America/Porto_Velho
-4128625;Alto ParaÌso;-261146;-527469;0;41;Paran·;5523;44;America/Sao_Paulo
-1100403;Alto ParaÌso;-971429;-633188;0;11;RondÙnia;675;69;America/Porto_Velho
-5200605;Alto ParaÌso de Goi·s;-141305;-4751;0;52;Goi·s;9211;62;America/Sao_Paulo
-4100608;Alto Paran·;-231312;-523189;0;41;Paran·;7409;44;America/Sao_Paulo
-2100501;Alto ParnaÌba;-910273;-459303;0;21;Maranh„o;709;99;America/Sao_Paulo
-4100707;Alto Piquiri;-240224;-5344;0;41;Paran·;7411;44;America/Sao_Paulo
+4128625;Alto Para√≠so;-261146;-527469;0;41;Paran√°;5523;44;America/Sao_Paulo
+1100403;Alto Para√≠so;-971429;-633188;0;11;Rond√¥nia;675;69;America/Porto_Velho
+5200605;Alto Para√≠so de Goi√°s;-141305;-4751;0;52;Goi√°s;9211;62;America/Sao_Paulo
+4100608;Alto Paran√°;-231312;-523189;0;41;Paran√°;7409;44;America/Sao_Paulo
+2100501;Alto Parna√≠ba;-910273;-459303;0;21;Maranh√£o;709;99;America/Sao_Paulo
+4100707;Alto Piquiri;-240224;-5344;0;41;Paran√°;7411;44;America/Sao_Paulo
 3102100;Alto Rio Doce;-210281;-434067;0;31;Minas Gerais;4041;32;America/Sao_Paulo
-3200359;Alto Rio Novo;-190618;-410209;0;32;EspÌrito Santo;5719;27;America/Sao_Paulo
-2300705;Alto Santo;-550894;-382743;0;23;Cear·;1313;88;America/Sao_Paulo
+3200359;Alto Rio Novo;-190618;-410209;0;32;Esp√≠rito Santo;5719;27;America/Sao_Paulo
+2300705;Alto Santo;-550894;-382743;0;23;Cear√°;1313;88;America/Sao_Paulo
 5100607;Alto Taquari;-178241;-532792;0;51;Mato Grosso;9911;66;America/Porto_Velho
-4100509;AltÙnia;-238759;-538958;0;41;Paran·;7951;44;America/Sao_Paulo
-2200400;Altos;-503888;-424612;0;22;PiauÌ;1007;86;America/Sao_Paulo
-3501152;AlumÌnio;-235306;-472546;0;35;S„o Paulo;3065;11;America/Sao_Paulo
-1300029;Alvar„es;-322727;-648007;0;13;Amazonas;289;97;America/Porto_Velho
+4100509;Alt√¥nia;-238759;-538958;0;41;Paran√°;7951;44;America/Sao_Paulo
+2200400;Altos;-503888;-424612;0;22;Piau√≠;1007;86;America/Sao_Paulo
+3501152;Alum√≠nio;-235306;-472546;0;35;S√£o Paulo;3065;11;America/Sao_Paulo
+1300029;Alvar√£es;-322727;-648007;0;13;Amazonas;289;97;America/Porto_Velho
 3102209;Alvarenga;-194174;-417317;0;31;Minas Gerais;4043;33;America/Sao_Paulo
-3501202;¡lvares Florence;-203203;-499141;0;35;S„o Paulo;6123;17;America/Sao_Paulo
-3501301;¡lvares Machado;-220764;-514722;0;35;S„o Paulo;6125;18;America/Sao_Paulo
-3501400;¡lvaro de Carvalho;-220841;-49719;0;35;S„o Paulo;6127;14;America/Sao_Paulo
-3501509;Alvinl‚ndia;-224435;-497623;0;35;S„o Paulo;6129;14;America/Sao_Paulo
-3102308;AlvinÛpolis;-201098;-430535;0;31;Minas Gerais;4045;31;America/Sao_Paulo
+3501202;√Ålvares Florence;-203203;-499141;0;35;S√£o Paulo;6123;17;America/Sao_Paulo
+3501301;√Ålvares Machado;-220764;-514722;0;35;S√£o Paulo;6125;18;America/Sao_Paulo
+3501400;√Ålvaro de Carvalho;-220841;-49719;0;35;S√£o Paulo;6127;14;America/Sao_Paulo
+3501509;Alvinl√¢ndia;-224435;-497623;0;35;S√£o Paulo;6129;14;America/Sao_Paulo
+3102308;Alvin√≥polis;-201098;-430535;0;31;Minas Gerais;4045;31;America/Sao_Paulo
 1700707;Alvorada;-124785;-491249;0;17;Tocantins;9213;63;America/Sao_Paulo
 4300604;Alvorada;-299914;-510809;0;43;Rio Grande do Sul;8511;51;America/Sao_Paulo
-1100346;Alvorada D'Oeste;-113463;-622847;0;11;RondÙnia;35;69;America/Porto_Velho
+1100346;Alvorada D'Oeste;-113463;-622847;0;11;Rond√¥nia;35;69;America/Porto_Velho
 3102407;Alvorada de Minas;-187334;-433638;0;31;Minas Gerais;4047;31;America/Sao_Paulo
-2200459;Alvorada do GurguÈia;-842418;-43777;0;22;PiauÌ;268;89;America/Sao_Paulo
-5200803;Alvorada do Norte;-144797;-46491;0;52;Goi·s;9215;62;America/Sao_Paulo
-4100806;Alvorada do Sul;-227813;-512297;0;41;Paran·;7413;43;America/Sao_Paulo
+2200459;Alvorada do Gurgu√©ia;-842418;-43777;0;22;Piau√≠;268;89;America/Sao_Paulo
+5200803;Alvorada do Norte;-144797;-46491;0;52;Goi√°s;9215;62;America/Sao_Paulo
+4100806;Alvorada do Sul;-227813;-512297;0;41;Paran√°;7413;43;America/Sao_Paulo
 1400027;Amajari;364571;-613692;0;14;Roraima;26;95;America/Porto_Velho
 5000609;Amambai;-231058;-552253;0;50;Mato Grosso do Sul;9011;67;America/Porto_Velho
-1600105;Amap·;205267;-507957;0;16;Amap·;601;96;America/Sao_Paulo
-2100550;Amap· do Maranh„o;-167524;-460024;0;21;Maranh„o;110;98;America/Sao_Paulo
-4100905;Amapor„;-230943;-527866;0;41;Paran·;7415;44;America/Sao_Paulo
+1600105;Amap√°;205267;-507957;0;16;Amap√°;601;96;America/Sao_Paulo
+2100550;Amap√° do Maranh√£o;-167524;-460024;0;21;Maranh√£o;110;98;America/Sao_Paulo
+4100905;Amapor√£;-230943;-527866;0;41;Paran√°;7415;44;America/Sao_Paulo
 2600906;Amaraji;-837691;-354501;0;26;Pernambuco;2317;81;America/Sao_Paulo
 4300638;Amaral Ferrador;-308756;-522509;0;43;Rio Grande do Sul;8493;51;America/Sao_Paulo
-5200829;Amaralina;-139236;-492962;0;52;Goi·s;1054;62;America/Sao_Paulo
-2200509;Amarante;-624304;-428433;0;22;PiauÌ;1009;86;America/Sao_Paulo
-2100600;Amarante do Maranh„o;-556913;-467473;0;21;Maranh„o;711;99;America/Sao_Paulo
+5200829;Amaralina;-139236;-492962;0;52;Goi√°s;1054;62;America/Sao_Paulo
+2200509;Amarante;-624304;-428433;0;22;Piau√≠;1009;86;America/Sao_Paulo
+2100600;Amarante do Maranh√£o;-556913;-467473;0;21;Maranh√£o;711;99;America/Sao_Paulo
 2901007;Amargosa;-130215;-39602;0;29;Bahia;3319;75;America/Sao_Paulo
-1300060;Amatur·;-337455;-682005;0;13;Amazonas;291;97;America/Porto_Velho
-2901106;AmÈlia Rodrigues;-123914;-387563;0;29;Bahia;3321;75;America/Sao_Paulo
-2901155;AmÈrica Dourada;-114429;-41439;0;29;Bahia;3071;74;America/Sao_Paulo
-3501608;Americana;-227374;-473331;0;35;S„o Paulo;6131;19;America/Sao_Paulo
-5200852;Americano do Brasil;-162514;-499831;0;52;Goi·s;9661;64;America/Sao_Paulo
-3501707;AmÈrico Brasiliense;-217288;-481147;0;35;S„o Paulo;6133;16;America/Sao_Paulo
-3501806;AmÈrico de Campos;-202985;-497359;0;35;S„o Paulo;6135;17;America/Sao_Paulo
+1300060;Amatur√°;-337455;-682005;0;13;Amazonas;291;97;America/Porto_Velho
+2901106;Am√©lia Rodrigues;-123914;-387563;0;29;Bahia;3321;75;America/Sao_Paulo
+2901155;Am√©rica Dourada;-114429;-41439;0;29;Bahia;3071;74;America/Sao_Paulo
+3501608;Americana;-227374;-473331;0;35;S√£o Paulo;6131;19;America/Sao_Paulo
+5200852;Americano do Brasil;-162514;-499831;0;52;Goi√°s;9661;64;America/Sao_Paulo
+3501707;Am√©rico Brasiliense;-217288;-481147;0;35;S√£o Paulo;6133;16;America/Sao_Paulo
+3501806;Am√©rico de Campos;-202985;-497359;0;35;S√£o Paulo;6135;17;America/Sao_Paulo
 4300646;Ametista do Sul;-273607;-53183;0;43;Rio Grande do Sul;5969;55;America/Sao_Paulo
-2300754;Amontada;-336017;-398288;0;23;Cear·;1587;88;America/Sao_Paulo
-5200902;AmorinÛpolis;-166151;-510919;0;52;Goi·s;9217;64;America/Sao_Paulo
-2500734;Amparo;-755502;-370628;0;25;ParaÌba;444;83;America/Sao_Paulo
-3501905;Amparo;-227088;-46772;0;35;S„o Paulo;6137;19;America/Sao_Paulo
-2800100;Amparo de S„o Francisco;-101348;-36935;0;28;Sergipe;3101;79;America/Sao_Paulo
+2300754;Amontada;-336017;-398288;0;23;Cear√°;1587;88;America/Sao_Paulo
+5200902;Amorin√≥polis;-166151;-510919;0;52;Goi√°s;9217;64;America/Sao_Paulo
+2500734;Amparo;-755502;-370628;0;25;Para√≠ba;444;83;America/Sao_Paulo
+3501905;Amparo;-227088;-46772;0;35;S√£o Paulo;6137;19;America/Sao_Paulo
+2800100;Amparo de S√£o Francisco;-101348;-36935;0;28;Sergipe;3101;79;America/Sao_Paulo
 3102506;Amparo do Serra;-205051;-428009;0;31;Minas Gerais;4049;31;America/Sao_Paulo
-4101002;AmpÈre;-259168;-534686;0;41;Paran·;7417;46;America/Sao_Paulo
+4101002;Amp√©re;-259168;-534686;0;41;Paran√°;7417;46;America/Sao_Paulo
 2700201;Anadia;-968489;-363078;0;27;Alagoas;2703;82;America/Sao_Paulo
-2901205;AnagÈ;-146151;-411356;0;29;Bahia;3323;77;America/Sao_Paulo
-4101051;Anahy;-246449;-531332;0;41;Paran·;5463;45;America/Sao_Paulo
-1500701;Anaj·s;-996811;-499354;0;15;Par·;413;91;America/Sao_Paulo
-2100709;Anajatuba;-326269;-446126;0;21;Maranh„o;713;98;America/Sao_Paulo
-3502002;Anal‚ndia;-221289;-476619;0;35;S„o Paulo;6139;19;America/Sao_Paulo
-1300086;Anam„;-356697;-613963;0;13;Amazonas;293;97;America/Porto_Velho
-1701002;Anan·s;-636437;-480735;0;17;Tocantins;9219;63;America/Sao_Paulo
-1500800;Ananindeua;-136391;-483743;0;15;Par·;415;91;America/Sao_Paulo
-5201108;An·polis;-163281;-48953;0;52;Goi·s;9221;62;America/Sao_Paulo
-1500859;Anapu;-346985;-512003;0;15;Par·;40;91;America/Sao_Paulo
-2100808;Anapurus;-367577;-431014;0;21;Maranh„o;715;98;America/Sao_Paulo
-5000708;Anast·cio;-204823;-558104;0;50;Mato Grosso do Sul;9013;67;America/Porto_Velho
-5000807;Anauril‚ndia;-221852;-527191;0;50;Mato Grosso do Sul;9015;67;America/Porto_Velho
+2901205;Anag√©;-146151;-411356;0;29;Bahia;3323;77;America/Sao_Paulo
+4101051;Anahy;-246449;-531332;0;41;Paran√°;5463;45;America/Sao_Paulo
+1500701;Anaj√°s;-996811;-499354;0;15;Par√°;413;91;America/Sao_Paulo
+2100709;Anajatuba;-326269;-446126;0;21;Maranh√£o;713;98;America/Sao_Paulo
+3502002;Anal√¢ndia;-221289;-476619;0;35;S√£o Paulo;6139;19;America/Sao_Paulo
+1300086;Anam√£;-356697;-613963;0;13;Amazonas;293;97;America/Porto_Velho
+1701002;Anan√°s;-636437;-480735;0;17;Tocantins;9219;63;America/Sao_Paulo
+1500800;Ananindeua;-136391;-483743;0;15;Par√°;415;91;America/Sao_Paulo
+5201108;An√°polis;-163281;-48953;0;52;Goi√°s;9221;62;America/Sao_Paulo
+1500859;Anapu;-346985;-512003;0;15;Par√°;40;91;America/Sao_Paulo
+2100808;Anapurus;-367577;-431014;0;21;Maranh√£o;715;98;America/Sao_Paulo
+5000708;Anast√°cio;-204823;-558104;0;50;Mato Grosso do Sul;9013;67;America/Porto_Velho
+5000807;Anauril√¢ndia;-221852;-527191;0;50;Mato Grosso do Sul;9015;67;America/Porto_Velho
 4200804;Anchieta;-265382;-533319;0;42;Santa Catarina;8015;49;America/Sao_Paulo
-3200409;Anchieta;-207955;-406425;0;32;EspÌrito Santo;5607;28;America/Sao_Paulo
-2901304;AndaraÌ;-128049;-413297;0;29;Bahia;3325;75;America/Sao_Paulo
-4101101;Andir·;-230533;-502304;0;41;Paran·;7419;43;America/Sao_Paulo
+3200409;Anchieta;-207955;-406425;0;32;Esp√≠rito Santo;5607;28;America/Sao_Paulo
+2901304;Andara√≠;-128049;-413297;0;29;Bahia;3325;75;America/Sao_Paulo
+4101101;Andir√°;-230533;-502304;0;41;Paran√°;7419;43;America/Sao_Paulo
 2901353;Andorinha;-103482;-398391;0;29;Bahia;3255;74;America/Sao_Paulo
 3102605;Andradas;-220695;-465724;0;31;Minas Gerais;4051;35;America/Sao_Paulo
-3502101;Andradina;-208948;-513786;0;35;S„o Paulo;6141;18;America/Sao_Paulo
-4300661;AndrÈ da Rocha;-286283;-515797;0;43;Rio Grande do Sul;8491;54;America/Sao_Paulo
-3102803;Andrel‚ndia;-217411;-443117;0;31;Minas Gerais;4055;35;America/Sao_Paulo
-3502200;Angatuba;-234917;-484139;0;35;S„o Paulo;6143;15;America/Sao_Paulo
-3102852;Angel‚ndia;-177279;-422641;0;31;Minas Gerais;566;33;America/Sao_Paulo
-5000856;AngÈlica;-221527;-537708;0;50;Mato Grosso do Sul;9169;67;America/Porto_Velho
+3502101;Andradina;-208948;-513786;0;35;S√£o Paulo;6141;18;America/Sao_Paulo
+4300661;Andr√© da Rocha;-286283;-515797;0;43;Rio Grande do Sul;8491;54;America/Sao_Paulo
+3102803;Andrel√¢ndia;-217411;-443117;0;31;Minas Gerais;4055;35;America/Sao_Paulo
+3502200;Angatuba;-234917;-484139;0;35;S√£o Paulo;6143;15;America/Sao_Paulo
+3102852;Angel√¢ndia;-177279;-422641;0;31;Minas Gerais;566;33;America/Sao_Paulo
+5000856;Ang√©lica;-221527;-537708;0;50;Mato Grosso do Sul;9169;67;America/Porto_Velho
 2601003;Angelim;-888429;-362902;0;26;Pernambuco;2319;87;America/Sao_Paulo
 4200903;Angelina;-275704;-489879;0;42;Santa Catarina;8017;48;America/Sao_Paulo
 2901403;Angical;-120063;-447003;0;29;Bahia;3327;77;America/Sao_Paulo
-2200608;Angical do PiauÌ;-608786;-4274;0;22;PiauÌ;1011;86;America/Sao_Paulo
+2200608;Angical do Piau√≠;-608786;-4274;0;22;Piau√≠;1011;86;America/Sao_Paulo
 1701051;Angico;-639179;-478611;0;17;Tocantins;165;63;America/Sao_Paulo
 2400802;Angicos;-565792;-366094;0;24;Rio Grande do Norte;1615;84;America/Sao_Paulo
 3300100;Angra dos Reis;-230011;-443196;0;33;Rio de Janeiro;5801;24;America/Sao_Paulo
 2901502;Anguera;-121462;-392462;0;29;Bahia;3329;75;America/Sao_Paulo
-4101150;¬ngulo;-231946;-519154;0;41;Paran·;5509;44;America/Sao_Paulo
-5201207;Anhanguera;-183339;-482204;0;52;Goi·s;9223;64;America/Sao_Paulo
-3502309;Anhembi;-22793;-481336;0;35;S„o Paulo;6145;14;America/Sao_Paulo
-3502408;Anhumas;-222934;-513895;0;35;S„o Paulo;6147;18;America/Sao_Paulo
-5201306;Anicuns;-164642;-499617;0;52;Goi·s;9225;64;America/Sao_Paulo
-2200707;AnÌsio de Abreu;-918564;-430494;0;22;PiauÌ;1013;89;America/Sao_Paulo
+4101150;√Çngulo;-231946;-519154;0;41;Paran√°;5509;44;America/Sao_Paulo
+5201207;Anhanguera;-183339;-482204;0;52;Goi√°s;9223;64;America/Sao_Paulo
+3502309;Anhembi;-22793;-481336;0;35;S√£o Paulo;6145;14;America/Sao_Paulo
+3502408;Anhumas;-222934;-513895;0;35;S√£o Paulo;6147;18;America/Sao_Paulo
+5201306;Anicuns;-164642;-499617;0;52;Goi√°s;9225;64;America/Sao_Paulo
+2200707;An√≠sio de Abreu;-918564;-430494;0;22;Piau√≠;1013;89;America/Sao_Paulo
 4201000;Anita Garibaldi;-276897;-511271;0;42;Santa Catarina;8019;49;America/Sao_Paulo
-4201109;Anit·polis;-279012;-491316;0;42;Santa Catarina;8021;48;America/Sao_Paulo
+4201109;Anit√°polis;-279012;-491316;0;42;Santa Catarina;8021;48;America/Sao_Paulo
 1300102;Anori;-374603;-616575;0;13;Amazonas;203;97;America/Porto_Velho
 4300703;Anta Gorda;-289698;-520102;0;43;Rio Grande do Sul;8513;51;America/Sao_Paulo
 2901601;Antas;-103856;-383401;0;29;Bahia;3331;75;America/Sao_Paulo
-4101200;Antonina;-254386;-487191;0;41;Paran·;7421;41;America/Sao_Paulo
-2300804;Antonina do Norte;-676919;-39987;0;23;Cear·;1315;88;America/Sao_Paulo
-2200806;AntÙnio Almeida;-721276;-441889;0;22;PiauÌ;1015;89;America/Sao_Paulo
-2901700;AntÙnio Cardoso;-124335;-391176;0;29;Bahia;3333;75;America/Sao_Paulo
-4201208;AntÙnio Carlos;-275191;-48766;0;42;Santa Catarina;8023;48;America/Sao_Paulo
-3102902;AntÙnio Carlos;-21321;-437451;0;31;Minas Gerais;4057;32;America/Sao_Paulo
-3103009;AntÙnio Dias;-196491;-428732;0;31;Minas Gerais;4059;31;America/Sao_Paulo
-2901809;AntÙnio GonÁalves;-105767;-402785;0;29;Bahia;3335;74;America/Sao_Paulo
-5000906;AntÙnio Jo„o;-221927;-559517;0;50;Mato Grosso do Sul;9017;67;America/Porto_Velho
-2400901;AntÙnio Martins;-621367;-378834;0;24;Rio Grande do Norte;1617;84;America/Sao_Paulo
-4101309;AntÙnio Olinto;-259804;-501972;0;41;Paran·;7423;42;America/Sao_Paulo
-4300802;AntÙnio Prado;-288565;-512883;0;43;Rio Grande do Sul;8515;54;America/Sao_Paulo
-3103108;AntÙnio Prado de Minas;-210192;-421109;0;31;Minas Gerais;4061;32;America/Sao_Paulo
-2500775;Aparecida;-678466;-380803;0;25;ParaÌba;446;83;America/Sao_Paulo
-3502507;Aparecida;-228495;-452325;0;35;S„o Paulo;6149;12;America/Sao_Paulo
-3502606;Aparecida d'Oeste;-204487;-508835;0;35;S„o Paulo;6151;17;America/Sao_Paulo
-5201405;Aparecida de Goi‚nia;-168198;-492469;0;52;Goi·s;9227;62;America/Sao_Paulo
-5201454;Aparecida do Rio Doce;-182941;-511516;0;52;Goi·s;71;64;America/Sao_Paulo
+4101200;Antonina;-254386;-487191;0;41;Paran√°;7421;41;America/Sao_Paulo
+2300804;Antonina do Norte;-676919;-39987;0;23;Cear√°;1315;88;America/Sao_Paulo
+2200806;Ant√¥nio Almeida;-721276;-441889;0;22;Piau√≠;1015;89;America/Sao_Paulo
+2901700;Ant√¥nio Cardoso;-124335;-391176;0;29;Bahia;3333;75;America/Sao_Paulo
+4201208;Ant√¥nio Carlos;-275191;-48766;0;42;Santa Catarina;8023;48;America/Sao_Paulo
+3102902;Ant√¥nio Carlos;-21321;-437451;0;31;Minas Gerais;4057;32;America/Sao_Paulo
+3103009;Ant√¥nio Dias;-196491;-428732;0;31;Minas Gerais;4059;31;America/Sao_Paulo
+2901809;Ant√¥nio Gon√ßalves;-105767;-402785;0;29;Bahia;3335;74;America/Sao_Paulo
+5000906;Ant√¥nio Jo√£o;-221927;-559517;0;50;Mato Grosso do Sul;9017;67;America/Porto_Velho
+2400901;Ant√¥nio Martins;-621367;-378834;0;24;Rio Grande do Norte;1617;84;America/Sao_Paulo
+4101309;Ant√¥nio Olinto;-259804;-501972;0;41;Paran√°;7423;42;America/Sao_Paulo
+4300802;Ant√¥nio Prado;-288565;-512883;0;43;Rio Grande do Sul;8515;54;America/Sao_Paulo
+3103108;Ant√¥nio Prado de Minas;-210192;-421109;0;31;Minas Gerais;4061;32;America/Sao_Paulo
+2500775;Aparecida;-678466;-380803;0;25;Para√≠ba;446;83;America/Sao_Paulo
+3502507;Aparecida;-228495;-452325;0;35;S√£o Paulo;6149;12;America/Sao_Paulo
+3502606;Aparecida d'Oeste;-204487;-508835;0;35;S√£o Paulo;6151;17;America/Sao_Paulo
+5201405;Aparecida de Goi√¢nia;-168198;-492469;0;52;Goi√°s;9227;62;America/Sao_Paulo
+5201454;Aparecida do Rio Doce;-182941;-511516;0;52;Goi√°s;71;64;America/Sao_Paulo
 1701101;Aparecida do Rio Negro;-994139;-479638;0;17;Tocantins;9713;63;America/Sao_Paulo
 5001003;Aparecida do Taboado;-200873;-510961;0;50;Mato Grosso do Sul;9019;67;America/Porto_Velho
-3300159;AperibÈ;-216252;-421017;0;33;Rio de Janeiro;2919;22;America/Sao_Paulo
-3200508;Apiac·;-211523;-415693;0;32;EspÌrito Santo;5609;28;America/Sao_Paulo
-5100805;Apiac·s;-953981;-574587;0;51;Mato Grosso;9773;66;America/Porto_Velho
-3502705;ApiaÌ;-245108;-488443;0;35;S„o Paulo;6153;15;America/Sao_Paulo
-2100832;Apicum-AÁu;-145862;-450864;0;21;Maranh„o;112;98;America/Sao_Paulo
-4201257;Api˙na;-270375;-493885;0;42;Santa Catarina;9941;47;America/Sao_Paulo
+3300159;Aperib√©;-216252;-421017;0;33;Rio de Janeiro;2919;22;America/Sao_Paulo
+3200508;Apiac√°;-211523;-415693;0;32;Esp√≠rito Santo;5609;28;America/Sao_Paulo
+5100805;Apiac√°s;-953981;-574587;0;51;Mato Grosso;9773;66;America/Porto_Velho
+3502705;Apia√≠;-245108;-488443;0;35;S√£o Paulo;6153;15;America/Sao_Paulo
+2100832;Apicum-A√ßu;-145862;-450864;0;21;Maranh√£o;112;98;America/Sao_Paulo
+4201257;Api√∫na;-270375;-493885;0;42;Santa Catarina;9941;47;America/Sao_Paulo
 2401008;Apodi;-565349;-377946;0;24;Rio Grande do Norte;1619;84;America/Sao_Paulo
-2901908;Apor·;-116577;-380814;0;29;Bahia;3337;75;America/Sao_Paulo
-5201504;AporÈ;-189607;-519232;0;52;Goi·s;9229;64;America/Sao_Paulo
+2901908;Apor√°;-116577;-380814;0;29;Bahia;3337;75;America/Sao_Paulo
+5201504;Apor√©;-189607;-519232;0;52;Goi√°s;9229;64;America/Sao_Paulo
 2901957;Apuarema;-138542;-397501;0;29;Bahia;3257;73;America/Sao_Paulo
-4101408;Apucarana;-2355;-514635;0;41;Paran·;7425;43;America/Sao_Paulo
-1300144;ApuÌ;-719409;-59896;0;13;Amazonas;969;97;America/Porto_Velho
-2300903;ApuiarÈs;-394506;-394359;0;23;Cear·;1317;85;America/Sao_Paulo
-2800209;Aquidab„;-10278;-370148;0;28;Sergipe;3103;79;America/Sao_Paulo
+4101408;Apucarana;-2355;-514635;0;41;Paran√°;7425;43;America/Sao_Paulo
+1300144;Apu√≠;-719409;-59896;0;13;Amazonas;969;97;America/Porto_Velho
+2300903;Apuiar√©s;-394506;-394359;0;23;Cear√°;1317;85;America/Sao_Paulo
+2800209;Aquidab√£;-10278;-370148;0;28;Sergipe;3103;79;America/Sao_Paulo
 5001102;Aquidauana;-204666;-557868;0;50;Mato Grosso do Sul;9021;67;America/Porto_Velho
-2301000;Aquiraz;-389929;-383896;0;23;Cear·;1319;85;America/Sao_Paulo
-4201273;Arabut„;-271587;-521423;0;42;Santa Catarina;5597;49;America/Sao_Paulo
-2500809;AraÁagi;-684374;-353737;0;25;ParaÌba;1915;83;America/Sao_Paulo
-3103207;AraÁaÌ;-191955;-442493;0;31;Minas Gerais;4063;31;America/Sao_Paulo
+2301000;Aquiraz;-389929;-383896;0;23;Cear√°;1319;85;America/Sao_Paulo
+4201273;Arabut√£;-271587;-521423;0;42;Santa Catarina;5597;49;America/Sao_Paulo
+2500809;Ara√ßagi;-684374;-353737;0;25;Para√≠ba;1915;83;America/Sao_Paulo
+3103207;Ara√ßa√≠;-191955;-442493;0;31;Minas Gerais;4063;31;America/Sao_Paulo
 2800308;Aracaju;-109091;-370677;1;28;Sergipe;3105;79;America/Sao_Paulo
-3502754;AraÁariguama;-234366;-470608;0;35;S„o Paulo;3067;11;America/Sao_Paulo
-2902054;AraÁas;-1222;-382027;0;29;Bahia;3259;75;America/Sao_Paulo
-2301109;Aracati;-455826;-377679;0;23;Cear·;1321;88;America/Sao_Paulo
+3502754;Ara√ßariguama;-234366;-470608;0;35;S√£o Paulo;3067;11;America/Sao_Paulo
+2902054;Ara√ßas;-1222;-382027;0;29;Bahia;3259;75;America/Sao_Paulo
+2301109;Aracati;-455826;-377679;0;23;Cear√°;1321;88;America/Sao_Paulo
 2902005;Aracatu;-14428;-414648;0;29;Bahia;3339;77;America/Sao_Paulo
-3502804;AraÁatuba;-212076;-504401;0;35;S„o Paulo;6155;18;America/Sao_Paulo
+3502804;Ara√ßatuba;-212076;-504401;0;35;S√£o Paulo;6155;18;America/Sao_Paulo
 2902104;Araci;-113253;-389584;0;29;Bahia;3341;75;America/Sao_Paulo
 3103306;Aracitaba;-213446;-433736;0;31;Minas Gerais;4065;32;America/Sao_Paulo
-2601052;AraÁoiaba;-778391;-350809;0;26;Pernambuco;544;81;America/Sao_Paulo
-2301208;Aracoiaba;-436872;-388125;0;23;Cear·;1323;85;America/Sao_Paulo
-3502903;AraÁoiaba da Serra;-235029;-476166;0;35;S„o Paulo;6157;15;America/Sao_Paulo
-3200607;Aracruz;-1982;-402764;0;32;EspÌrito Santo;5611;27;America/Sao_Paulo
-5201603;AraÁu;-163563;-496804;0;52;Goi·s;9231;62;America/Sao_Paulo
-3103405;AraÁuaÌ;-168523;-420637;0;31;Minas Gerais;4067;33;America/Sao_Paulo
-5201702;AragarÁas;-158955;-522372;0;52;Goi·s;9233;64;America/Sao_Paulo
-5201801;Aragoi‚nia;-169087;-494476;0;52;Goi·s;9235;62;America/Sao_Paulo
+2601052;Ara√ßoiaba;-778391;-350809;0;26;Pernambuco;544;81;America/Sao_Paulo
+2301208;Aracoiaba;-436872;-388125;0;23;Cear√°;1323;85;America/Sao_Paulo
+3502903;Ara√ßoiaba da Serra;-235029;-476166;0;35;S√£o Paulo;6157;15;America/Sao_Paulo
+3200607;Aracruz;-1982;-402764;0;32;Esp√≠rito Santo;5611;27;America/Sao_Paulo
+5201603;Ara√ßu;-163563;-496804;0;52;Goi√°s;9231;62;America/Sao_Paulo
+3103405;Ara√ßua√≠;-168523;-420637;0;31;Minas Gerais;4067;33;America/Sao_Paulo
+5201702;Aragar√ßas;-158955;-522372;0;52;Goi√°s;9233;64;America/Sao_Paulo
+5201801;Aragoi√¢nia;-169087;-494476;0;52;Goi√°s;9235;62;America/Sao_Paulo
 1701309;Aragominas;-716005;-485291;0;17;Tocantins;167;63;America/Sao_Paulo
 1701903;Araguacema;-880755;-495569;0;17;Tocantins;9237;63;America/Sao_Paulo
-1702000;AraguaÁu;-129289;-498231;0;17;Tocantins;9239;63;America/Sao_Paulo
+1702000;Aragua√ßu;-129289;-498231;0;17;Tocantins;9239;63;America/Sao_Paulo
 5101001;Araguaiana;-157291;-518341;0;51;Mato Grosso;9869;66;America/Porto_Velho
-1702109;AraguaÌna;-719238;-482044;0;17;Tocantins;9241;63;America/Sao_Paulo
+1702109;Aragua√≠na;-719238;-482044;0;17;Tocantins;9241;63;America/Sao_Paulo
 5101209;Araguainha;-16857;-530318;0;51;Mato Grosso;9023;66;America/Porto_Velho
-1702158;Araguan„;-658225;-486395;0;17;Tocantins;169;63;America/Sao_Paulo
-2100873;Araguan„;-294644;-456589;0;21;Maranh„o;114;98;America/Sao_Paulo
-5202155;Araguapaz;-150909;-506315;0;52;Goi·s;9669;62;America/Sao_Paulo
+1702158;Araguan√£;-658225;-486395;0;17;Tocantins;169;63;America/Sao_Paulo
+2100873;Araguan√£;-294644;-456589;0;21;Maranh√£o;114;98;America/Sao_Paulo
+5202155;Araguapaz;-150909;-506315;0;52;Goi√°s;9669;62;America/Sao_Paulo
 3103504;Araguari;-186456;-481934;0;31;Minas Gerais;4069;34;America/Sao_Paulo
 1702208;Araguatins;-564659;-481232;0;17;Tocantins;9243;63;America/Sao_Paulo
-2100907;Araioses;-289091;-41905;0;21;Maranh„o;717;98;America/Sao_Paulo
+2100907;Araioses;-289091;-41905;0;21;Maranh√£o;717;98;America/Sao_Paulo
 5001243;Aral Moreira;-229385;-556334;0;50;Mato Grosso do Sul;9171;67;America/Porto_Velho
 2902203;Aramari;-120884;-384969;0;29;Bahia;3343;75;America/Sao_Paulo
-4300851;ArambarÈ;-309092;-515046;0;43;Rio Grande do Sul;5779;51;America/Sao_Paulo
-2100956;Arame;-488347;-460032;0;21;Maranh„o;1281;99;America/Sao_Paulo
-3503000;Aramina;-200882;-477873;0;35;S„o Paulo;6159;16;America/Sao_Paulo
-3503109;Arandu;-231386;-490487;0;35;S„o Paulo;6161;14;America/Sao_Paulo
+4300851;Arambar√©;-309092;-515046;0;43;Rio Grande do Sul;5779;51;America/Sao_Paulo
+2100956;Arame;-488347;-460032;0;21;Maranh√£o;1281;99;America/Sao_Paulo
+3503000;Aramina;-200882;-477873;0;35;S√£o Paulo;6159;16;America/Sao_Paulo
+3503109;Arandu;-231386;-490487;0;35;S√£o Paulo;6161;14;America/Sao_Paulo
 3103603;Arantina;-219102;-442555;0;31;Minas Gerais;4071;32;America/Sao_Paulo
-3503158;ArapeÌ;-226717;-444441;0;35;S„o Paulo;2991;12;America/Sao_Paulo
+3503158;Arape√≠;-226717;-444441;0;35;S√£o Paulo;2991;12;America/Sao_Paulo
 2700300;Arapiraca;-975487;-366615;0;27;Alagoas;2705;82;America/Sao_Paulo
 1702307;Arapoema;-765463;-490637;0;17;Tocantins;9245;63;America/Sao_Paulo
 3103702;Araponga;-206686;-425178;0;31;Minas Gerais;4073;31;America/Sao_Paulo
-4101507;Arapongas;-234153;-514259;0;41;Paran·;7427;43;America/Sao_Paulo
-3103751;Arapor„;-184357;-491847;0;31;Minas Gerais;2903;34;America/Sao_Paulo
-4101606;Arapoti;-241548;-498285;0;41;Paran·;7429;43;America/Sao_Paulo
-4101655;Arapu„;-243132;-517856;0;41;Paran·;830;43;America/Sao_Paulo
-3103801;Arapu·;-190268;-461484;0;31;Minas Gerais;4075;34;America/Sao_Paulo
+4101507;Arapongas;-234153;-514259;0;41;Paran√°;7427;43;America/Sao_Paulo
+3103751;Arapor√£;-184357;-491847;0;31;Minas Gerais;2903;34;America/Sao_Paulo
+4101606;Arapoti;-241548;-498285;0;41;Paran√°;7429;43;America/Sao_Paulo
+4101655;Arapu√£;-243132;-517856;0;41;Paran√°;830;43;America/Sao_Paulo
+3103801;Arapu√°;-190268;-461484;0;31;Minas Gerais;4075;34;America/Sao_Paulo
 5101258;Araputanga;-154641;-583425;0;51;Mato Grosso;8989;65;America/Porto_Velho
 4201307;Araquari;-263754;-487188;0;42;Santa Catarina;8025;47;America/Sao_Paulo
-2500908;Arara;-682813;-357552;0;25;ParaÌba;1917;83;America/Sao_Paulo
-4201406;Ararangu·;-289356;-494918;0;42;Santa Catarina;8027;48;America/Sao_Paulo
-3503208;Araraquara;-217845;-48178;0;35;S„o Paulo;6163;16;America/Sao_Paulo
-3503307;Araras;-223572;-473842;0;35;S„o Paulo;6165;19;America/Sao_Paulo
-2301257;Ararend·;-474567;-40831;0;23;Cear·;989;88;America/Sao_Paulo
-2101004;Arari;-345214;-447665;0;21;Maranh„o;719;98;America/Sao_Paulo
-4300877;Araric·;-296168;-509291;0;43;Rio Grande do Sul;952;51;America/Sao_Paulo
-2301307;Araripe;-721319;-401359;0;23;Cear·;1325;88;America/Sao_Paulo
+2500908;Arara;-682813;-357552;0;25;Para√≠ba;1917;83;America/Sao_Paulo
+4201406;Ararangu√°;-289356;-494918;0;42;Santa Catarina;8027;48;America/Sao_Paulo
+3503208;Araraquara;-217845;-48178;0;35;S√£o Paulo;6163;16;America/Sao_Paulo
+3503307;Araras;-223572;-473842;0;35;S√£o Paulo;6165;19;America/Sao_Paulo
+2301257;Ararend√°;-474567;-40831;0;23;Cear√°;989;88;America/Sao_Paulo
+2101004;Arari;-345214;-447665;0;21;Maranh√£o;719;98;America/Sao_Paulo
+4300877;Araric√°;-296168;-509291;0;43;Rio Grande do Sul;952;51;America/Sao_Paulo
+2301307;Araripe;-721319;-401359;0;23;Cear√°;1325;88;America/Sao_Paulo
 2601102;Araripina;-757073;-40494;0;26;Pernambuco;2321;87;America/Sao_Paulo
 3300209;Araruama;-228697;-423326;0;33;Rio de Janeiro;5803;22;America/Sao_Paulo
-4101705;Araruna;-239315;-525021;0;41;Paran·;7431;44;America/Sao_Paulo
-2501005;Araruna;-654848;-357498;0;25;ParaÌba;1919;83;America/Sao_Paulo
+4101705;Araruna;-239315;-525021;0;41;Paran√°;7431;44;America/Sao_Paulo
+2501005;Araruna;-654848;-357498;0;25;Para√≠ba;1919;83;America/Sao_Paulo
 2902252;Arataca;-152651;-39419;0;29;Bahia;3073;73;America/Sao_Paulo
 4300901;Aratiba;-273978;-522975;0;43;Rio Grande do Sul;8517;54;America/Sao_Paulo
-2301406;Aratuba;-441229;-390471;0;23;Cear·;1327;85;America/Sao_Paulo
-2902302;AratuÌpe;-130716;-390038;0;29;Bahia;3345;75;America/Sao_Paulo
-2800407;Arau·;-112614;-376201;0;28;Sergipe;3107;79;America/Sao_Paulo
-4101804;Arauc·ria;-255859;-494047;0;41;Paran·;7435;41;America/Sao_Paulo
-3103900;Ara˙jos;-199405;-451671;0;31;Minas Gerais;4077;37;America/Sao_Paulo
-3104007;Arax·;-195902;-469438;0;31;Minas Gerais;4079;34;America/Sao_Paulo
+2301406;Aratuba;-441229;-390471;0;23;Cear√°;1327;85;America/Sao_Paulo
+2902302;Aratu√≠pe;-130716;-390038;0;29;Bahia;3345;75;America/Sao_Paulo
+2800407;Arau√°;-112614;-376201;0;28;Sergipe;3107;79;America/Sao_Paulo
+4101804;Arauc√°ria;-255859;-494047;0;41;Paran√°;7435;41;America/Sao_Paulo
+3103900;Ara√∫jos;-199405;-451671;0;31;Minas Gerais;4077;37;America/Sao_Paulo
+3104007;Arax√°;-195902;-469438;0;31;Minas Gerais;4079;34;America/Sao_Paulo
 3104106;Arceburgo;-21359;-469401;0;31;Minas Gerais;4081;35;America/Sao_Paulo
-3503356;Arco-Õris;-217728;-50466;0;35;S„o Paulo;790;14;America/Sao_Paulo
+3503356;Arco-√çris;-217728;-50466;0;35;S√£o Paulo;790;14;America/Sao_Paulo
 3104205;Arcos;-202863;-455373;0;31;Minas Gerais;4083;37;America/Sao_Paulo
 2601201;Arcoverde;-841519;-370577;0;26;Pernambuco;2323;87;America/Sao_Paulo
 3104304;Areado;-213572;-461421;0;31;Minas Gerais;4085;35;America/Sao_Paulo
 3300225;Areal;-222283;-431118;0;33;Rio de Janeiro;2925;24;America/Sao_Paulo
-3503406;Arealva;-22031;-489135;0;35;S„o Paulo;6167;14;America/Sao_Paulo
-2501104;Areia;-696396;-356977;0;25;ParaÌba;1921;83;America/Sao_Paulo
+3503406;Arealva;-22031;-489135;0;35;S√£o Paulo;6167;14;America/Sao_Paulo
+2501104;Areia;-696396;-356977;0;25;Para√≠ba;1921;83;America/Sao_Paulo
 2401107;Areia Branca;-495254;-371252;0;24;Rio Grande do Norte;1621;84;America/Sao_Paulo
 2800506;Areia Branca;-10758;-373251;0;28;Sergipe;3109;79;America/Sao_Paulo
-2501153;Areia de Bara˙nas;-711702;-369404;0;25;ParaÌba;448;83;America/Sao_Paulo
-2501203;Areial;-704789;-359313;0;25;ParaÌba;1923;83;America/Sao_Paulo
-3503505;Areias;-225786;-446992;0;35;S„o Paulo;6169;12;America/Sao_Paulo
-3503604;AreiÛpolis;-226672;-486681;0;35;S„o Paulo;6171;14;America/Sao_Paulo
-5101308;Aren·polis;-144472;-568437;0;51;Mato Grosso;9025;65;America/Porto_Velho
-5202353;ArenÛpolis;-163837;-515563;0;52;Goi·s;9671;64;America/Sao_Paulo
-2401206;ArÍs;-618831;-351608;0;24;Rio Grande do Norte;1623;84;America/Sao_Paulo
+2501153;Areia de Bara√∫nas;-711702;-369404;0;25;Para√≠ba;448;83;America/Sao_Paulo
+2501203;Areial;-704789;-359313;0;25;Para√≠ba;1923;83;America/Sao_Paulo
+3503505;Areias;-225786;-446992;0;35;S√£o Paulo;6169;12;America/Sao_Paulo
+3503604;Arei√≥polis;-226672;-486681;0;35;S√£o Paulo;6171;14;America/Sao_Paulo
+5101308;Aren√°polis;-144472;-568437;0;51;Mato Grosso;9025;65;America/Porto_Velho
+5202353;Aren√≥polis;-163837;-515563;0;52;Goi√°s;9671;64;America/Sao_Paulo
+2401206;Ar√™s;-618831;-351608;0;24;Rio Grande do Norte;1623;84;America/Sao_Paulo
 3104403;Argirita;-216083;-428292;0;31;Minas Gerais;4087;32;America/Sao_Paulo
 3104452;Aricanduva;-178666;-425533;0;31;Minas Gerais;568;33;America/Sao_Paulo
 3104502;Arinos;-159187;-461043;0;31;Minas Gerais;4089;38;America/Sao_Paulo
-5101407;Aripuan„;-101723;-594568;0;51;Mato Grosso;9027;66;America/Porto_Velho
-1100023;Ariquemes;-990571;-630325;0;11;RondÙnia;7;69;America/Porto_Velho
-3503703;Ariranha;-211872;-487904;0;35;S„o Paulo;6173;17;America/Sao_Paulo
-4101853;Ariranha do IvaÌ;-243857;-515839;0;41;Paran·;832;43;America/Sao_Paulo
-3300233;ArmaÁ„o dos B˙zios;-227528;-418846;0;33;Rio de Janeiro;770;22;America/Sao_Paulo
-4201505;ArmazÈm;-282448;-490215;0;42;Santa Catarina;8029;48;America/Sao_Paulo
-2301505;Arneiroz;-63165;-401653;0;23;Cear·;1329;88;America/Sao_Paulo
-2200905;Aroazes;-611022;-417822;0;22;PiauÌ;1017;89;America/Sao_Paulo
-2501302;Aroeiras;-754473;-357066;0;25;ParaÌba;1925;83;America/Sao_Paulo
-2200954;Aroeiras do Itaim;-724502;-415325;0;22;PiauÌ;1188;89;America/Sao_Paulo
-2201002;Arraial;-665075;-425418;0;22;PiauÌ;1019;89;America/Sao_Paulo
+5101407;Aripuan√£;-101723;-594568;0;51;Mato Grosso;9027;66;America/Porto_Velho
+1100023;Ariquemes;-990571;-630325;0;11;Rond√¥nia;7;69;America/Porto_Velho
+3503703;Ariranha;-211872;-487904;0;35;S√£o Paulo;6173;17;America/Sao_Paulo
+4101853;Ariranha do Iva√≠;-243857;-515839;0;41;Paran√°;832;43;America/Sao_Paulo
+3300233;Arma√ß√£o dos B√∫zios;-227528;-418846;0;33;Rio de Janeiro;770;22;America/Sao_Paulo
+4201505;Armaz√©m;-282448;-490215;0;42;Santa Catarina;8029;48;America/Sao_Paulo
+2301505;Arneiroz;-63165;-401653;0;23;Cear√°;1329;88;America/Sao_Paulo
+2200905;Aroazes;-611022;-417822;0;22;Piau√≠;1017;89;America/Sao_Paulo
+2501302;Aroeiras;-754473;-357066;0;25;Para√≠ba;1925;83;America/Sao_Paulo
+2200954;Aroeiras do Itaim;-724502;-415325;0;22;Piau√≠;1188;89;America/Sao_Paulo
+2201002;Arraial;-665075;-425418;0;22;Piau√≠;1019;89;America/Sao_Paulo
 3300258;Arraial do Cabo;-229774;-420267;0;33;Rio de Janeiro;5927;22;America/Sao_Paulo
 1702406;Arraias;-129287;-469359;0;17;Tocantins;9247;63;America/Sao_Paulo
 4301008;Arroio do Meio;-294014;-519557;0;43;Rio Grande do Sul;8519;51;America/Sao_Paulo
@@ -399,193 +399,193 @@ codigo_ibge;municipio;latitude;longitude;capital;codigo_uf;estado;siafi_id;ddd;f
 4301107;Arroio dos Ratos;-300875;-517275;0;43;Rio Grande do Sul;8521;51;America/Sao_Paulo
 4301305;Arroio Grande;-322327;-530862;0;43;Rio Grande do Sul;8525;53;America/Sao_Paulo
 4201604;Arroio Trinta;-269257;-513407;0;42;Santa Catarina;8031;49;America/Sao_Paulo
-3503802;Artur Nogueira;-225727;-471727;0;35;S„o Paulo;6175;19;America/Sao_Paulo
-5202502;Aruan„;-149166;-51075;0;52;Goi·s;9249;62;America/Sao_Paulo
-3503901;Aruj·;-233965;-4632;0;35;S„o Paulo;6177;11;America/Sao_Paulo
+3503802;Artur Nogueira;-225727;-471727;0;35;S√£o Paulo;6175;19;America/Sao_Paulo
+5202502;Aruan√£;-149166;-51075;0;52;Goi√°s;9249;62;America/Sao_Paulo
+3503901;Aruj√°;-233965;-4632;0;35;S√£o Paulo;6177;11;America/Sao_Paulo
 4201653;Arvoredo;-270748;-524543;0;42;Santa Catarina;5599;49;America/Sao_Paulo
 4301404;Arvorezinha;-288737;-521781;0;43;Rio Grande do Sul;8527;51;America/Sao_Paulo
 4201703;Ascurra;-269548;-493783;0;42;Santa Catarina;8033;47;America/Sao_Paulo
-3503950;Asp·sia;-2016;-50728;0;35;S„o Paulo;2981;17;America/Sao_Paulo
-4101903;AssaÌ;-233697;-508459;0;41;Paran·;7437;43;America/Sao_Paulo
-2301604;AssarÈ;-68669;-398689;0;23;Cear·;1331;88;America/Sao_Paulo
-3504008;Assis;-2266;-504183;0;35;S„o Paulo;6179;18;America/Sao_Paulo
+3503950;Asp√°sia;-2016;-50728;0;35;S√£o Paulo;2981;17;America/Sao_Paulo
+4101903;Assa√≠;-233697;-508459;0;41;Paran√°;7437;43;America/Sao_Paulo
+2301604;Assar√©;-68669;-398689;0;23;Cear√°;1331;88;America/Sao_Paulo
+3504008;Assis;-2266;-504183;0;35;S√£o Paulo;6179;18;America/Sao_Paulo
 1200054;Assis Brasil;-109298;-695738;0;12;Acre;157;68;America/Rio_Branco
-4102000;Assis Chateaubriand;-244168;-535213;0;41;Paran·;7953;44;America/Sao_Paulo
-2501351;AssunÁ„o;-707231;-36725;0;25;ParaÌba;450;83;America/Sao_Paulo
-2201051;AssunÁ„o do PiauÌ;-5865;-410389;0;22;PiauÌ;270;86;America/Sao_Paulo
+4102000;Assis Chateaubriand;-244168;-535213;0;41;Paran√°;7953;44;America/Sao_Paulo
+2501351;Assun√ß√£o;-707231;-36725;0;25;Para√≠ba;450;83;America/Sao_Paulo
+2201051;Assun√ß√£o do Piau√≠;-5865;-410389;0;22;Piau√≠;270;86;America/Sao_Paulo
 3104601;Astolfo Dutra;-213184;-428572;0;31;Minas Gerais;4091;32;America/Sao_Paulo
-4102109;Astorga;-232318;-516668;0;41;Paran·;7439;44;America/Sao_Paulo
-4102208;Atalaia;-231517;-520551;0;41;Paran·;7441;44;America/Sao_Paulo
+4102109;Astorga;-232318;-516668;0;41;Paran√°;7439;44;America/Sao_Paulo
+4102208;Atalaia;-231517;-520551;0;41;Paran√°;7441;44;America/Sao_Paulo
 2700409;Atalaia;-95119;-360086;0;27;Alagoas;2707;82;America/Sao_Paulo
 1300201;Atalaia do Norte;-437055;-701967;0;13;Amazonas;205;97;America/Rio_Branco
 4201802;Atalanta;-274219;-497789;0;42;Santa Catarina;8035;47;America/Sao_Paulo
-3104700;AtalÈia;-180438;-411149;0;31;Minas Gerais;4093;33;America/Sao_Paulo
-3504107;Atibaia;-231171;-465563;0;35;S„o Paulo;6181;11;America/Sao_Paulo
-3200706;Atilio Vivacqua;-20913;-411986;0;32;EspÌrito Santo;5613;28;America/Sao_Paulo
-1702554;AugustinÛpolis;-546863;-478863;0;17;Tocantins;9685;63;America/Sao_Paulo
-1500909;Augusto CorrÍa;-105109;-466147;0;15;Par·;417;91;America/Sao_Paulo
+3104700;Atal√©ia;-180438;-411149;0;31;Minas Gerais;4093;33;America/Sao_Paulo
+3504107;Atibaia;-231171;-465563;0;35;S√£o Paulo;6181;11;America/Sao_Paulo
+3200706;Atilio Vivacqua;-20913;-411986;0;32;Esp√≠rito Santo;5613;28;America/Sao_Paulo
+1702554;Augustin√≥polis;-546863;-478863;0;17;Tocantins;9685;63;America/Sao_Paulo
+1500909;Augusto Corr√™a;-105109;-466147;0;15;Par√°;417;91;America/Sao_Paulo
 3104809;Augusto de Lima;-180997;-442655;0;31;Minas Gerais;4095;38;America/Sao_Paulo
 4301503;Augusto Pestana;-285172;-539883;0;43;Rio Grande do Sul;8529;55;America/Sao_Paulo
 2401305;Augusto Severo (Campo Grande);-586206;-373135;0;24;Rio Grande do Norte;1625;84;America/Sao_Paulo
-4301552;¡urea;-276936;-520505;0;43;Rio Grande do Sul;8487;54;America/Sao_Paulo
+4301552;√Åurea;-276936;-520505;0;43;Rio Grande do Sul;8487;54;America/Sao_Paulo
 2902401;Aurelino Leal;-14321;-39329;0;29;Bahia;3347;73;America/Sao_Paulo
-3504206;Auriflama;-206836;-505572;0;35;S„o Paulo;6183;17;America/Sao_Paulo
-5202601;Auril‚ndia;-166773;-504641;0;52;Goi·s;9251;64;America/Sao_Paulo
-2301703;Aurora;-693349;-389742;0;23;Cear·;1333;88;America/Sao_Paulo
+3504206;Auriflama;-206836;-505572;0;35;S√£o Paulo;6183;17;America/Sao_Paulo
+5202601;Auril√¢ndia;-166773;-504641;0;52;Goi√°s;9251;64;America/Sao_Paulo
+2301703;Aurora;-693349;-389742;0;23;Cear√°;1333;88;America/Sao_Paulo
 4201901;Aurora;-273098;-496295;0;42;Santa Catarina;8037;47;America/Sao_Paulo
-1500958;Aurora do Par·;-214898;-475677;0;15;Par·;389;91;America/Sao_Paulo
+1500958;Aurora do Par√°;-214898;-475677;0;15;Par√°;389;91;America/Sao_Paulo
 1702703;Aurora do Tocantins;-127105;-464076;0;17;Tocantins;9253;63;America/Sao_Paulo
 1300300;Autazes;-358574;-591256;0;13;Amazonas;207;92;America/Porto_Velho
-3504305;AvaÌ;-221514;-493356;0;35;S„o Paulo;6185;14;America/Sao_Paulo
-3504404;Avanhandava;-214584;-499509;0;35;S„o Paulo;6187;18;America/Sao_Paulo
-3504503;AvarÈ;-231067;-489251;0;35;S„o Paulo;6189;14;America/Sao_Paulo
-1501006;Aveiro;-360841;-553199;0;15;Par·;419;93;America/Sao_Paulo
-2201101;Avelino Lopes;-101345;-439563;0;22;PiauÌ;1021;89;America/Sao_Paulo
-5202809;AvelinÛpolis;-164672;-497579;0;52;Goi·s;9255;64;America/Sao_Paulo
-2101103;Axix·;-283939;-44062;0;21;Maranh„o;721;98;America/Sao_Paulo
-1702901;Axix· do Tocantins;-561275;-477701;0;17;Tocantins;9257;63;America/Sao_Paulo
-1703008;BabaÁul‚ndia;-720923;-477613;0;17;Tocantins;9259;63;America/Sao_Paulo
-2101202;Bacabal;-422447;-447832;0;21;Maranh„o;723;99;America/Sao_Paulo
-2101251;Bacabeira;-296452;-443164;0;21;Maranh„o;116;98;America/Sao_Paulo
-2101301;Bacuri;-16965;-451328;0;21;Maranh„o;725;98;America/Sao_Paulo
-2101350;Bacurituba;-271;-447329;0;21;Maranh„o;118;98;America/Sao_Paulo
-3504602;Bady Bassitt;-209197;-494385;0;35;S„o Paulo;6191;17;America/Sao_Paulo
+3504305;Ava√≠;-221514;-493356;0;35;S√£o Paulo;6185;14;America/Sao_Paulo
+3504404;Avanhandava;-214584;-499509;0;35;S√£o Paulo;6187;18;America/Sao_Paulo
+3504503;Avar√©;-231067;-489251;0;35;S√£o Paulo;6189;14;America/Sao_Paulo
+1501006;Aveiro;-360841;-553199;0;15;Par√°;419;93;America/Sao_Paulo
+2201101;Avelino Lopes;-101345;-439563;0;22;Piau√≠;1021;89;America/Sao_Paulo
+5202809;Avelin√≥polis;-164672;-497579;0;52;Goi√°s;9255;64;America/Sao_Paulo
+2101103;Axix√°;-283939;-44062;0;21;Maranh√£o;721;98;America/Sao_Paulo
+1702901;Axix√° do Tocantins;-561275;-477701;0;17;Tocantins;9257;63;America/Sao_Paulo
+1703008;Baba√ßul√¢ndia;-720923;-477613;0;17;Tocantins;9259;63;America/Sao_Paulo
+2101202;Bacabal;-422447;-447832;0;21;Maranh√£o;723;99;America/Sao_Paulo
+2101251;Bacabeira;-296452;-443164;0;21;Maranh√£o;116;98;America/Sao_Paulo
+2101301;Bacuri;-16965;-451328;0;21;Maranh√£o;725;98;America/Sao_Paulo
+2101350;Bacurituba;-271;-447329;0;21;Maranh√£o;118;98;America/Sao_Paulo
+3504602;Bady Bassitt;-209197;-494385;0;35;S√£o Paulo;6191;17;America/Sao_Paulo
 3104908;Baependi;-21957;-448874;0;31;Minas Gerais;4097;35;America/Sao_Paulo
-4301602;BagÈ;-313297;-540999;0;43;Rio Grande do Sul;8531;53;America/Sao_Paulo
-1501105;Bagre;-190057;-501987;0;15;Par·;421;91;America/Sao_Paulo
-2501401;BaÌa da TraiÁ„o;-669209;-349381;0;25;ParaÌba;1929;83;America/Sao_Paulo
-2401404;BaÌa Formosa;-637161;-350033;0;24;Rio Grande do Norte;1627;84;America/Sao_Paulo
-2902500;BaianÛpolis;-123016;-445388;0;29;Bahia;3349;77;America/Sao_Paulo
-1501204;Bai„o;-279021;-496694;0;15;Par·;423;91;America/Sao_Paulo
+4301602;Bag√©;-313297;-540999;0;43;Rio Grande do Sul;8531;53;America/Sao_Paulo
+1501105;Bagre;-190057;-501987;0;15;Par√°;421;91;America/Sao_Paulo
+2501401;Ba√≠a da Trai√ß√£o;-669209;-349381;0;25;Para√≠ba;1929;83;America/Sao_Paulo
+2401404;Ba√≠a Formosa;-637161;-350033;0;24;Rio Grande do Norte;1627;84;America/Sao_Paulo
+2902500;Baian√≥polis;-123016;-445388;0;29;Bahia;3349;77;America/Sao_Paulo
+1501204;Bai√£o;-279021;-496694;0;15;Par√°;423;91;America/Sao_Paulo
 2902609;Baixa Grande;-119519;-40169;0;29;Bahia;3351;74;America/Sao_Paulo
-2201150;Baixa Grande do Ribeiro;-784903;-45219;0;22;PiauÌ;2245;89;America/Sao_Paulo
-2301802;Baixio;-671945;-387134;0;23;Cear·;1335;88;America/Sao_Paulo
-3200805;Baixo Guandu;-195213;-410109;0;32;EspÌrito Santo;5615;27;America/Sao_Paulo
-3504701;Balbinos;-218963;-493619;0;35;S„o Paulo;6193;14;America/Sao_Paulo
+2201150;Baixa Grande do Ribeiro;-784903;-45219;0;22;Piau√≠;2245;89;America/Sao_Paulo
+2301802;Baixio;-671945;-387134;0;23;Cear√°;1335;88;America/Sao_Paulo
+3200805;Baixo Guandu;-195213;-410109;0;32;Esp√≠rito Santo;5615;27;America/Sao_Paulo
+3504701;Balbinos;-218963;-493619;0;35;S√£o Paulo;6193;14;America/Sao_Paulo
 3105004;Baldim;-192832;-439613;0;31;Minas Gerais;4099;31;America/Sao_Paulo
-5203104;Baliza;-161966;-525393;0;52;Goi·s;9261;64;America/Sao_Paulo
-4201950;Balne·rio Arroio do Silva;-289806;-494237;0;42;Santa Catarina;888;48;America/Sao_Paulo
-4202057;Balne·rio Barra do Sul;-264597;-486123;0;42;Santa Catarina;5549;47;America/Sao_Paulo
-4202008;Balne·rio Cambori˙;-269926;-486352;0;42;Santa Catarina;8039;47;America/Sao_Paulo
-4202073;Balne·rio Gaivota;-291527;-495841;0;42;Santa Catarina;890;48;America/Sao_Paulo
-4212809;Balne·rio PiÁarras;-267639;-486717;0;42;Santa Catarina;8251;47;America/Sao_Paulo
-4301636;Balne·rio Pinhal;-302419;-502337;0;43;Rio Grande do Sul;954;51;America/Sao_Paulo
-4220000;Balne·rio Rinc„o;-288314;-492352;0;42;Santa Catarina;1192;48;America/Sao_Paulo
-4102307;Balsa Nova;-255804;-496291;0;41;Paran·;7443;41;America/Sao_Paulo
-3504800;B·lsamo;-207348;-495865;0;35;S„o Paulo;6195;17;America/Sao_Paulo
-2101400;Balsas;-753214;-460372;0;21;Maranh„o;727;99;America/Sao_Paulo
-3105103;BambuÌ;-200166;-459754;0;31;Minas Gerais;4101;37;America/Sao_Paulo
-2301851;Banabui˙;-530454;-389132;0;23;Cear·;1233;88;America/Sao_Paulo
-3504909;Bananal;-226819;-443281;0;35;S„o Paulo;6197;12;America/Sao_Paulo
-2501500;Bananeiras;-674775;-356246;0;25;ParaÌba;1931;83;America/Sao_Paulo
+5203104;Baliza;-161966;-525393;0;52;Goi√°s;9261;64;America/Sao_Paulo
+4201950;Balne√°rio Arroio do Silva;-289806;-494237;0;42;Santa Catarina;888;48;America/Sao_Paulo
+4202057;Balne√°rio Barra do Sul;-264597;-486123;0;42;Santa Catarina;5549;47;America/Sao_Paulo
+4202008;Balne√°rio Cambori√∫;-269926;-486352;0;42;Santa Catarina;8039;47;America/Sao_Paulo
+4202073;Balne√°rio Gaivota;-291527;-495841;0;42;Santa Catarina;890;48;America/Sao_Paulo
+4212809;Balne√°rio Pi√ßarras;-267639;-486717;0;42;Santa Catarina;8251;47;America/Sao_Paulo
+4301636;Balne√°rio Pinhal;-302419;-502337;0;43;Rio Grande do Sul;954;51;America/Sao_Paulo
+4220000;Balne√°rio Rinc√£o;-288314;-492352;0;42;Santa Catarina;1192;48;America/Sao_Paulo
+4102307;Balsa Nova;-255804;-496291;0;41;Paran√°;7443;41;America/Sao_Paulo
+3504800;B√°lsamo;-207348;-495865;0;35;S√£o Paulo;6195;17;America/Sao_Paulo
+2101400;Balsas;-753214;-460372;0;21;Maranh√£o;727;99;America/Sao_Paulo
+3105103;Bambu√≠;-200166;-459754;0;31;Minas Gerais;4101;37;America/Sao_Paulo
+2301851;Banabui√∫;-530454;-389132;0;23;Cear√°;1233;88;America/Sao_Paulo
+3504909;Bananal;-226819;-443281;0;35;S√£o Paulo;6197;12;America/Sao_Paulo
+2501500;Bananeiras;-674775;-356246;0;25;Para√≠ba;1931;83;America/Sao_Paulo
 3105202;Bandeira;-158783;-405622;0;31;Minas Gerais;4103;33;America/Sao_Paulo
 3105301;Bandeira do Sul;-217308;-463833;0;31;Minas Gerais;4105;35;America/Sao_Paulo
 4202081;Bandeirante;-267705;-536413;0;42;Santa Catarina;892;49;America/Sao_Paulo
 5001508;Bandeirantes;-199275;-543585;0;50;Mato Grosso do Sul;9029;67;America/Porto_Velho
-4102406;Bandeirantes;-231078;-503704;0;41;Paran·;7445;43;America/Sao_Paulo
+4102406;Bandeirantes;-231078;-503704;0;41;Paran√°;7445;43;America/Sao_Paulo
 1703057;Bandeirantes do Tocantins;-775612;-485836;0;17;Tocantins;74;63;America/Sao_Paulo
-1501253;Bannach;-734779;-503959;0;15;Par·;42;94;America/Sao_Paulo
-2902658;BanzaÍ;-105788;-386212;0;29;Bahia;3261;75;America/Sao_Paulo
-4301651;Bar„o;-293725;-514949;0;43;Rio Grande do Sul;8485;51;America/Sao_Paulo
-3505005;Bar„o de Antonina;-236284;-495634;0;35;S„o Paulo;6201;15;America/Sao_Paulo
-3105400;Bar„o de Cocais;-199389;-434755;0;31;Minas Gerais;4107;31;America/Sao_Paulo
-4301701;Bar„o de Cotegipe;-276208;-523798;0;43;Rio Grande do Sul;8533;54;America/Sao_Paulo
-2101509;Bar„o de Graja˙;-674463;-430261;0;21;Maranh„o;729;99;America/Sao_Paulo
-5101605;Bar„o de MelgaÁo;-162067;-559623;0;51;Mato Grosso;9031;65;America/Porto_Velho
-3105509;Bar„o de Monte Alto;-212444;-422372;0;31;Minas Gerais;4109;32;America/Sao_Paulo
-4301750;Bar„o do Triunfo;-303891;-517384;0;43;Rio Grande do Sul;5771;51;America/Sao_Paulo
-2401453;Bara˙na;-506977;-376129;0;24;Rio Grande do Norte;3003;84;America/Sao_Paulo
-2501534;Bara˙na;-663484;-362601;0;25;ParaÌba;452;83;America/Sao_Paulo
+1501253;Bannach;-734779;-503959;0;15;Par√°;42;94;America/Sao_Paulo
+2902658;Banza√™;-105788;-386212;0;29;Bahia;3261;75;America/Sao_Paulo
+4301651;Bar√£o;-293725;-514949;0;43;Rio Grande do Sul;8485;51;America/Sao_Paulo
+3505005;Bar√£o de Antonina;-236284;-495634;0;35;S√£o Paulo;6201;15;America/Sao_Paulo
+3105400;Bar√£o de Cocais;-199389;-434755;0;31;Minas Gerais;4107;31;America/Sao_Paulo
+4301701;Bar√£o de Cotegipe;-276208;-523798;0;43;Rio Grande do Sul;8533;54;America/Sao_Paulo
+2101509;Bar√£o de Graja√∫;-674463;-430261;0;21;Maranh√£o;729;99;America/Sao_Paulo
+5101605;Bar√£o de Melga√ßo;-162067;-559623;0;51;Mato Grosso;9031;65;America/Porto_Velho
+3105509;Bar√£o de Monte Alto;-212444;-422372;0;31;Minas Gerais;4109;32;America/Sao_Paulo
+4301750;Bar√£o do Triunfo;-303891;-517384;0;43;Rio Grande do Sul;5771;51;America/Sao_Paulo
+2401453;Bara√∫na;-506977;-376129;0;24;Rio Grande do Norte;3003;84;America/Sao_Paulo
+2501534;Bara√∫na;-663484;-362601;0;25;Para√≠ba;452;83;America/Sao_Paulo
 3105608;Barbacena;-212214;-437703;0;31;Minas Gerais;4111;32;America/Sao_Paulo
-2301901;Barbalha;-72982;-393021;0;23;Cear·;1337;88;America/Sao_Paulo
-3505104;Barbosa;-212657;-499518;0;35;S„o Paulo;6199;18;America/Sao_Paulo
-4102505;Barbosa Ferraz;-240334;-52004;0;41;Paran·;7447;44;America/Sao_Paulo
-1501303;Barcarena;-151187;-486195;0;15;Par·;425;91;America/Sao_Paulo
+2301901;Barbalha;-72982;-393021;0;23;Cear√°;1337;88;America/Sao_Paulo
+3505104;Barbosa;-212657;-499518;0;35;S√£o Paulo;6199;18;America/Sao_Paulo
+4102505;Barbosa Ferraz;-240334;-52004;0;41;Paran√°;7447;44;America/Sao_Paulo
+1501303;Barcarena;-151187;-486195;0;15;Par√°;425;91;America/Sao_Paulo
 2401503;Barcelona;-594284;-359247;0;24;Rio Grande do Norte;1629;84;America/Sao_Paulo
 1300409;Barcelos;-983373;-629311;0;13;Amazonas;209;97;America/Porto_Velho
-3505203;Bariri;-22073;-487438;0;35;S„o Paulo;6203;14;America/Sao_Paulo
+3505203;Bariri;-22073;-487438;0;35;S√£o Paulo;6203;14;America/Sao_Paulo
 2902708;Barra;-110859;-431459;0;29;Bahia;3353;74;America/Sao_Paulo
 4202099;Barra Bonita;-26654;-5344;0;42;Santa Catarina;894;49;America/Sao_Paulo
-3505302;Barra Bonita;-224909;-485583;0;35;S„o Paulo;6205;14;America/Sao_Paulo
-2201176;Barra D'Alc‚ntara;-651645;-421146;0;22;PiauÌ;272;89;America/Sao_Paulo
+3505302;Barra Bonita;-224909;-485583;0;35;S√£o Paulo;6205;14;America/Sao_Paulo
+2201176;Barra D'Alc√¢ntara;-651645;-421146;0;22;Piau√≠;272;89;America/Sao_Paulo
 2902807;Barra da Estiva;-136237;-413347;0;29;Bahia;3355;77;America/Sao_Paulo
 2601300;Barra de Guabiraba;-842075;-356585;0;26;Pernambuco;2325;81;America/Sao_Paulo
-2501609;Barra de Santa Rosa;-671816;-360671;0;25;ParaÌba;1933;83;America/Sao_Paulo
-2501575;Barra de Santana;-751809;-359913;0;25;ParaÌba;454;83;America/Sao_Paulo
-2700508;Barra de Santo AntÙnio;-94023;-355101;0;27;Alagoas;2709;82;America/Sao_Paulo
-3200904;Barra de S„o Francisco;-187548;-408965;0;32;EspÌrito Santo;5617;27;America/Sao_Paulo
-2501708;Barra de S„o Miguel;-774603;-363209;0;25;ParaÌba;1935;83;America/Sao_Paulo
-2700607;Barra de S„o Miguel;-983842;-359057;0;27;Alagoas;2711;82;America/Sao_Paulo
+2501609;Barra de Santa Rosa;-671816;-360671;0;25;Para√≠ba;1933;83;America/Sao_Paulo
+2501575;Barra de Santana;-751809;-359913;0;25;Para√≠ba;454;83;America/Sao_Paulo
+2700508;Barra de Santo Ant√¥nio;-94023;-355101;0;27;Alagoas;2709;82;America/Sao_Paulo
+3200904;Barra de S√£o Francisco;-187548;-408965;0;32;Esp√≠rito Santo;5617;27;America/Sao_Paulo
+2501708;Barra de S√£o Miguel;-774603;-363209;0;25;Para√≠ba;1935;83;America/Sao_Paulo
+2700607;Barra de S√£o Miguel;-983842;-359057;0;27;Alagoas;2711;82;America/Sao_Paulo
 5101704;Barra do Bugres;-150702;-571878;0;51;Mato Grosso;9033;65;America/Porto_Velho
-3505351;Barra do ChapÈu;-244722;-490238;0;35;S„o Paulo;2997;15;America/Sao_Paulo
-2902906;Barra do ChoÁa;-148654;-405791;0;29;Bahia;3357;77;America/Sao_Paulo
-2101608;Barra do Corda;-549682;-452485;0;21;Maranh„o;731;99;America/Sao_Paulo
-5101803;Barra do GarÁas;-158804;-52264;0;51;Mato Grosso;9035;66;America/Porto_Velho
+3505351;Barra do Chap√©u;-244722;-490238;0;35;S√£o Paulo;2997;15;America/Sao_Paulo
+2902906;Barra do Cho√ßa;-148654;-405791;0;29;Bahia;3357;77;America/Sao_Paulo
+2101608;Barra do Corda;-549682;-452485;0;21;Maranh√£o;731;99;America/Sao_Paulo
+5101803;Barra do Gar√ßas;-158804;-52264;0;51;Mato Grosso;9035;66;America/Porto_Velho
 4301859;Barra do Guarita;-271927;-537109;0;43;Rio Grande do Sul;6069;55;America/Sao_Paulo
-4102703;Barra do JacarÈ;-23116;-501842;0;41;Paran·;7451;43;America/Sao_Paulo
+4102703;Barra do Jacar√©;-23116;-501842;0;41;Paran√°;7451;43;America/Sao_Paulo
 2903003;Barra do Mendes;-1181;-42059;0;29;Bahia;3359;74;America/Sao_Paulo
 1703073;Barra do Ouro;-769593;-476776;0;17;Tocantins;76;63;America/Sao_Paulo
-3300308;Barra do PiraÌ;-224715;-438269;0;33;Rio de Janeiro;5805;24;America/Sao_Paulo
-4301875;Barra do QuaraÌ;-302029;-575497;0;43;Rio Grande do Sul;956;55;America/Sao_Paulo
+3300308;Barra do Pira√≠;-224715;-438269;0;33;Rio de Janeiro;5805;24;America/Sao_Paulo
+4301875;Barra do Quara√≠;-302029;-575497;0;43;Rio Grande do Sul;956;55;America/Sao_Paulo
 4301909;Barra do Ribeiro;-302939;-513014;0;43;Rio Grande do Sul;8537;51;America/Sao_Paulo
 4301925;Barra do Rio Azul;-274069;-524084;0;43;Rio Grande do Sul;5959;54;America/Sao_Paulo
 2903102;Barra do Rocha;-142;-395991;0;29;Bahia;3361;73;America/Sao_Paulo
-3505401;Barra do Turvo;-24759;-485013;0;35;S„o Paulo;6207;15;America/Sao_Paulo
+3505401;Barra do Turvo;-24759;-485013;0;35;S√£o Paulo;6207;15;America/Sao_Paulo
 2800605;Barra dos Coqueiros;-108996;-370323;0;28;Sergipe;3111;79;America/Sao_Paulo
 4301958;Barra Funda;-279205;-530391;0;43;Rio Grande do Sul;5943;54;America/Sao_Paulo
 3105707;Barra Longa;-202869;-430402;0;31;Minas Gerais;4113;31;America/Sao_Paulo
 3300407;Barra Mansa;-225481;-441752;0;33;Rio de Janeiro;5807;24;America/Sao_Paulo
 4202107;Barra Velha;-26637;-486933;0;42;Santa Catarina;8041;47;America/Sao_Paulo
-4301800;Barrac„o;-276739;-514585;0;43;Rio Grande do Sul;8535;54;America/Sao_Paulo
-4102604;Barrac„o;-262502;-536324;0;41;Paran·;7449;49;America/Sao_Paulo
-2201200;Barras;-424468;-422922;0;22;PiauÌ;1023;86;America/Sao_Paulo
-2301950;Barreira;-428921;-386429;0;23;Cear·;1235;85;America/Sao_Paulo
+4301800;Barrac√£o;-276739;-514585;0;43;Rio Grande do Sul;8535;54;America/Sao_Paulo
+4102604;Barrac√£o;-262502;-536324;0;41;Paran√°;7449;49;America/Sao_Paulo
+2201200;Barras;-424468;-422922;0;22;Piau√≠;1023;86;America/Sao_Paulo
+2301950;Barreira;-428921;-386429;0;23;Cear√°;1235;85;America/Sao_Paulo
 2903201;Barreiras;-121439;-449968;0;29;Bahia;3363;77;America/Sao_Paulo
-2201309;Barreiras do PiauÌ;-99296;-454702;0;22;PiauÌ;1025;89;America/Sao_Paulo
+2201309;Barreiras do Piau√≠;-99296;-454702;0;22;Piau√≠;1025;89;America/Sao_Paulo
 1300508;Barreirinha;-279886;-570679;0;13;Amazonas;211;92;America/Porto_Velho
-2101707;Barreirinhas;-275863;-428232;0;21;Maranh„o;733;98;America/Sao_Paulo
+2101707;Barreirinhas;-275863;-428232;0;21;Maranh√£o;733;98;America/Sao_Paulo
 2601409;Barreiros;-881605;-351832;0;26;Pernambuco;2327;81;America/Sao_Paulo
-3505500;Barretos;-205531;-485698;0;35;S„o Paulo;6209;17;America/Sao_Paulo
-3505609;Barrinha;-211864;-481636;0;35;S„o Paulo;6211;16;America/Sao_Paulo
-2302008;Barro;-717188;-387741;0;23;Cear·;1339;88;America/Sao_Paulo
+3505500;Barretos;-205531;-485698;0;35;S√£o Paulo;6209;17;America/Sao_Paulo
+3505609;Barrinha;-211864;-481636;0;35;S√£o Paulo;6211;16;America/Sao_Paulo
+2302008;Barro;-717188;-387741;0;23;Cear√°;1339;88;America/Sao_Paulo
 2903235;Barro Alto;-117605;-419054;0;29;Bahia;3075;74;America/Sao_Paulo
-5203203;Barro Alto;-149658;-489086;0;52;Goi·s;9263;62;America/Sao_Paulo
-2201408;Barro Duro;-581673;-425147;0;22;PiauÌ;1027;86;America/Sao_Paulo
+5203203;Barro Alto;-149658;-489086;0;52;Goi√°s;9263;62;America/Sao_Paulo
+2201408;Barro Duro;-581673;-425147;0;22;Piau√≠;1027;86;America/Sao_Paulo
 2903300;Barro Preto;-147948;-39476;0;29;Bahia;3365;73;America/Sao_Paulo
 2903276;Barrocas;-115272;-390776;0;29;Bahia;1110;75;America/Sao_Paulo
-1703107;Barrol‚ndia;-983404;-487252;0;17;Tocantins;9693;63;America/Sao_Paulo
-2302057;Barroquinha;-302051;-411358;0;23;Cear·;1237;88;America/Sao_Paulo
+1703107;Barrol√¢ndia;-983404;-487252;0;17;Tocantins;9693;63;America/Sao_Paulo
+2302057;Barroquinha;-302051;-411358;0;23;Cear√°;1237;88;America/Sao_Paulo
 4302006;Barros Cassal;-290947;-525836;0;43;Rio Grande do Sul;8539;54;America/Sao_Paulo
 3105905;Barroso;-211907;-43972;0;31;Minas Gerais;4117;32;America/Sao_Paulo
-3505708;Barueri;-235057;-46879;0;35;S„o Paulo;6213;11;America/Sao_Paulo
-3505807;Bastos;-21921;-507357;0;35;S„o Paulo;6215;14;America/Sao_Paulo
+3505708;Barueri;-235057;-46879;0;35;S√£o Paulo;6213;11;America/Sao_Paulo
+3505807;Bastos;-21921;-507357;0;35;S√£o Paulo;6215;14;America/Sao_Paulo
 5001904;Bataguassu;-217159;-524221;0;50;Mato Grosso do Sul;9037;67;America/Porto_Velho
-2201507;Batalha;-40223;-420787;0;22;PiauÌ;1029;86;America/Sao_Paulo
+2201507;Batalha;-40223;-420787;0;22;Piau√≠;1029;86;America/Sao_Paulo
 2700706;Batalha;-96742;-37133;0;27;Alagoas;2713;82;America/Sao_Paulo
-3505906;Batatais;-208929;-475921;0;35;S„o Paulo;6217;16;America/Sao_Paulo
-5002001;Bataypor„;-222944;-532705;0;50;Mato Grosso do Sul;9039;67;America/Porto_Velho
-2302107;BaturitÈ;-432598;-388812;0;23;Cear·;1341;85;America/Sao_Paulo
-3506003;Bauru;-223246;-490871;0;35;S„o Paulo;6219;14;America/Sao_Paulo
-2501807;Bayeux;-71238;-349293;0;25;ParaÌba;1937;83;America/Sao_Paulo
-3506102;Bebedouro;-209491;-484791;0;35;S„o Paulo;6221;17;America/Sao_Paulo
-2302206;Beberibe;-417741;-381271;0;23;Cear·;1343;85;America/Sao_Paulo
-2302305;Bela Cruz;-304996;-401671;0;23;Cear·;1345;88;America/Sao_Paulo
+3505906;Batatais;-208929;-475921;0;35;S√£o Paulo;6217;16;America/Sao_Paulo
+5002001;Bataypor√£;-222944;-532705;0;50;Mato Grosso do Sul;9039;67;America/Porto_Velho
+2302107;Baturit√©;-432598;-388812;0;23;Cear√°;1341;85;America/Sao_Paulo
+3506003;Bauru;-223246;-490871;0;35;S√£o Paulo;6219;14;America/Sao_Paulo
+2501807;Bayeux;-71238;-349293;0;25;Para√≠ba;1937;83;America/Sao_Paulo
+3506102;Bebedouro;-209491;-484791;0;35;S√£o Paulo;6221;17;America/Sao_Paulo
+2302206;Beberibe;-417741;-381271;0;23;Cear√°;1343;85;America/Sao_Paulo
+2302305;Bela Cruz;-304996;-401671;0;23;Cear√°;1345;88;America/Sao_Paulo
 5002100;Bela Vista;-221073;-565263;0;50;Mato Grosso do Sul;9041;67;America/Porto_Velho
-4102752;Bela Vista da Caroba;-258842;-536725;0;41;Paran·;834;46;America/Sao_Paulo
-5203302;Bela Vista de Goi·s;-169693;-489513;0;52;Goi·s;9265;62;America/Sao_Paulo
+4102752;Bela Vista da Caroba;-258842;-536725;0;41;Paran√°;834;46;America/Sao_Paulo
+5203302;Bela Vista de Goi√°s;-169693;-489513;0;52;Goi√°s;9265;62;America/Sao_Paulo
 3106002;Bela Vista de Minas;-198302;-430922;0;31;Minas Gerais;4119;31;America/Sao_Paulo
-2101772;Bela Vista do Maranh„o;-372618;-453075;0;21;Maranh„o;122;98;America/Sao_Paulo
-4102802;Bela Vista do ParaÌso;-229937;-511927;0;41;Paran·;7453;43;America/Sao_Paulo
-2201556;Bela Vista do PiauÌ;-798809;-418675;0;22;PiauÌ;274;89;America/Sao_Paulo
+2101772;Bela Vista do Maranh√£o;-372618;-453075;0;21;Maranh√£o;122;98;America/Sao_Paulo
+4102802;Bela Vista do Para√≠so;-229937;-511927;0;41;Paran√°;7453;43;America/Sao_Paulo
+2201556;Bela Vista do Piau√≠;-798809;-418675;0;22;Piau√≠;274;89;America/Sao_Paulo
 4202131;Bela Vista do Toldo;-262746;-504664;0;42;Santa Catarina;896;47;America/Sao_Paulo
-2101731;Bel·gua;-315485;-435122;0;21;Maranh„o;120;98;America/Sao_Paulo
-1501402;BelÈm;-14554;-484898;1;15;Par·;427;91;America/Sao_Paulo
-2501906;BelÈm;-674261;-355166;0;25;ParaÌba;1939;83;America/Sao_Paulo
-2700805;BelÈm;-957047;-364904;0;27;Alagoas;2715;82;America/Sao_Paulo
-2601508;BelÈm de Maria;-862504;-358335;0;26;Pernambuco;2329;81;America/Sao_Paulo
-2502003;BelÈm do Brejo do Cruz;-618515;-375348;0;25;ParaÌba;1941;83;America/Sao_Paulo
-2201572;BelÈm do PiauÌ;-736652;-409688;0;22;PiauÌ;276;89;America/Sao_Paulo
-2601607;BelÈm do S„o Francisco;-875046;-389623;0;26;Pernambuco;2331;87;America/Sao_Paulo
+2101731;Bel√°gua;-315485;-435122;0;21;Maranh√£o;120;98;America/Sao_Paulo
+1501402;Bel√©m;-14554;-484898;1;15;Par√°;427;91;America/Sao_Paulo
+2501906;Bel√©m;-674261;-355166;0;25;Para√≠ba;1939;83;America/Sao_Paulo
+2700805;Bel√©m;-957047;-364904;0;27;Alagoas;2715;82;America/Sao_Paulo
+2601508;Bel√©m de Maria;-862504;-358335;0;26;Pernambuco;2329;81;America/Sao_Paulo
+2502003;Bel√©m do Brejo do Cruz;-618515;-375348;0;25;Para√≠ba;1941;83;America/Sao_Paulo
+2201572;Bel√©m do Piau√≠;-736652;-409688;0;22;Piau√≠;276;89;America/Sao_Paulo
+2601607;Bel√©m do S√£o Francisco;-875046;-389623;0;26;Pernambuco;2331;87;America/Sao_Paulo
 3300456;Belford Roxo;-22764;-433992;0;33;Rio de Janeiro;2909;21;America/Sao_Paulo
 3106101;Belmiro Braga;-21944;-434084;0;31;Minas Gerais;4121;32;America/Sao_Paulo
 4202156;Belmonte;-26843;-535758;0;42;Santa Catarina;5745;49;America/Sao_Paulo
@@ -596,1076 +596,1076 @@ codigo_ibge;municipio;latitude;longitude;capital;codigo_uf;estado;siafi_id;ddd;f
 2700904;Belo Monte;-982272;-37277;0;27;Alagoas;2717;82;America/Sao_Paulo
 3106309;Belo Oriente;-192199;-424828;0;31;Minas Gerais;4125;31;America/Sao_Paulo
 3106408;Belo Vale;-204077;-440275;0;31;Minas Gerais;4127;31;America/Sao_Paulo
-1501451;Belterra;-263609;-549374;0;15;Par·;44;93;America/Sao_Paulo
-2201606;Beneditinos;-545676;-423638;0;22;PiauÌ;1031;86;America/Sao_Paulo
-2101806;Benedito Leite;-721037;-445577;0;21;Maranh„o;735;99;America/Sao_Paulo
+1501451;Belterra;-263609;-549374;0;15;Par√°;44;93;America/Sao_Paulo
+2201606;Beneditinos;-545676;-423638;0;22;Piau√≠;1031;86;America/Sao_Paulo
+2101806;Benedito Leite;-721037;-445577;0;21;Maranh√£o;735;99;America/Sao_Paulo
 4202206;Benedito Novo;-26781;-493593;0;42;Santa Catarina;8043;47;America/Sao_Paulo
-1501501;Benevides;-136183;-482434;0;15;Par·;429;91;America/Sao_Paulo
+1501501;Benevides;-136183;-482434;0;15;Par√°;429;91;America/Sao_Paulo
 1300607;Benjamin Constant;-437768;-700342;0;13;Amazonas;213;97;America/Rio_Branco
 4302055;Benjamin Constant do Sul;-275086;-525995;0;43;Rio Grande do Sul;958;54;America/Sao_Paulo
-3506201;Bento de Abreu;-212686;-50814;0;35;S„o Paulo;6223;18;America/Sao_Paulo
+3506201;Bento de Abreu;-212686;-50814;0;35;S√£o Paulo;6223;18;America/Sao_Paulo
 2401602;Bento Fernandes;-569906;-35813;0;24;Rio Grande do Norte;1631;84;America/Sao_Paulo
-4302105;Bento GonÁalves;-291662;-515165;0;43;Rio Grande do Sul;8541;54;America/Sao_Paulo
-2101905;Bequim„o;-244162;-447842;0;21;Maranh„o;737;98;America/Sao_Paulo
+4302105;Bento Gon√ßalves;-291662;-515165;0;43;Rio Grande do Sul;8541;54;America/Sao_Paulo
+2101905;Bequim√£o;-244162;-447842;0;21;Maranh√£o;737;98;America/Sao_Paulo
 3106507;Berilo;-169567;-424606;0;31;Minas Gerais;4129;33;America/Sao_Paulo
 3106655;Berizal;-1561;-417432;0;31;Minas Gerais;570;38;America/Sao_Paulo
-2502052;Bernardino Batista;-644572;-385521;0;25;ParaÌba;456;83;America/Sao_Paulo
-3506300;Bernardino de Campos;-230164;-494679;0;35;S„o Paulo;6225;14;America/Sao_Paulo
-2101939;Bernardo do Mearim;-462666;-447608;0;21;Maranh„o;124;99;America/Sao_Paulo
-1703206;Bernardo Say„o;-787481;-488893;0;17;Tocantins;9695;63;America/Sao_Paulo
-3506359;Bertioga;-238486;-461396;0;35;S„o Paulo;2965;13;America/Sao_Paulo
-2201705;BertolÌnia;-763338;-439498;0;22;PiauÌ;1033;89;America/Sao_Paulo
-3106606;BertÛpolis;-17059;-4058;0;31;Minas Gerais;4131;33;America/Sao_Paulo
+2502052;Bernardino Batista;-644572;-385521;0;25;Para√≠ba;456;83;America/Sao_Paulo
+3506300;Bernardino de Campos;-230164;-494679;0;35;S√£o Paulo;6225;14;America/Sao_Paulo
+2101939;Bernardo do Mearim;-462666;-447608;0;21;Maranh√£o;124;99;America/Sao_Paulo
+1703206;Bernardo Say√£o;-787481;-488893;0;17;Tocantins;9695;63;America/Sao_Paulo
+3506359;Bertioga;-238486;-461396;0;35;S√£o Paulo;2965;13;America/Sao_Paulo
+2201705;Bertol√≠nia;-763338;-439498;0;22;Piau√≠;1033;89;America/Sao_Paulo
+3106606;Bert√≥polis;-17059;-4058;0;31;Minas Gerais;4131;33;America/Sao_Paulo
 1300631;Beruri;-389874;-613616;0;13;Amazonas;295;97;America/Porto_Velho
-2601805;Bet‚nia;-826787;-380345;0;26;Pernambuco;2335;87;America/Sao_Paulo
-2201739;Bet‚nia do PiauÌ;-814376;-407989;0;22;PiauÌ;278;89;America/Sao_Paulo
+2601805;Bet√¢nia;-826787;-380345;0;26;Pernambuco;2335;87;America/Sao_Paulo
+2201739;Bet√¢nia do Piau√≠;-814376;-407989;0;22;Piau√≠;278;89;America/Sao_Paulo
 3106705;Betim;-199668;-442008;0;31;Minas Gerais;4133;31;America/Sao_Paulo
 2601904;Bezerros;-82328;-35796;0;26;Pernambuco;2337;81;America/Sao_Paulo
 3106804;Bias Fortes;-21602;-437574;0;31;Minas Gerais;4135;32;America/Sao_Paulo
 3106903;Bicas;-217232;-43056;0;31;Minas Gerais;4137;32;America/Sao_Paulo
-4202305;BiguaÁu;-27496;-486598;0;42;Santa Catarina;8045;48;America/Sao_Paulo
-3506409;Bilac;-21404;-504746;0;35;S„o Paulo;6227;18;America/Sao_Paulo
+4202305;Bigua√ßu;-27496;-486598;0;42;Santa Catarina;8045;48;America/Sao_Paulo
+3506409;Bilac;-21404;-504746;0;35;S√£o Paulo;6227;18;America/Sao_Paulo
 3107000;Biquinhas;-187754;-454974;0;31;Minas Gerais;4139;37;America/Sao_Paulo
-3506508;Birigui;-21291;-503432;0;35;S„o Paulo;6229;18;America/Sao_Paulo
-3506607;Biritiba-Mirim;-235698;-460407;0;35;S„o Paulo;6231;11;America/Sao_Paulo
+3506508;Birigui;-21291;-503432;0;35;S√£o Paulo;6229;18;America/Sao_Paulo
+3506607;Biritiba-Mirim;-235698;-460407;0;35;S√£o Paulo;6231;11;America/Sao_Paulo
 2903607;Biritinga;-116072;-388051;0;29;Bahia;3371;75;America/Sao_Paulo
-4102901;Bituruna;-261607;-515518;0;41;Paran·;7455;42;America/Sao_Paulo
+4102901;Bituruna;-261607;-515518;0;41;Paran√°;7455;42;America/Sao_Paulo
 4202404;Blumenau;-269155;-490709;0;42;Santa Catarina;8047;47;America/Sao_Paulo
-4103008;Boa EsperanÁa;-242467;-527876;0;41;Paran·;7457;44;America/Sao_Paulo
-3107109;Boa EsperanÁa;-210927;-455612;0;31;Minas Gerais;4141;35;America/Sao_Paulo
-3201001;Boa EsperanÁa;-185395;-403025;0;32;EspÌrito Santo;5619;27;America/Sao_Paulo
-4103024;Boa EsperanÁa do IguaÁu;-256324;-532108;0;41;Paran·;5471;46;America/Sao_Paulo
-3506706;Boa EsperanÁa do Sul;-219918;-483906;0;35;S„o Paulo;6233;16;America/Sao_Paulo
-2201770;Boa Hora;-441404;-421357;0;22;PiauÌ;280;86;America/Sao_Paulo
+4103008;Boa Esperan√ßa;-242467;-527876;0;41;Paran√°;7457;44;America/Sao_Paulo
+3107109;Boa Esperan√ßa;-210927;-455612;0;31;Minas Gerais;4141;35;America/Sao_Paulo
+3201001;Boa Esperan√ßa;-185395;-403025;0;32;Esp√≠rito Santo;5619;27;America/Sao_Paulo
+4103024;Boa Esperan√ßa do Igua√ßu;-256324;-532108;0;41;Paran√°;5471;46;America/Sao_Paulo
+3506706;Boa Esperan√ßa do Sul;-219918;-483906;0;35;S√£o Paulo;6233;16;America/Sao_Paulo
+2201770;Boa Hora;-441404;-421357;0;22;Piau√≠;280;86;America/Sao_Paulo
 2903706;Boa Nova;-143598;-402064;0;29;Bahia;3373;77;America/Sao_Paulo
-2502102;Boa Ventura;-740982;-382113;0;25;ParaÌba;1943;83;America/Sao_Paulo
-4103040;Boa Ventura de S„o Roque;-248688;-516276;0;41;Paran·;836;42;America/Sao_Paulo
-2302404;Boa Viagem;-511258;-397337;0;23;Cear·;1347;88;America/Sao_Paulo
+2502102;Boa Ventura;-740982;-382113;0;25;Para√≠ba;1943;83;America/Sao_Paulo
+4103040;Boa Ventura de S√£o Roque;-248688;-516276;0;41;Paran√°;836;42;America/Sao_Paulo
+2302404;Boa Viagem;-511258;-397337;0;23;Cear√°;1347;88;America/Sao_Paulo
 1400100;Boa Vista;282384;-606753;1;14;Roraima;301;95;America/Porto_Velho
-2502151;Boa Vista;-726365;-362357;0;25;ParaÌba;458;83;America/Sao_Paulo
-4103057;Boa Vista da Aparecida;-254308;-534117;0;41;Paran·;7981;45;America/Sao_Paulo
-4302154;Boa Vista das Missıes;-276671;-533102;0;43;Rio Grande do Sul;5981;55;America/Sao_Paulo
-4302204;Boa Vista do Buric·;-276693;-541082;0;43;Rio Grande do Sul;8543;55;America/Sao_Paulo
+2502151;Boa Vista;-726365;-362357;0;25;Para√≠ba;458;83;America/Sao_Paulo
+4103057;Boa Vista da Aparecida;-254308;-534117;0;41;Paran√°;7981;45;America/Sao_Paulo
+4302154;Boa Vista das Miss√µes;-276671;-533102;0;43;Rio Grande do Sul;5981;55;America/Sao_Paulo
+4302204;Boa Vista do Buric√°;-276693;-541082;0;43;Rio Grande do Sul;8543;55;America/Sao_Paulo
 4302220;Boa Vista do Cadeado;-285791;-538108;0;43;Rio Grande do Sul;1124;55;America/Sao_Paulo
-2101970;Boa Vista do Gurupi;-177614;-463002;0;21;Maranh„o;126;98;America/Sao_Paulo
+2101970;Boa Vista do Gurupi;-177614;-463002;0;21;Maranh√£o;126;98;America/Sao_Paulo
 4302238;Boa Vista do Incra;-288185;-53391;0;43;Rio Grande do Sul;1126;55;America/Sao_Paulo
 1300680;Boa Vista do Ramos;-297409;-575873;0;13;Amazonas;297;92;America/Porto_Velho
 4302253;Boa Vista do Sul;-293544;-516687;0;43;Rio Grande do Sul;960;54;America/Sao_Paulo
 2903805;Boa Vista do Tupim;-126498;-406064;0;29;Bahia;3375;75;America/Sao_Paulo
 2701001;Boca da Mata;-964308;-362125;0;27;Alagoas;2719;82;America/Sao_Paulo
 1300706;Boca do Acre;-874232;-673919;0;13;Amazonas;215;97;America/Rio_Branco
-2201804;Bocaina;-694124;-413168;0;22;PiauÌ;1035;89;America/Sao_Paulo
-3506805;Bocaina;-221365;-48523;0;35;S„o Paulo;6235;14;America/Sao_Paulo
+2201804;Bocaina;-694124;-413168;0;22;Piau√≠;1035;89;America/Sao_Paulo
+3506805;Bocaina;-221365;-48523;0;35;S√£o Paulo;6235;14;America/Sao_Paulo
 3107208;Bocaina de Minas;-221697;-443972;0;31;Minas Gerais;4143;32;America/Sao_Paulo
 4202438;Bocaina do Sul;-277455;-499423;0;42;Santa Catarina;898;49;America/Sao_Paulo
-3107307;Bocai˙va;-171135;-438104;0;31;Minas Gerais;4145;38;America/Sao_Paulo
-4103107;Bocai˙va do Sul;-252066;-491141;0;41;Paran·;7459;41;America/Sao_Paulo
-2401651;BodÛ;-598027;-364167;0;24;Rio Grande do Norte;412;84;America/Sao_Paulo
-2602001;BodocÛ;-777759;-399338;0;26;Pernambuco;2339;87;America/Sao_Paulo
+3107307;Bocai√∫va;-171135;-438104;0;31;Minas Gerais;4145;38;America/Sao_Paulo
+4103107;Bocai√∫va do Sul;-252066;-491141;0;41;Paran√°;7459;41;America/Sao_Paulo
+2401651;Bod√≥;-598027;-364167;0;24;Rio Grande do Norte;412;84;America/Sao_Paulo
+2602001;Bodoc√≥;-777759;-399338;0;26;Pernambuco;2339;87;America/Sao_Paulo
 5002159;Bodoquena;-20537;-567127;0;50;Mato Grosso do Sul;9801;67;America/Porto_Velho
-3506904;Bofete;-231055;-482582;0;35;S„o Paulo;6237;14;America/Sao_Paulo
-3507001;Boituva;-232855;-476786;0;35;S„o Paulo;6239;15;America/Sao_Paulo
+3506904;Bofete;-231055;-482582;0;35;S√£o Paulo;6237;14;America/Sao_Paulo
+3507001;Boituva;-232855;-476786;0;35;S√£o Paulo;6239;15;America/Sao_Paulo
 2602100;Bom Conselho;-916919;-366857;0;26;Pernambuco;2341;87;America/Sao_Paulo
 3107406;Bom Despacho;-197386;-452622;0;31;Minas Gerais;4147;37;America/Sao_Paulo
 3300506;Bom Jardim;-221545;-424251;0;33;Rio de Janeiro;5809;22;America/Sao_Paulo
 2602209;Bom Jardim;-779695;-355784;0;26;Pernambuco;2343;81;America/Sao_Paulo
-2102002;Bom Jardim;-354129;-45606;0;21;Maranh„o;955;98;America/Sao_Paulo
+2102002;Bom Jardim;-354129;-45606;0;21;Maranh√£o;955;98;America/Sao_Paulo
 4202503;Bom Jardim da Serra;-283377;-496373;0;42;Santa Catarina;8389;49;America/Sao_Paulo
-5203401;Bom Jardim de Goi·s;-162063;-521728;0;52;Goi·s;9267;64;America/Sao_Paulo
+5203401;Bom Jardim de Goi√°s;-162063;-521728;0;52;Goi√°s;9267;64;America/Sao_Paulo
 3107505;Bom Jardim de Minas;-219479;-441885;0;31;Minas Gerais;4149;32;America/Sao_Paulo
 4202537;Bom Jesus;-267326;-523919;0;42;Santa Catarina;900;49;America/Sao_Paulo
 4302303;Bom Jesus;-286697;-504295;0;43;Rio Grande do Sul;8545;54;America/Sao_Paulo
-2201903;Bom Jesus;-907124;-44359;0;22;PiauÌ;1037;89;America/Sao_Paulo
+2201903;Bom Jesus;-907124;-44359;0;22;Piau√≠;1037;89;America/Sao_Paulo
 2401701;Bom Jesus;-598648;-355792;0;24;Rio Grande do Norte;1633;84;America/Sao_Paulo
-2502201;Bom Jesus;-681601;-386453;0;25;ParaÌba;1945;83;America/Sao_Paulo
+2502201;Bom Jesus;-681601;-386453;0;25;Para√≠ba;1945;83;America/Sao_Paulo
 2903904;Bom Jesus da Lapa;-132506;-434108;0;29;Bahia;3377;77;America/Sao_Paulo
 3107604;Bom Jesus da Penha;-210148;-465174;0;31;Minas Gerais;4151;35;America/Sao_Paulo
 2903953;Bom Jesus da Serra;-143663;-405126;0;29;Bahia;3263;77;America/Sao_Paulo
-2102036;Bom Jesus das Selvas;-447638;-468641;0;21;Maranh„o;128;98;America/Sao_Paulo
-5203500;Bom Jesus de Goi·s;-182173;-4974;0;52;Goi·s;9269;64;America/Sao_Paulo
+2102036;Bom Jesus das Selvas;-447638;-468641;0;21;Maranh√£o;128;98;America/Sao_Paulo
+5203500;Bom Jesus de Goi√°s;-182173;-4974;0;52;Goi√°s;9269;64;America/Sao_Paulo
 3107703;Bom Jesus do Amparo;-197054;-434782;0;31;Minas Gerais;4153;31;America/Sao_Paulo
 5101852;Bom Jesus do Araguaia;-121706;-515032;0;51;Mato Grosso;1078;66;America/Porto_Velho
 3107802;Bom Jesus do Galho;-19836;-423165;0;31;Minas Gerais;4155;33;America/Sao_Paulo
 3300605;Bom Jesus do Itabapoana;-211449;-416822;0;33;Rio de Janeiro;5811;22;America/Sao_Paulo
-3201100;Bom Jesus do Norte;-211173;-416731;0;32;EspÌrito Santo;5621;28;America/Sao_Paulo
+3201100;Bom Jesus do Norte;-211173;-416731;0;32;Esp√≠rito Santo;5621;28;America/Sao_Paulo
 4202578;Bom Jesus do Oeste;-266927;-530967;0;42;Santa Catarina;902;49;America/Sao_Paulo
-4103156;Bom Jesus do Sul;-261958;-535955;0;41;Paran·;838;46;America/Sao_Paulo
-1501576;Bom Jesus do Tocantins;-50424;-486047;0;15;Par·;575;94;America/Sao_Paulo
+4103156;Bom Jesus do Sul;-261958;-535955;0;41;Paran√°;838;46;America/Sao_Paulo
+1501576;Bom Jesus do Tocantins;-50424;-486047;0;15;Par√°;575;94;America/Sao_Paulo
 1703305;Bom Jesus do Tocantins;-896306;-48165;0;17;Tocantins;341;63;America/Sao_Paulo
-3507100;Bom Jesus dos Perdıes;-231356;-464675;0;35;S„o Paulo;6241;11;America/Sao_Paulo
-2102077;Bom Lugar;-437311;-450326;0;21;Maranh„o;130;99;America/Sao_Paulo
-4302352;Bom PrincÌpio;-294856;-513548;0;43;Rio Grande do Sul;9823;51;America/Sao_Paulo
-2201919;Bom PrincÌpio do PiauÌ;-319631;-416403;0;22;PiauÌ;2287;86;America/Sao_Paulo
+3507100;Bom Jesus dos Perd√µes;-231356;-464675;0;35;S√£o Paulo;6241;11;America/Sao_Paulo
+2102077;Bom Lugar;-437311;-450326;0;21;Maranh√£o;130;99;America/Sao_Paulo
+4302352;Bom Princ√≠pio;-294856;-513548;0;43;Rio Grande do Sul;9823;51;America/Sao_Paulo
+2201919;Bom Princ√≠pio do Piau√≠;-319631;-416403;0;22;Piau√≠;2287;86;America/Sao_Paulo
 4302378;Bom Progresso;-275399;-538716;0;43;Rio Grande do Sul;6071;55;America/Sao_Paulo
 3107901;Bom Repouso;-224675;-46144;0;31;Minas Gerais;4157;35;America/Sao_Paulo
 4202602;Bom Retiro;-27799;-49487;0;42;Santa Catarina;8049;49;America/Sao_Paulo
 4302402;Bom Retiro do Sul;-296071;-519456;0;43;Rio Grande do Sul;8547;51;America/Sao_Paulo
 3108008;Bom Sucesso;-210329;-447537;0;31;Minas Gerais;4159;35;America/Sao_Paulo
-4103206;Bom Sucesso;-237063;-517671;0;41;Paran·;7461;43;America/Sao_Paulo
-2502300;Bom Sucesso;-644176;-379234;0;25;ParaÌba;1947;83;America/Sao_Paulo
-3507159;Bom Sucesso de ItararÈ;-243155;-491451;0;35;S„o Paulo;3059;15;America/Sao_Paulo
-4103222;Bom Sucesso do Sul;-260731;-528353;0;41;Paran·;9979;46;America/Sao_Paulo
+4103206;Bom Sucesso;-237063;-517671;0;41;Paran√°;7461;43;America/Sao_Paulo
+2502300;Bom Sucesso;-644176;-379234;0;25;Para√≠ba;1947;83;America/Sao_Paulo
+3507159;Bom Sucesso de Itarar√©;-243155;-491451;0;35;S√£o Paulo;3059;15;America/Sao_Paulo
+4103222;Bom Sucesso do Sul;-260731;-528353;0;41;Paran√°;9979;46;America/Sao_Paulo
 4202453;Bombinhas;-271382;-485146;0;42;Santa Catarina;5537;47;America/Sao_Paulo
 1400159;Bonfim;336161;-598333;0;14;Roraima;307;95;America/Porto_Velho
 3108107;Bonfim;-203302;-442366;0;31;Minas Gerais;4161;31;America/Sao_Paulo
-2201929;Bonfim do PiauÌ;-91605;-428865;0;22;PiauÌ;2251;89;America/Sao_Paulo
-5203559;BonfinÛpolis;-166173;-489616;0;52;Goi·s;9775;62;America/Sao_Paulo
-3108206;BonfinÛpolis de Minas;-16568;-459839;0;31;Minas Gerais;4163;38;America/Sao_Paulo
+2201929;Bonfim do Piau√≠;-91605;-428865;0;22;Piau√≠;2251;89;America/Sao_Paulo
+5203559;Bonfin√≥polis;-166173;-489616;0;52;Goi√°s;9775;62;America/Sao_Paulo
+3108206;Bonfin√≥polis de Minas;-16568;-459839;0;31;Minas Gerais;4163;38;America/Sao_Paulo
 2904001;Boninal;-127069;-418286;0;29;Bahia;3379;75;America/Sao_Paulo
 2602308;Bonito;-847163;-357292;0;26;Pernambuco;2345;81;America/Sao_Paulo
 2904050;Bonito;-119668;-412647;0;29;Bahia;3265;75;America/Sao_Paulo
-1501600;Bonito;-136745;-473066;0;15;Par·;431;91;America/Sao_Paulo
+1501600;Bonito;-136745;-473066;0;15;Par√°;431;91;America/Sao_Paulo
 5002209;Bonito;-211261;-564836;0;50;Mato Grosso do Sul;9043;67;America/Porto_Velho
 3108255;Bonito de Minas;-153231;-447543;0;31;Minas Gerais;572;38;America/Sao_Paulo
-2502409;Bonito de Santa FÈ;-731341;-385133;0;25;ParaÌba;1949;83;America/Sao_Paulo
-5203575;BonÛpolis;-136329;-498106;0;52;Goi·s;1056;62;America/Sao_Paulo
-2502508;Boqueir„o;-7487;-361309;0;25;ParaÌba;1951;83;America/Sao_Paulo
-4302451;Boqueir„o do Le„o;-293046;-524284;0;43;Rio Grande do Sul;8483;51;America/Sao_Paulo
-2201945;Boqueir„o do PiauÌ;-448181;-421212;0;22;PiauÌ;282;86;America/Sao_Paulo
+2502409;Bonito de Santa F√©;-731341;-385133;0;25;Para√≠ba;1949;83;America/Sao_Paulo
+5203575;Bon√≥polis;-136329;-498106;0;52;Goi√°s;1056;62;America/Sao_Paulo
+2502508;Boqueir√£o;-7487;-361309;0;25;Para√≠ba;1951;83;America/Sao_Paulo
+4302451;Boqueir√£o do Le√£o;-293046;-524284;0;43;Rio Grande do Sul;8483;51;America/Sao_Paulo
+2201945;Boqueir√£o do Piau√≠;-448181;-421212;0;22;Piau√≠;282;86;America/Sao_Paulo
 2800670;Boquim;-111397;-376195;0;28;Sergipe;3115;79;America/Sao_Paulo
 2904100;Boquira;-128205;-427324;0;29;Bahia;3381;77;America/Sao_Paulo
-3507209;Bor·;-222696;-505409;0;35;S„o Paulo;6243;18;America/Sao_Paulo
-3507308;BoracÈia;-221926;-487808;0;35;S„o Paulo;6245;14;America/Sao_Paulo
+3507209;Bor√°;-222696;-505409;0;35;S√£o Paulo;6243;18;America/Sao_Paulo
+3507308;Borac√©ia;-221926;-487808;0;35;S√£o Paulo;6245;14;America/Sao_Paulo
 1300805;Borba;-439154;-595874;0;13;Amazonas;217;92;America/Porto_Velho
-2502706;Borborema;-680199;-356187;0;25;ParaÌba;1955;83;America/Sao_Paulo
-3507407;Borborema;-216214;-490741;0;35;S„o Paulo;6247;16;America/Sao_Paulo
+2502706;Borborema;-680199;-356187;0;25;Para√≠ba;1955;83;America/Sao_Paulo
+3507407;Borborema;-216214;-490741;0;35;S√£o Paulo;6247;16;America/Sao_Paulo
 3108305;Borda da Mata;-222707;-461653;0;31;Minas Gerais;4165;35;America/Sao_Paulo
-3507456;Borebi;-225728;-489707;0;35;S„o Paulo;7247;14;America/Sao_Paulo
-4103305;BorrazÛpolis;-239366;-515875;0;41;Paran·;7463;43;America/Sao_Paulo
+3507456;Borebi;-225728;-489707;0;35;S√£o Paulo;7247;14;America/Sao_Paulo
+4103305;Borraz√≥polis;-239366;-515875;0;41;Paran√°;7463;43;America/Sao_Paulo
 4302501;Bossoroca;-287291;-549035;0;43;Rio Grande do Sul;8549;55;America/Sao_Paulo
 3108404;Botelhos;-216412;-46391;0;31;Minas Gerais;4167;35;America/Sao_Paulo
-3507506;Botucatu;-228837;-484437;0;35;S„o Paulo;6249;14;America/Sao_Paulo
+3507506;Botucatu;-228837;-484437;0;35;S√£o Paulo;6249;14;America/Sao_Paulo
 3108503;Botumirim;-168657;-430086;0;31;Minas Gerais;4169;38;America/Sao_Paulo
-2904209;Botupor„;-133772;-425163;0;29;Bahia;3383;77;America/Sao_Paulo
-4202701;Botuver·;-272007;-490689;0;42;Santa Catarina;8051;47;America/Sao_Paulo
+2904209;Botupor√£;-133772;-425163;0;29;Bahia;3383;77;America/Sao_Paulo
+4202701;Botuver√°;-272007;-490689;0;42;Santa Catarina;8051;47;America/Sao_Paulo
 4302584;Bozano;-283659;-53772;0;43;Rio Grande do Sul;1128;55;America/Sao_Paulo
-4202800;BraÁo do Norte;-282681;-491701;0;42;Santa Catarina;8053;48;America/Sao_Paulo
-4202859;BraÁo do Trombudo;-273586;-498821;0;42;Santa Catarina;5557;47;America/Sao_Paulo
+4202800;Bra√ßo do Norte;-282681;-491701;0;42;Santa Catarina;8053;48;America/Sao_Paulo
+4202859;Bra√ßo do Trombudo;-273586;-498821;0;42;Santa Catarina;5557;47;America/Sao_Paulo
 4302600;Braga;-276173;-537405;0;43;Rio Grande do Sul;8551;55;America/Sao_Paulo
-1501709;BraganÁa;-106126;-467826;0;15;Par·;433;91;America/Sao_Paulo
-3507605;BraganÁa Paulista;-229527;-465419;0;35;S„o Paulo;6251;11;America/Sao_Paulo
-4103354;Braganey;-248173;-531218;0;41;Paran·;7983;45;America/Sao_Paulo
+1501709;Bragan√ßa;-106126;-467826;0;15;Par√°;433;91;America/Sao_Paulo
+3507605;Bragan√ßa Paulista;-229527;-465419;0;35;S√£o Paulo;6251;11;America/Sao_Paulo
+4103354;Braganey;-248173;-531218;0;41;Paran√°;7983;45;America/Sao_Paulo
 2701100;Branquinha;-923342;-360162;0;27;Alagoas;2721;82;America/Sao_Paulo
-3108701;Br·s Pires;-208419;-432406;0;31;Minas Gerais;4173;32;America/Sao_Paulo
-1501725;Brasil Novo;-329792;-52534;0;15;Par·;639;93;America/Sao_Paulo
-5002308;Brasil‚ndia;-212544;-520365;0;50;Mato Grosso do Sul;9045;67;America/Porto_Velho
-3108552;Brasil‚ndia de Minas;-169999;-460081;0;31;Minas Gerais;574;38;America/Sao_Paulo
-4103370;Brasil‚ndia do Sul;-241978;-535275;0;41;Paran·;5521;44;America/Sao_Paulo
-1703602;Brasil‚ndia do Tocantins;-838918;-484822;0;17;Tocantins;339;63;America/Sao_Paulo
-1200104;BrasilÈia;-10995;-687497;0;12;Acre;105;68;America/Rio_Branco
-2201960;Brasileira;-41337;-417859;0;22;PiauÌ;2283;86;America/Sao_Paulo
-5300108;BrasÌlia;-157795;-479297;1;53;Distrito Federal;9701;61;America/Sao_Paulo
-3108602;BrasÌlia de Minas;-162104;-444299;0;31;Minas Gerais;4171;38;America/Sao_Paulo
+3108701;Br√°s Pires;-208419;-432406;0;31;Minas Gerais;4173;32;America/Sao_Paulo
+1501725;Brasil Novo;-329792;-52534;0;15;Par√°;639;93;America/Sao_Paulo
+5002308;Brasil√¢ndia;-212544;-520365;0;50;Mato Grosso do Sul;9045;67;America/Porto_Velho
+3108552;Brasil√¢ndia de Minas;-169999;-460081;0;31;Minas Gerais;574;38;America/Sao_Paulo
+4103370;Brasil√¢ndia do Sul;-241978;-535275;0;41;Paran√°;5521;44;America/Sao_Paulo
+1703602;Brasil√¢ndia do Tocantins;-838918;-484822;0;17;Tocantins;339;63;America/Sao_Paulo
+1200104;Brasil√©ia;-10995;-687497;0;12;Acre;105;68;America/Rio_Branco
+2201960;Brasileira;-41337;-417859;0;22;Piau√≠;2283;86;America/Sao_Paulo
+5300108;Bras√≠lia;-157795;-479297;1;53;Distrito Federal;9701;61;America/Sao_Paulo
+3108602;Bras√≠lia de Minas;-162104;-444299;0;31;Minas Gerais;4171;38;America/Sao_Paulo
 5101902;Brasnorte;-121474;-579833;0;51;Mato Grosso;9873;66;America/Porto_Velho
-3507704;Bra˙na;-21499;-503175;0;35;S„o Paulo;6255;18;America/Sao_Paulo
-3108800;Bra˙nas;-190562;-427099;0;31;Minas Gerais;4175;35;America/Sao_Paulo
-5203609;Brazabrantes;-164281;-493863;0;52;Goi·s;9271;62;America/Sao_Paulo
-3108909;BrazÛpolis;-224743;-456166;0;31;Minas Gerais;4177;33;America/Sao_Paulo
-2602407;Brej„o;-902915;-36566;0;26;Pernambuco;2347;87;America/Sao_Paulo
-3201159;Brejetuba;-201395;-412954;0;32;EspÌrito Santo;758;27;America/Sao_Paulo
+3507704;Bra√∫na;-21499;-503175;0;35;S√£o Paulo;6255;18;America/Sao_Paulo
+3108800;Bra√∫nas;-190562;-427099;0;31;Minas Gerais;4175;35;America/Sao_Paulo
+5203609;Brazabrantes;-164281;-493863;0;52;Goi√°s;9271;62;America/Sao_Paulo
+3108909;Braz√≥polis;-224743;-456166;0;31;Minas Gerais;4177;33;America/Sao_Paulo
+2602407;Brej√£o;-902915;-36566;0;26;Pernambuco;2347;87;America/Sao_Paulo
+3201159;Brejetuba;-201395;-412954;0;32;Esp√≠rito Santo;758;27;America/Sao_Paulo
 2401800;Brejinho;-618566;-353591;0;24;Rio Grande do Norte;1635;84;America/Sao_Paulo
 2602506;Brejinho;-734694;-372865;0;26;Pernambuco;2349;87;America/Sao_Paulo
-1703701;Brejinho de NazarÈ;-110058;-485683;0;17;Tocantins;9273;63;America/Sao_Paulo
-2102101;Brejo;-367796;-427527;0;21;Maranh„o;739;98;America/Sao_Paulo
-3507753;Brejo Alegre;-211651;-501861;0;35;S„o Paulo;792;18;America/Sao_Paulo
+1703701;Brejinho de Nazar√©;-110058;-485683;0;17;Tocantins;9273;63;America/Sao_Paulo
+2102101;Brejo;-367796;-427527;0;21;Maranh√£o;739;98;America/Sao_Paulo
+3507753;Brejo Alegre;-211651;-501861;0;35;S√£o Paulo;792;18;America/Sao_Paulo
 2602605;Brejo da Madre de Deus;-814933;-363741;0;26;Pernambuco;2351;81;America/Sao_Paulo
-2102150;Brejo de Areia;-4334;-45581;0;21;Maranh„o;132;98;America/Sao_Paulo
-2502805;Brejo do Cruz;-634185;-374943;0;25;ParaÌba;1957;83;America/Sao_Paulo
-2201988;Brejo do PiauÌ;-820314;-428229;0;22;PiauÌ;284;89;America/Sao_Paulo
-2502904;Brejo dos Santos;-637065;-378253;0;25;ParaÌba;1959;83;America/Sao_Paulo
+2102150;Brejo de Areia;-4334;-45581;0;21;Maranh√£o;132;98;America/Sao_Paulo
+2502805;Brejo do Cruz;-634185;-374943;0;25;Para√≠ba;1957;83;America/Sao_Paulo
+2201988;Brejo do Piau√≠;-820314;-428229;0;22;Piau√≠;284;89;America/Sao_Paulo
+2502904;Brejo dos Santos;-637065;-378253;0;25;Para√≠ba;1959;83;America/Sao_Paulo
 2800704;Brejo Grande;-104297;-364611;0;28;Sergipe;3113;79;America/Sao_Paulo
-1501758;Brejo Grande do Araguaia;-569822;-484103;0;15;Par·;577;94;America/Sao_Paulo
-2302503;Brejo Santo;-748469;-389799;0;23;Cear·;1349;88;America/Sao_Paulo
-2904308;Brejıes;-131039;-397988;0;29;Bahia;3385;75;America/Sao_Paulo
-2904407;Brejol‚ndia;-124815;-439679;0;29;Bahia;3387;77;America/Sao_Paulo
-1501782;Breu Branco;-377191;-495735;0;15;Par·;625;94;America/Sao_Paulo
-1501808;Breves;-168036;-504791;0;15;Par·;435;91;America/Sao_Paulo
-5203807;Brit‚nia;-152428;-511602;0;52;Goi·s;9275;62;America/Sao_Paulo
+1501758;Brejo Grande do Araguaia;-569822;-484103;0;15;Par√°;577;94;America/Sao_Paulo
+2302503;Brejo Santo;-748469;-389799;0;23;Cear√°;1349;88;America/Sao_Paulo
+2904308;Brej√µes;-131039;-397988;0;29;Bahia;3385;75;America/Sao_Paulo
+2904407;Brejol√¢ndia;-124815;-439679;0;29;Bahia;3387;77;America/Sao_Paulo
+1501782;Breu Branco;-377191;-495735;0;15;Par√°;625;94;America/Sao_Paulo
+1501808;Breves;-168036;-504791;0;15;Par√°;435;91;America/Sao_Paulo
+5203807;Brit√¢nia;-152428;-511602;0;52;Goi√°s;9275;62;America/Sao_Paulo
 4302659;Brochier;-295501;-515945;0;43;Rio Grande do Sul;8449;51;America/Sao_Paulo
-3507803;Brodowski;-209845;-476572;0;35;S„o Paulo;6257;16;America/Sao_Paulo
-3507902;Brotas;-222795;-481251;0;35;S„o Paulo;6259;14;America/Sao_Paulo
-2904506;Brotas de Maca˙bas;-119915;-426326;0;29;Bahia;3389;77;America/Sao_Paulo
+3507803;Brodowski;-209845;-476572;0;35;S√£o Paulo;6257;16;America/Sao_Paulo
+3507902;Brotas;-222795;-481251;0;35;S√£o Paulo;6259;14;America/Sao_Paulo
+2904506;Brotas de Maca√∫bas;-119915;-426326;0;29;Bahia;3389;77;America/Sao_Paulo
 3109006;Brumadinho;-20151;-442007;0;31;Minas Gerais;4179;31;America/Sao_Paulo
 2904605;Brumado;-142021;-416696;0;29;Bahia;3391;77;America/Sao_Paulo
-4202875;BrunÛpolis;-273058;-508684;0;42;Santa Catarina;904;49;America/Sao_Paulo
+4202875;Brun√≥polis;-273058;-508684;0;42;Santa Catarina;904;49;America/Sao_Paulo
 4202909;Brusque;-270977;-489107;0;42;Santa Catarina;8055;47;America/Sao_Paulo
-3109105;Bueno Brand„o;-224383;-463491;0;31;Minas Gerais;4181;35;America/Sao_Paulo
-3109204;BuenÛpolis;-178744;-441775;0;31;Minas Gerais;4183;38;America/Sao_Paulo
+3109105;Bueno Brand√£o;-224383;-463491;0;31;Minas Gerais;4181;35;America/Sao_Paulo
+3109204;Buen√≥polis;-178744;-441775;0;31;Minas Gerais;4183;38;America/Sao_Paulo
 2602704;Buenos Aires;-772449;-353182;0;26;Pernambuco;2353;81;America/Sao_Paulo
 2904704;Buerarema;-149595;-393028;0;29;Bahia;3393;73;America/Sao_Paulo
 3109253;Bugre;-194231;-422552;0;31;Minas Gerais;576;33;America/Sao_Paulo
-2602803;BuÌque;-861954;-371606;0;26;Pernambuco;2355;87;America/Sao_Paulo
+2602803;Bu√≠que;-861954;-371606;0;26;Pernambuco;2355;87;America/Sao_Paulo
 1200138;Bujari;-981528;-67955;0;12;Acre;645;68;America/Rio_Branco
-1501907;Bujaru;-151762;-480381;0;15;Par·;437;91;America/Sao_Paulo
-3508009;Buri;-237977;-485958;0;35;S„o Paulo;6261;15;America/Sao_Paulo
-3508108;Buritama;-210661;-501475;0;35;S„o Paulo;6263;18;America/Sao_Paulo
-2102200;Buriti;-394169;-429179;0;21;Maranh„o;741;98;America/Sao_Paulo
-5203906;Buriti Alegre;-181378;-490404;0;52;Goi·s;9277;64;America/Sao_Paulo
-2102309;Buriti Bravo;-583239;-438353;0;21;Maranh„o;743;99;America/Sao_Paulo
-5203939;Buriti de Goi·s;-161792;-504302;0;52;Goi·s;63;64;America/Sao_Paulo
+1501907;Bujaru;-151762;-480381;0;15;Par√°;437;91;America/Sao_Paulo
+3508009;Buri;-237977;-485958;0;35;S√£o Paulo;6261;15;America/Sao_Paulo
+3508108;Buritama;-210661;-501475;0;35;S√£o Paulo;6263;18;America/Sao_Paulo
+2102200;Buriti;-394169;-429179;0;21;Maranh√£o;741;98;America/Sao_Paulo
+5203906;Buriti Alegre;-181378;-490404;0;52;Goi√°s;9277;64;America/Sao_Paulo
+2102309;Buriti Bravo;-583239;-438353;0;21;Maranh√£o;743;99;America/Sao_Paulo
+5203939;Buriti de Goi√°s;-161792;-504302;0;52;Goi√°s;63;64;America/Sao_Paulo
 1703800;Buriti do Tocantins;-531448;-482271;0;17;Tocantins;9715;63;America/Sao_Paulo
-2202000;Buriti dos Lopes;-318259;-418695;0;22;PiauÌ;1039;86;America/Sao_Paulo
-2202026;Buriti dos Montes;-530584;-410933;0;22;PiauÌ;1297;86;America/Sao_Paulo
-2102325;Buriticupu;-432375;-464409;0;21;Maranh„o;134;98;America/Sao_Paulo
-5203962;BuritinÛpolis;-144772;-464076;0;52;Goi·s;61;62;America/Sao_Paulo
+2202000;Buriti dos Lopes;-318259;-418695;0;22;Piau√≠;1039;86;America/Sao_Paulo
+2202026;Buriti dos Montes;-530584;-410933;0;22;Piau√≠;1297;86;America/Sao_Paulo
+2102325;Buriticupu;-432375;-464409;0;21;Maranh√£o;134;98;America/Sao_Paulo
+5203962;Buritin√≥polis;-144772;-464076;0;52;Goi√°s;61;62;America/Sao_Paulo
 2904753;Buritirama;-107171;-436302;0;29;Bahia;3079;77;America/Sao_Paulo
-2102358;Buritirana;-559823;-470131;0;21;Maranh„o;136;99;America/Sao_Paulo
-1100452;Buritis;-101943;-638324;0;11;RondÙnia;4;69;America/Porto_Velho
+2102358;Buritirana;-559823;-470131;0;21;Maranh√£o;136;99;America/Sao_Paulo
+1100452;Buritis;-101943;-638324;0;11;Rond√¥nia;4;69;America/Porto_Velho
 3109303;Buritis;-156218;-464221;0;31;Minas Gerais;4185;38;America/Sao_Paulo
-3508207;Buritizal;-201911;-477096;0;35;S„o Paulo;6265;16;America/Sao_Paulo
+3508207;Buritizal;-201911;-477096;0;35;S√£o Paulo;6265;16;America/Sao_Paulo
 3109402;Buritizeiro;-173656;-449606;0;31;Minas Gerais;4187;38;America/Sao_Paulo
-4302709;Buti·;-301179;-519601;0;43;Rio Grande do Sul;8553;51;America/Sao_Paulo
+4302709;Buti√°;-301179;-519601;0;43;Rio Grande do Sul;8553;51;America/Sao_Paulo
 1300839;Caapiranga;-331537;-612206;0;13;Amazonas;299;92;America/Porto_Velho
-2503001;Caapor„;-751351;-349055;0;25;ParaÌba;1961;83;America/Sao_Paulo
-5002407;CaarapÛ;-226368;-548209;0;50;Mato Grosso do Sul;9055;67;America/Porto_Velho
+2503001;Caapor√£;-751351;-349055;0;25;Para√≠ba;1961;83;America/Sao_Paulo
+5002407;Caarap√≥;-226368;-548209;0;50;Mato Grosso do Sul;9055;67;America/Porto_Velho
 2904803;Caatiba;-149699;-404092;0;29;Bahia;3395;77;America/Sao_Paulo
-2503100;Cabaceiras;-748899;-36287;0;25;ParaÌba;1963;83;America/Sao_Paulo
-2904852;Cabaceiras do ParaguaÁu;-125317;-391902;0;29;Bahia;3267;75;America/Sao_Paulo
+2503100;Cabaceiras;-748899;-36287;0;25;Para√≠ba;1963;83;America/Sao_Paulo
+2904852;Cabaceiras do Paragua√ßu;-125317;-391902;0;29;Bahia;3267;75;America/Sao_Paulo
 3109451;Cabeceira Grande;-160335;-470862;0;31;Minas Gerais;578;38;America/Sao_Paulo
-5204003;Cabeceiras;-157995;-469265;0;52;Goi·s;9279;61;America/Sao_Paulo
-2202059;Cabeceiras do PiauÌ;-44773;-423069;0;22;PiauÌ;1299;86;America/Sao_Paulo
-2503209;Cabedelo;-698731;-348284;0;25;ParaÌba;1965;83;America/Sao_Paulo
-1100031;Cabixi;-134945;-60552;0;11;RondÙnia;37;69;America/Porto_Velho
+5204003;Cabeceiras;-157995;-469265;0;52;Goi√°s;9279;61;America/Sao_Paulo
+2202059;Cabeceiras do Piau√≠;-44773;-423069;0;22;Piau√≠;1299;86;America/Sao_Paulo
+2503209;Cabedelo;-698731;-348284;0;25;Para√≠ba;1965;83;America/Sao_Paulo
+1100031;Cabixi;-134945;-60552;0;11;Rond√¥nia;37;69;America/Porto_Velho
 2602902;Cabo de Santo Agostinho;-828218;-350253;0;26;Pernambuco;2357;81;America/Sao_Paulo
 3300704;Cabo Frio;-228894;-420286;0;33;Rio de Janeiro;5813;22;America/Sao_Paulo
 3109501;Cabo Verde;-214699;-463919;0;31;Minas Gerais;4189;35;America/Sao_Paulo
-3508306;Cabr·lia Paulista;-224576;-493393;0;35;S„o Paulo;6267;14;America/Sao_Paulo
-3508405;Cabre˙va;-233053;-471362;0;35;S„o Paulo;6269;11;America/Sao_Paulo
-2603009;CabrobÛ;-850548;-393094;0;26;Pernambuco;2359;87;America/Sao_Paulo
-4203006;CaÁador;-267757;-51012;0;42;Santa Catarina;8057;49;America/Sao_Paulo
-3508504;CaÁapava;-230992;-457076;0;35;S„o Paulo;6271;12;America/Sao_Paulo
-4302808;CaÁapava do Sul;-305144;-534827;0;43;Rio Grande do Sul;8555;55;America/Sao_Paulo
-1100601;Cacaul‚ndia;-10349;-629043;0;11;RondÙnia;677;69;America/Porto_Velho
+3508306;Cabr√°lia Paulista;-224576;-493393;0;35;S√£o Paulo;6267;14;America/Sao_Paulo
+3508405;Cabre√∫va;-233053;-471362;0;35;S√£o Paulo;6269;11;America/Sao_Paulo
+2603009;Cabrob√≥;-850548;-393094;0;26;Pernambuco;2359;87;America/Sao_Paulo
+4203006;Ca√ßador;-267757;-51012;0;42;Santa Catarina;8057;49;America/Sao_Paulo
+3508504;Ca√ßapava;-230992;-457076;0;35;S√£o Paulo;6271;12;America/Sao_Paulo
+4302808;Ca√ßapava do Sul;-305144;-534827;0;43;Rio Grande do Sul;8555;55;America/Sao_Paulo
+1100601;Cacaul√¢ndia;-10349;-629043;0;11;Rond√¥nia;677;69;America/Porto_Velho
 4302907;Cacequi;-298883;-54822;0;43;Rio Grande do Sul;8557;55;America/Sao_Paulo
-5102504;C·ceres;-160764;-576818;0;51;Mato Grosso;9047;65;America/Porto_Velho
+5102504;C√°ceres;-160764;-576818;0;51;Mato Grosso;9047;65;America/Porto_Velho
 2904902;Cachoeira;-125994;-389587;0;29;Bahia;3397;75;America/Sao_Paulo
-5204102;Cachoeira Alta;-187618;-509432;0;52;Goi·s;9281;64;America/Sao_Paulo
+5204102;Cachoeira Alta;-187618;-509432;0;52;Goi√°s;9281;64;America/Sao_Paulo
 3109600;Cachoeira da Prata;-19521;-444544;0;31;Minas Gerais;4191;31;America/Sao_Paulo
-5204201;Cachoeira de Goi·s;-166635;-50646;0;52;Goi·s;9283;64;America/Sao_Paulo
+5204201;Cachoeira de Goi√°s;-166635;-50646;0;52;Goi√°s;9283;64;America/Sao_Paulo
 3109709;Cachoeira de Minas;-223511;-457809;0;31;Minas Gerais;4193;35;America/Sao_Paulo
-3102704;Cachoeira de Paje˙;-159688;-414948;0;31;Minas Gerais;4053;33;America/Sao_Paulo
-1502004;Cachoeira do Arari;-101226;-489503;0;15;Par·;439;91;America/Sao_Paulo
-1501956;Cachoeira do Piri·;-175974;-465459;0;15;Par·;46;91;America/Sao_Paulo
+3102704;Cachoeira de Paje√∫;-159688;-414948;0;31;Minas Gerais;4053;33;America/Sao_Paulo
+1502004;Cachoeira do Arari;-101226;-489503;0;15;Par√°;439;91;America/Sao_Paulo
+1501956;Cachoeira do Piri√°;-175974;-465459;0;15;Par√°;46;91;America/Sao_Paulo
 4303004;Cachoeira do Sul;-30033;-528928;0;43;Rio Grande do Sul;8559;51;America/Sao_Paulo
-2503308;Cachoeira dos Õndios;-691353;-38676;0;25;ParaÌba;1967;83;America/Sao_Paulo
-5204250;Cachoeira Dourada;-184859;-494766;0;52;Goi·s;9673;64;America/Sao_Paulo
+2503308;Cachoeira dos √çndios;-691353;-38676;0;25;Para√≠ba;1967;83;America/Sao_Paulo
+5204250;Cachoeira Dourada;-184859;-494766;0;52;Goi√°s;9673;64;America/Sao_Paulo
 3109808;Cachoeira Dourada;-185161;-495039;0;31;Minas Gerais;4195;34;America/Sao_Paulo
-2102374;Cachoeira Grande;-293074;-440528;0;21;Maranh„o;138;98;America/Sao_Paulo
-3508603;Cachoeira Paulista;-226665;-450154;0;35;S„o Paulo;6273;12;America/Sao_Paulo
+2102374;Cachoeira Grande;-293074;-440528;0;21;Maranh√£o;138;98;America/Sao_Paulo
+3508603;Cachoeira Paulista;-226665;-450154;0;35;S√£o Paulo;6273;12;America/Sao_Paulo
 3300803;Cachoeiras de Macacu;-224658;-426523;0;33;Rio de Janeiro;5815;21;America/Sao_Paulo
 1703826;Cachoeirinha;-61156;-479234;0;17;Tocantins;171;63;America/Sao_Paulo
 2603108;Cachoeirinha;-848668;-362402;0;26;Pernambuco;2361;81;America/Sao_Paulo
 4303103;Cachoeirinha;-299472;-511016;0;43;Rio Grande do Sul;8561;51;America/Sao_Paulo
-3201209;Cachoeiro de Itapemirim;-208462;-411198;0;32;EspÌrito Santo;5623;28;America/Sao_Paulo
-2503407;Cacimba de Areia;-712128;-371563;0;25;ParaÌba;1969;83;America/Sao_Paulo
-2503506;Cacimba de Dentro;-66386;-357778;0;25;ParaÌba;1971;83;America/Sao_Paulo
-2503555;Cacimbas;-720721;-370604;0;25;ParaÌba;460;83;America/Sao_Paulo
+3201209;Cachoeiro de Itapemirim;-208462;-411198;0;32;Esp√≠rito Santo;5623;28;America/Sao_Paulo
+2503407;Cacimba de Areia;-712128;-371563;0;25;Para√≠ba;1969;83;America/Sao_Paulo
+2503506;Cacimba de Dentro;-66386;-357778;0;25;Para√≠ba;1971;83;America/Sao_Paulo
+2503555;Cacimbas;-720721;-370604;0;25;Para√≠ba;460;83;America/Sao_Paulo
 2701209;Cacimbinhas;-940121;-369911;0;27;Alagoas;2723;82;America/Sao_Paulo
 4303202;Cacique Doble;-27767;-516597;0;43;Rio Grande do Sul;8563;54;America/Sao_Paulo
-1100049;Cacoal;-114343;-614562;0;11;RondÙnia;9;69;America/Porto_Velho
-3508702;Caconde;-21528;-466437;0;35;S„o Paulo;6275;19;America/Sao_Paulo
-5204300;CaÁu;-185594;-511328;0;52;Goi·s;9285;64;America/Sao_Paulo
-2905008;CaculÈ;-145003;-422229;0;29;Bahia;3399;77;America/Sao_Paulo
-2905107;CaÈm;-110677;-40432;0;29;Bahia;3401;74;America/Sao_Paulo
-3109907;CaetanÛpolis;-192971;-444189;0;31;Minas Gerais;4197;31;America/Sao_Paulo
+1100049;Cacoal;-114343;-614562;0;11;Rond√¥nia;9;69;America/Porto_Velho
+3508702;Caconde;-21528;-466437;0;35;S√£o Paulo;6275;19;America/Sao_Paulo
+5204300;Ca√ßu;-185594;-511328;0;52;Goi√°s;9285;64;America/Sao_Paulo
+2905008;Cacul√©;-145003;-422229;0;29;Bahia;3399;77;America/Sao_Paulo
+2905107;Ca√©m;-110677;-40432;0;29;Bahia;3401;74;America/Sao_Paulo
+3109907;Caetan√≥polis;-192971;-444189;0;31;Minas Gerais;4197;31;America/Sao_Paulo
 2905156;Caetanos;-143347;-409175;0;29;Bahia;3269;77;America/Sao_Paulo
-3110004;CaetÈ;-198826;-436704;0;31;Minas Gerais;4199;31;America/Sao_Paulo
-2603207;CaetÈs;-87803;-366268;0;26;Pernambuco;2363;87;America/Sao_Paulo
-2905206;CaetitÈ;-140684;-424861;0;29;Bahia;3403;77;America/Sao_Paulo
+3110004;Caet√©;-198826;-436704;0;31;Minas Gerais;4199;31;America/Sao_Paulo
+2603207;Caet√©s;-87803;-366268;0;26;Pernambuco;2363;87;America/Sao_Paulo
+2905206;Caetit√©;-140684;-424861;0;29;Bahia;3403;77;America/Sao_Paulo
 2905305;Cafarnaum;-116914;-414688;0;29;Bahia;3405;74;America/Sao_Paulo
-4103404;Cafeara;-22789;-517142;0;41;Paran·;7465;43;America/Sao_Paulo
-3508801;Cafel‚ndia;-218031;-496092;0;35;S„o Paulo;6277;14;America/Sao_Paulo
-4103453;Cafel‚ndia;-246189;-533207;0;41;Paran·;7985;45;America/Sao_Paulo
-4103479;Cafezal do Sul;-239005;-535124;0;41;Paran·;5491;44;America/Sao_Paulo
-3508900;Caiabu;-220127;-512394;0;35;S„o Paulo;6279;18;America/Sao_Paulo
+4103404;Cafeara;-22789;-517142;0;41;Paran√°;7465;43;America/Sao_Paulo
+3508801;Cafel√¢ndia;-218031;-496092;0;35;S√£o Paulo;6277;14;America/Sao_Paulo
+4103453;Cafel√¢ndia;-246189;-533207;0;41;Paran√°;7985;45;America/Sao_Paulo
+4103479;Cafezal do Sul;-239005;-535124;0;41;Paran√°;5491;44;America/Sao_Paulo
+3508900;Caiabu;-220127;-512394;0;35;S√£o Paulo;6279;18;America/Sao_Paulo
 3110103;Caiana;-206956;-419292;0;31;Minas Gerais;4201;32;America/Sao_Paulo
-5204409;CaiapÙnia;-169539;-518091;0;52;Goi·s;9287;64;America/Sao_Paulo
-4303301;CaibatÈ;-282905;-546454;0;43;Rio Grande do Sul;8565;55;America/Sao_Paulo
+5204409;Caiap√¥nia;-169539;-518091;0;52;Goi√°s;9287;64;America/Sao_Paulo
+4303301;Caibat√©;-282905;-546454;0;43;Rio Grande do Sul;8565;55;America/Sao_Paulo
 4203105;Caibi;-270741;-532458;0;42;Santa Catarina;8059;49;America/Sao_Paulo
-4303400;CaiÁara;-272791;-534257;0;43;Rio Grande do Sul;8567;55;America/Sao_Paulo
-2503605;CaiÁara;-662115;-354581;0;25;ParaÌba;1973;83;America/Sao_Paulo
-2401859;CaiÁara do Norte;-507091;-360717;0;24;Rio Grande do Norte;414;84;America/Sao_Paulo
-2401909;CaiÁara do Rio do Vento;-576541;-359938;0;24;Rio Grande do Norte;1637;84;America/Sao_Paulo
-2402006;CaicÛ;-645441;-371067;0;24;Rio Grande do Norte;1639;84;America/Sao_Paulo
-3509007;Caieiras;-233607;-467397;0;35;S„o Paulo;6281;11;America/Sao_Paulo
+4303400;Cai√ßara;-272791;-534257;0;43;Rio Grande do Sul;8567;55;America/Sao_Paulo
+2503605;Cai√ßara;-662115;-354581;0;25;Para√≠ba;1973;83;America/Sao_Paulo
+2401859;Cai√ßara do Norte;-507091;-360717;0;24;Rio Grande do Norte;414;84;America/Sao_Paulo
+2401909;Cai√ßara do Rio do Vento;-576541;-359938;0;24;Rio Grande do Norte;1637;84;America/Sao_Paulo
+2402006;Caic√≥;-645441;-371067;0;24;Rio Grande do Norte;1639;84;America/Sao_Paulo
+3509007;Caieiras;-233607;-467397;0;35;S√£o Paulo;6281;11;America/Sao_Paulo
 2905404;Cairu;-134904;-390465;0;29;Bahia;3407;75;America/Sao_Paulo
-3509106;Caiu·;-218322;-519969;0;35;S„o Paulo;6283;18;America/Sao_Paulo
-3509205;Cajamar;-23355;-468781;0;35;S„o Paulo;6285;11;America/Sao_Paulo
-2102408;CajapiÛ;-287326;-446741;0;21;Maranh„o;745;98;America/Sao_Paulo
-2102507;Cajari;-332742;-450145;0;21;Maranh„o;747;98;America/Sao_Paulo
-3509254;Cajati;-247324;-481223;0;35;S„o Paulo;2967;13;America/Sao_Paulo
-2503704;Cajazeiras;-688004;-385577;0;25;ParaÌba;1975;83;America/Sao_Paulo
-2202075;Cajazeiras do PiauÌ;-679667;-423903;0;22;PiauÌ;286;89;America/Sao_Paulo
-2503753;Cajazeirinhas;-696016;-378009;0;25;ParaÌba;462;83;America/Sao_Paulo
-3509304;Cajobi;-208773;-488063;0;35;S„o Paulo;6287;17;America/Sao_Paulo
+3509106;Caiu√°;-218322;-519969;0;35;S√£o Paulo;6283;18;America/Sao_Paulo
+3509205;Cajamar;-23355;-468781;0;35;S√£o Paulo;6285;11;America/Sao_Paulo
+2102408;Cajapi√≥;-287326;-446741;0;21;Maranh√£o;745;98;America/Sao_Paulo
+2102507;Cajari;-332742;-450145;0;21;Maranh√£o;747;98;America/Sao_Paulo
+3509254;Cajati;-247324;-481223;0;35;S√£o Paulo;2967;13;America/Sao_Paulo
+2503704;Cajazeiras;-688004;-385577;0;25;Para√≠ba;1975;83;America/Sao_Paulo
+2202075;Cajazeiras do Piau√≠;-679667;-423903;0;22;Piau√≠;286;89;America/Sao_Paulo
+2503753;Cajazeirinhas;-696016;-378009;0;25;Para√≠ba;462;83;America/Sao_Paulo
+3509304;Cajobi;-208773;-488063;0;35;S√£o Paulo;6287;17;America/Sao_Paulo
 2701308;Cajueiro;-93994;-361559;0;27;Alagoas;2725;82;America/Sao_Paulo
-2202083;Cajueiro da Praia;-293111;-413408;0;22;PiauÌ;288;86;America/Sao_Paulo
+2202083;Cajueiro da Praia;-293111;-413408;0;22;Piau√≠;288;86;America/Sao_Paulo
 3110202;Cajuri;-207903;-427925;0;31;Minas Gerais;4203;31;America/Sao_Paulo
-3509403;Cajuru;-212749;-47303;0;35;S„o Paulo;6289;16;America/Sao_Paulo
-2603306;CalÁado;-873108;-363366;0;26;Pernambuco;2365;87;America/Sao_Paulo
-1600204;CalÁoene;250475;-509512;0;16;Amap·;603;96;America/Sao_Paulo
+3509403;Cajuru;-212749;-47303;0;35;S√£o Paulo;6289;16;America/Sao_Paulo
+2603306;Cal√ßado;-873108;-363366;0;26;Pernambuco;2365;87;America/Sao_Paulo
+1600204;Cal√ßoene;250475;-509512;0;16;Amap√°;603;96;America/Sao_Paulo
 3110301;Caldas;-219183;-463843;0;31;Minas Gerais;4205;35;America/Sao_Paulo
-2503803;Caldas Brand„o;-71025;-353272;0;25;ParaÌba;1977;83;America/Sao_Paulo
-5204508;Caldas Novas;-177441;-486246;0;52;Goi·s;9289;64;America/Sao_Paulo
-5204557;Caldazinha;-167117;-490013;0;52;Goi·s;31;62;America/Sao_Paulo
-2905503;Caldeir„o Grande;-110208;-402956;0;29;Bahia;3409;74;America/Sao_Paulo
-2202091;Caldeir„o Grande do PiauÌ;-73314;-406366;0;22;PiauÌ;2271;89;America/Sao_Paulo
-4103503;CalifÛrnia;-236566;-513574;0;41;Paran·;7467;43;America/Sao_Paulo
+2503803;Caldas Brand√£o;-71025;-353272;0;25;Para√≠ba;1977;83;America/Sao_Paulo
+5204508;Caldas Novas;-177441;-486246;0;52;Goi√°s;9289;64;America/Sao_Paulo
+5204557;Caldazinha;-167117;-490013;0;52;Goi√°s;31;62;America/Sao_Paulo
+2905503;Caldeir√£o Grande;-110208;-402956;0;29;Bahia;3409;74;America/Sao_Paulo
+2202091;Caldeir√£o Grande do Piau√≠;-73314;-406366;0;22;Piau√≠;2271;89;America/Sao_Paulo
+4103503;Calif√≥rnia;-236566;-513574;0;41;Paran√°;7467;43;America/Sao_Paulo
 4203154;Calmon;-265942;-51095;0;42;Santa Catarina;5553;49;America/Sao_Paulo
 2603405;Calumbi;-793551;-381482;0;26;Pernambuco;2367;87;America/Sao_Paulo
 2905602;Camacan;-154142;-394919;0;29;Bahia;3411;73;America/Sao_Paulo
-2905701;CamaÁari;-126996;-383263;0;29;Bahia;3413;71;America/Sao_Paulo
+2905701;Cama√ßari;-126996;-383263;0;29;Bahia;3413;71;America/Sao_Paulo
 3110400;Camacho;-206294;-451593;0;31;Minas Gerais;4207;37;America/Sao_Paulo
-2503902;Camala˙;-788503;-368242;0;25;ParaÌba;1979;83;America/Sao_Paulo
+2503902;Camala√∫;-788503;-368242;0;25;Para√≠ba;1979;83;America/Sao_Paulo
 2905800;Camamu;-139398;-391071;0;29;Bahia;3415;73;America/Sao_Paulo
 3110509;Camanducaia;-227515;-461494;0;31;Minas Gerais;4209;35;America/Sao_Paulo
-5002605;Camapu„;-195347;-540431;0;50;Mato Grosso do Sul;9049;67;America/Porto_Velho
-4303509;Camaqu„;-308489;-518043;0;43;Rio Grande do Sul;8569;51;America/Sao_Paulo
+5002605;Camapu√£;-195347;-540431;0;50;Mato Grosso do Sul;9049;67;America/Porto_Velho
+4303509;Camaqu√£;-308489;-518043;0;43;Rio Grande do Sul;8569;51;America/Sao_Paulo
 2603454;Camaragibe;-802351;-349782;0;26;Pernambuco;2629;81;America/Sao_Paulo
 4303558;Camargo;-28588;-522003;0;43;Rio Grande do Sul;8447;54;America/Sao_Paulo
-4103602;Cambar·;-230423;-500753;0;41;Paran·;7469;43;America/Sao_Paulo
-4303608;Cambar· do Sul;-290474;-501465;0;43;Rio Grande do Sul;8571;54;America/Sao_Paulo
-4103701;CambÈ;-232766;-512798;0;41;Paran·;7471;43;America/Sao_Paulo
-4103800;Cambira;-23589;-515792;0;41;Paran·;7473;43;America/Sao_Paulo
-4203204;Cambori˙;-270241;-486503;0;42;Santa Catarina;8061;47;America/Sao_Paulo
+4103602;Cambar√°;-230423;-500753;0;41;Paran√°;7469;43;America/Sao_Paulo
+4303608;Cambar√° do Sul;-290474;-501465;0;43;Rio Grande do Sul;8571;54;America/Sao_Paulo
+4103701;Camb√©;-232766;-512798;0;41;Paran√°;7471;43;America/Sao_Paulo
+4103800;Cambira;-23589;-515792;0;41;Paran√°;7473;43;America/Sao_Paulo
+4203204;Cambori√∫;-270241;-486503;0;42;Santa Catarina;8061;47;America/Sao_Paulo
 3300902;Cambuci;-215691;-419187;0;33;Rio de Janeiro;5817;22;America/Sao_Paulo
-3110608;CambuÌ;-226115;-460572;0;31;Minas Gerais;4211;35;America/Sao_Paulo
+3110608;Cambu√≠;-226115;-460572;0;31;Minas Gerais;4211;35;America/Sao_Paulo
 3110707;Cambuquira;-21854;-452896;0;31;Minas Gerais;4213;35;America/Sao_Paulo
-1502103;Camet·;-224295;-494979;0;15;Par·;441;91;America/Sao_Paulo
-2302602;Camocim;-29005;-408544;0;23;Cear·;1351;88;America/Sao_Paulo
-2603504;Camocim de S„o FÈlix;-835865;-357653;0;26;Pernambuco;2369;81;America/Sao_Paulo
-3110806;Campan·rio;-182427;-417355;0;31;Minas Gerais;4215;33;America/Sao_Paulo
+1502103;Camet√°;-224295;-494979;0;15;Par√°;441;91;America/Sao_Paulo
+2302602;Camocim;-29005;-408544;0;23;Cear√°;1351;88;America/Sao_Paulo
+2603504;Camocim de S√£o F√©lix;-835865;-357653;0;26;Pernambuco;2369;81;America/Sao_Paulo
+3110806;Campan√°rio;-182427;-417355;0;31;Minas Gerais;4215;33;America/Sao_Paulo
 3110905;Campanha;-21836;-454004;0;31;Minas Gerais;4217;35;America/Sao_Paulo
 3111002;Campestre;-217079;-462381;0;31;Minas Gerais;4219;35;America/Sao_Paulo
 2701357;Campestre;-884723;-355685;0;27;Alagoas;560;82;America/Sao_Paulo
 4303673;Campestre da Serra;-287926;-510941;0;43;Rio Grande do Sul;6013;54;America/Sao_Paulo
-5204607;Campestre de Goi·s;-167624;-49695;0;52;Goi·s;9291;62;America/Sao_Paulo
-2102556;Campestre do Maranh„o;-617075;-473625;0;21;Maranh„o;140;99;America/Sao_Paulo
-4103909;Campina da Lagoa;-245893;-527976;0;41;Paran·;7475;44;America/Sao_Paulo
-4303707;Campina das Missıes;-279888;-548416;0;43;Rio Grande do Sul;8573;55;America/Sao_Paulo
-3509452;Campina do Monte Alegre;-235895;-484758;0;35;S„o Paulo;2999;15;America/Sao_Paulo
-4103958;Campina do Sim„o;-250802;-518237;0;41;Paran·;840;42;America/Sao_Paulo
-2504009;Campina Grande;-722196;-358731;0;25;ParaÌba;1981;83;America/Sao_Paulo
-4104006;Campina Grande do Sul;-253044;-490551;0;41;Paran·;7477;41;America/Sao_Paulo
+5204607;Campestre de Goi√°s;-167624;-49695;0;52;Goi√°s;9291;62;America/Sao_Paulo
+2102556;Campestre do Maranh√£o;-617075;-473625;0;21;Maranh√£o;140;99;America/Sao_Paulo
+4103909;Campina da Lagoa;-245893;-527976;0;41;Paran√°;7475;44;America/Sao_Paulo
+4303707;Campina das Miss√µes;-279888;-548416;0;43;Rio Grande do Sul;8573;55;America/Sao_Paulo
+3509452;Campina do Monte Alegre;-235895;-484758;0;35;S√£o Paulo;2999;15;America/Sao_Paulo
+4103958;Campina do Sim√£o;-250802;-518237;0;41;Paran√°;840;42;America/Sao_Paulo
+2504009;Campina Grande;-722196;-358731;0;25;Para√≠ba;1981;83;America/Sao_Paulo
+4104006;Campina Grande do Sul;-253044;-490551;0;41;Paran√°;7477;41;America/Sao_Paulo
 3111101;Campina Verde;-195382;-494862;0;31;Minas Gerais;4221;34;America/Sao_Paulo
-5204656;CampinaÁu;-13787;-485704;0;52;Goi·s;9687;62;America/Sao_Paulo
-5102603;Campin·polis;-145162;-52893;0;51;Mato Grosso;9863;66;America/Porto_Velho
-3509502;Campinas;-229053;-470659;0;35;S„o Paulo;6291;19;America/Sao_Paulo
-2202109;Campinas do PiauÌ;-76593;-418775;0;22;PiauÌ;1041;89;America/Sao_Paulo
+5204656;Campina√ßu;-13787;-485704;0;52;Goi√°s;9687;62;America/Sao_Paulo
+5102603;Campin√°polis;-145162;-52893;0;51;Mato Grosso;9863;66;America/Porto_Velho
+3509502;Campinas;-229053;-470659;0;35;S√£o Paulo;6291;19;America/Sao_Paulo
+2202109;Campinas do Piau√≠;-76593;-418775;0;22;Piau√≠;1041;89;America/Sao_Paulo
 4303806;Campinas do Sul;-277174;-526248;0;43;Rio Grande do Sul;8575;54;America/Sao_Paulo
-5204706;Campinorte;-143137;-491511;0;52;Goi·s;9293;62;America/Sao_Paulo
+5204706;Campinorte;-143137;-491511;0;52;Goi√°s;9293;62;America/Sao_Paulo
 4203303;Campo Alegre;-26195;-492676;0;42;Santa Catarina;8063;47;America/Sao_Paulo
 2701407;Campo Alegre;-978451;-363525;0;27;Alagoas;2727;82;America/Sao_Paulo
-5204805;Campo Alegre de Goi·s;-176363;-477768;0;52;Goi·s;9295;64;America/Sao_Paulo
+5204805;Campo Alegre de Goi√°s;-176363;-477768;0;52;Goi√°s;9295;64;America/Sao_Paulo
 2905909;Campo Alegre de Lourdes;-952221;-430126;0;29;Bahia;3417;74;America/Sao_Paulo
-2202117;Campo Alegre do Fidalgo;-838236;-418344;0;22;PiauÌ;290;89;America/Sao_Paulo
+2202117;Campo Alegre do Fidalgo;-838236;-418344;0;22;Piau√≠;290;89;America/Sao_Paulo
 3111150;Campo Azul;-165028;-448096;0;31;Minas Gerais;580;38;America/Sao_Paulo
 3111200;Campo Belo;-208932;-452699;0;31;Minas Gerais;4223;35;America/Sao_Paulo
 4203402;Campo Belo do Sul;-278975;-507595;0;42;Santa Catarina;8065;49;America/Sao_Paulo
 4303905;Campo Bom;-296747;-510606;0;43;Rio Grande do Sul;8577;51;America/Sao_Paulo
-4104055;Campo Bonito;-250294;-529939;0;41;Paran·;8475;45;America/Sao_Paulo
+4104055;Campo Bonito;-250294;-529939;0;41;Paran√°;8475;45;America/Sao_Paulo
 2801009;Campo do Brito;-107392;-374954;0;28;Sergipe;3119;79;America/Sao_Paulo
 3111309;Campo do Meio;-211127;-458273;0;31;Minas Gerais;4225;35;America/Sao_Paulo
-4104105;Campo do Tenente;-2598;-496844;0;41;Paran·;7479;41;America/Sao_Paulo
-4203501;Campo ErÍ;-263931;-530856;0;42;Santa Catarina;8067;49;America/Sao_Paulo
+4104105;Campo do Tenente;-2598;-496844;0;41;Paran√°;7479;41;America/Sao_Paulo
+4203501;Campo Er√™;-263931;-530856;0;42;Santa Catarina;8067;49;America/Sao_Paulo
 3111408;Campo Florido;-197631;-485716;0;31;Minas Gerais;4227;34;America/Sao_Paulo
 2906006;Campo Formoso;-105105;-4032;0;29;Bahia;3419;74;America/Sao_Paulo
 2701506;Campo Grande;-995542;-367926;0;27;Alagoas;2729;82;America/Sao_Paulo
 5002704;Campo Grande;-204486;-546295;1;50;Mato Grosso do Sul;9051;67;America/Porto_Velho
-2202133;Campo Grande do PiauÌ;-712827;-410315;0;22;PiauÌ;292;89;America/Sao_Paulo
-4104204;Campo Largo;-254525;-49529;0;41;Paran·;7481;41;America/Sao_Paulo
-2202174;Campo Largo do PiauÌ;-380441;-4264;0;22;PiauÌ;294;86;America/Sao_Paulo
-5204854;Campo Limpo de Goi·s;-162971;-490895;0;52;Goi·s;1070;62;America/Sao_Paulo
-3509601;Campo Limpo Paulista;-232078;-467889;0;35;S„o Paulo;6293;11;America/Sao_Paulo
-4104253;Campo Magro;-253687;-494501;0;41;Paran·;842;41;America/Sao_Paulo
-2202208;Campo Maior;-48217;-421641;0;22;PiauÌ;1043;86;America/Sao_Paulo
-4104303;Campo Mour„o;-240463;-52378;0;41;Paran·;7483;44;America/Sao_Paulo
+2202133;Campo Grande do Piau√≠;-712827;-410315;0;22;Piau√≠;292;89;America/Sao_Paulo
+4104204;Campo Largo;-254525;-49529;0;41;Paran√°;7481;41;America/Sao_Paulo
+2202174;Campo Largo do Piau√≠;-380441;-4264;0;22;Piau√≠;294;86;America/Sao_Paulo
+5204854;Campo Limpo de Goi√°s;-162971;-490895;0;52;Goi√°s;1070;62;America/Sao_Paulo
+3509601;Campo Limpo Paulista;-232078;-467889;0;35;S√£o Paulo;6293;11;America/Sao_Paulo
+4104253;Campo Magro;-253687;-494501;0;41;Paran√°;842;41;America/Sao_Paulo
+2202208;Campo Maior;-48217;-421641;0;22;Piau√≠;1043;86;America/Sao_Paulo
+4104303;Campo Mour√£o;-240463;-52378;0;41;Paran√°;7483;44;America/Sao_Paulo
 4304002;Campo Novo;-276792;-538052;0;43;Rio Grande do Sul;8579;55;America/Sao_Paulo
-1100700;Campo Novo de RondÙnia;-105712;-636266;0;11;RondÙnia;679;69;America/Porto_Velho
+1100700;Campo Novo de Rond√¥nia;-105712;-636266;0;11;Rond√¥nia;679;69;America/Porto_Velho
 5102637;Campo Novo do Parecis;-136587;-578907;0;51;Mato Grosso;9777;65;America/Porto_Velho
 2402105;Campo Redondo;-623829;-361888;0;24;Rio Grande do Norte;1641;84;America/Sao_Paulo
 5102678;Campo Verde;-15545;-551626;0;51;Mato Grosso;9779;66;America/Porto_Velho
 3111507;Campos Altos;-196914;-461725;0;31;Minas Gerais;4229;37;America/Sao_Paulo
-5204904;Campos Belos;-13035;-467681;0;52;Goi·s;9297;62;America/Sao_Paulo
+5204904;Campos Belos;-13035;-467681;0;52;Goi√°s;9297;62;America/Sao_Paulo
 4304101;Campos Borges;-288871;-530008;0;43;Rio Grande do Sul;8445;54;America/Sao_Paulo
-5102686;Campos de J˙lio;-137242;-592858;0;51;Mato Grosso;1032;65;America/Porto_Velho
-3509700;Campos do Jord„o;-227296;-455833;0;35;S„o Paulo;6295;12;America/Sao_Paulo
+5102686;Campos de J√∫lio;-137242;-592858;0;51;Mato Grosso;1032;65;America/Porto_Velho
+3509700;Campos do Jord√£o;-227296;-455833;0;35;S√£o Paulo;6295;12;America/Sao_Paulo
 3301009;Campos dos Goytacazes;-217622;-413181;0;33;Rio de Janeiro;5819;22;America/Sao_Paulo
 3111606;Campos Gerais;-21237;-457569;0;31;Minas Gerais;4231;35;America/Sao_Paulo
 1703842;Campos Lindos;-798956;-468645;0;17;Tocantins;173;63;America/Sao_Paulo
 4203600;Campos Novos;-274002;-512276;0;42;Santa Catarina;8069;49;America/Sao_Paulo
-3509809;Campos Novos Paulista;-22602;-499987;0;35;S„o Paulo;6297;14;America/Sao_Paulo
-2302701;Campos Sales;-706761;-403687;0;23;Cear·;1353;88;America/Sao_Paulo
-5204953;Campos Verdes;-142442;-496528;0;52;Goi·s;9781;62;America/Sao_Paulo
+3509809;Campos Novos Paulista;-22602;-499987;0;35;S√£o Paulo;6297;14;America/Sao_Paulo
+2302701;Campos Sales;-706761;-403687;0;23;Cear√°;1353;88;America/Sao_Paulo
+5204953;Campos Verdes;-142442;-496528;0;52;Goi√°s;9781;62;America/Sao_Paulo
 2603603;Camutanga;-740545;-352664;0;26;Pernambuco;2371;81;America/Sao_Paulo
 3111903;Cana Verde;-210232;-451801;0;31;Minas Gerais;4237;35;America/Sao_Paulo
-3111705;Cana„;-206869;-426167;0;31;Minas Gerais;4233;31;America/Sao_Paulo
-1502152;Cana„ dos Caraj·s;-649659;-498776;0;15;Par·;48;94;America/Sao_Paulo
+3111705;Cana√£;-206869;-426167;0;31;Minas Gerais;4233;31;America/Sao_Paulo
+1502152;Cana√£ dos Caraj√°s;-649659;-498776;0;15;Par√°;48;94;America/Sao_Paulo
 5102694;Canabrava do Norte;-110556;-518209;0;51;Mato Grosso;129;66;America/Porto_Velho
-3509908;CananÈia;-250144;-479341;0;35;S„o Paulo;6299;13;America/Sao_Paulo
+3509908;Canan√©ia;-250144;-479341;0;35;S√£o Paulo;6299;13;America/Sao_Paulo
 2701605;Canapi;-911932;-375967;0;27;Alagoas;2731;82;America/Sao_Paulo
-2906105;Can·polis;-130725;-44201;0;29;Bahia;3421;77;America/Sao_Paulo
-3111804;Can·polis;-187212;-492035;0;31;Minas Gerais;4235;34;America/Sao_Paulo
+2906105;Can√°polis;-130725;-44201;0;29;Bahia;3421;77;America/Sao_Paulo
+3111804;Can√°polis;-187212;-492035;0;31;Minas Gerais;4235;34;America/Sao_Paulo
 2906204;Canarana;-116858;-417677;0;29;Bahia;3423;74;America/Sao_Paulo
 5102702;Canarana;-135515;-522705;0;51;Mato Grosso;9193;66;America/Porto_Velho
-3509957;Canas;-227003;-450521;0;35;S„o Paulo;794;12;America/Sao_Paulo
-2202251;Canavieira;-768821;-437233;0;22;PiauÌ;2247;89;America/Sao_Paulo
+3509957;Canas;-227003;-450521;0;35;S√£o Paulo;794;12;America/Sao_Paulo
+2202251;Canavieira;-768821;-437233;0;22;Piau√≠;2247;89;America/Sao_Paulo
 2906303;Canavieiras;-156722;-389536;0;29;Bahia;3425;73;America/Sao_Paulo
 2906402;Candeal;-118049;-391203;0;29;Bahia;3427;75;America/Sao_Paulo
 2906501;Candeias;-126716;-385472;0;29;Bahia;3429;71;America/Sao_Paulo
 3112000;Candeias;-207692;-452765;0;31;Minas Gerais;4239;35;America/Sao_Paulo
-1100809;Candeias do Jamari;-87907;-637005;0;11;RondÙnia;681;69;America/Porto_Velho
-4304200;Candel·ria;-296684;-527895;0;43;Rio Grande do Sul;8581;51;America/Sao_Paulo
+1100809;Candeias do Jamari;-87907;-637005;0;11;Rond√¥nia;681;69;America/Porto_Velho
+4304200;Candel√°ria;-296684;-527895;0;43;Rio Grande do Sul;8581;51;America/Sao_Paulo
 2906600;Candiba;-144097;-428667;0;29;Bahia;3431;77;America/Sao_Paulo
-4104402;C‚ndido de Abreu;-245649;-513372;0;41;Paran·;7485;43;America/Sao_Paulo
-4304309;C‚ndido GodÛi;-279515;-547517;0;43;Rio Grande do Sul;8583;55;America/Sao_Paulo
-2102606;C‚ndido Mendes;-143265;-457161;0;21;Maranh„o;749;98;America/Sao_Paulo
-3510005;C‚ndido Mota;-227471;-503873;0;35;S„o Paulo;6301;18;America/Sao_Paulo
-3510104;C‚ndido Rodrigues;-213275;-486327;0;35;S„o Paulo;6303;16;America/Sao_Paulo
-2906709;C‚ndido Sales;-154993;-412414;0;29;Bahia;3433;77;America/Sao_Paulo
+4104402;C√¢ndido de Abreu;-245649;-513372;0;41;Paran√°;7485;43;America/Sao_Paulo
+4304309;C√¢ndido God√≥i;-279515;-547517;0;43;Rio Grande do Sul;8583;55;America/Sao_Paulo
+2102606;C√¢ndido Mendes;-143265;-457161;0;21;Maranh√£o;749;98;America/Sao_Paulo
+3510005;C√¢ndido Mota;-227471;-503873;0;35;S√£o Paulo;6301;18;America/Sao_Paulo
+3510104;C√¢ndido Rodrigues;-213275;-486327;0;35;S√£o Paulo;6303;16;America/Sao_Paulo
+2906709;C√¢ndido Sales;-154993;-412414;0;29;Bahia;3433;77;America/Sao_Paulo
 4304358;Candiota;-315516;-536773;0;43;Rio Grande do Sul;6083;53;America/Sao_Paulo
-4104428;CandÛi;-255758;-520409;0;41;Paran·;5499;42;America/Sao_Paulo
+4104428;Cand√≥i;-255758;-520409;0;41;Paran√°;5499;42;America/Sao_Paulo
 4304408;Canela;-29356;-508119;0;43;Rio Grande do Sul;8585;54;America/Sao_Paulo
 4203709;Canelinha;-272616;-487658;0;42;Santa Catarina;8071;48;America/Sao_Paulo
 2402204;Canguaretama;-637193;-351281;0;24;Rio Grande do Norte;1643;84;America/Sao_Paulo
-4304507;CanguÁu;-31396;-526783;0;43;Rio Grande do Sul;8587;53;America/Sao_Paulo
+4304507;Cangu√ßu;-31396;-526783;0;43;Rio Grande do Sul;8587;53;America/Sao_Paulo
 2801108;Canhoba;-101365;-369806;0;28;Sergipe;3121;79;America/Sao_Paulo
 2603702;Canhotinho;-887652;-361979;0;26;Pernambuco;2373;87;America/Sao_Paulo
-2302800;CanindÈ;-435162;-393155;0;23;Cear·;1355;85;America/Sao_Paulo
-2801207;CanindÈ de S„o Francisco;-964882;-377923;0;28;Sergipe;3123;79;America/Sao_Paulo
-3510153;Canitar;-23004;-497839;0;35;S„o Paulo;2947;14;America/Sao_Paulo
+2302800;Canind√©;-435162;-393155;0;23;Cear√°;1355;85;America/Sao_Paulo
+2801207;Canind√© de S√£o Francisco;-964882;-377923;0;28;Sergipe;3123;79;America/Sao_Paulo
+3510153;Canitar;-23004;-497839;0;35;S√£o Paulo;2947;14;America/Sao_Paulo
 4304606;Canoas;-299128;-511857;0;43;Rio Grande do Sul;8589;51;America/Sao_Paulo
 4203808;Canoinhas;-261766;-50395;0;42;Santa Catarina;8073;47;America/Sao_Paulo
-2906808;CansanÁ„o;-106647;-394944;0;29;Bahia;3435;75;America/Sao_Paulo
-1400175;Cant·;260994;-606058;0;14;Roraima;28;95;America/Porto_Velho
+2906808;Cansan√ß√£o;-106647;-394944;0;29;Bahia;3435;75;America/Sao_Paulo
+1400175;Cant√°;260994;-606058;0;14;Roraima;28;95;America/Porto_Velho
 3301108;Cantagalo;-219797;-423664;0;33;Rio de Janeiro;5821;22;America/Sao_Paulo
-4104451;Cantagalo;-253734;-521198;0;41;Paran·;8451;42;America/Sao_Paulo
+4104451;Cantagalo;-253734;-521198;0;41;Paran√°;8451;42;America/Sao_Paulo
 3112059;Cantagalo;-185248;-426223;0;31;Minas Gerais;582;33;America/Sao_Paulo
-2102705;Cantanhede;-363757;-44383;0;21;Maranh„o;751;98;America/Sao_Paulo
-2202307;Canto do Buriti;-81111;-429517;0;22;PiauÌ;1045;89;America/Sao_Paulo
+2102705;Cantanhede;-363757;-44383;0;21;Maranh√£o;751;98;America/Sao_Paulo
+2202307;Canto do Buriti;-81111;-429517;0;22;Piau√≠;1045;89;America/Sao_Paulo
 2906824;Canudos;-990014;-391471;0;29;Bahia;3085;75;America/Sao_Paulo
 4304614;Canudos do Vale;-293271;-522374;0;43;Rio Grande do Sul;1130;51;America/Sao_Paulo
 1300904;Canutama;-652582;-643953;0;13;Amazonas;219;97;America/Porto_Velho
-1502202;Capanema;-120529;-471778;0;15;Par·;443;91;America/Sao_Paulo
-4104501;Capanema;-256691;-538055;0;41;Paran·;7487;46;America/Sao_Paulo
-4203253;Cap„o Alto;-279389;-505098;0;42;Santa Catarina;906;49;America/Sao_Paulo
-3510203;Cap„o Bonito;-240113;-483482;0;35;S„o Paulo;6305;15;America/Sao_Paulo
-4304622;Cap„o Bonito do Sul;-281254;-513961;0;43;Rio Grande do Sul;1132;54;America/Sao_Paulo
-4304630;Cap„o da Canoa;-297642;-500282;0;43;Rio Grande do Sul;8915;51;America/Sao_Paulo
-4304655;Cap„o do CipÛ;-289312;-545558;0;43;Rio Grande do Sul;1134;55;America/Sao_Paulo
-4304663;Cap„o do Le„o;-317565;-524889;0;43;Rio Grande do Sul;8973;53;America/Sao_Paulo
-3112109;CaparaÛ;-205289;-419061;0;31;Minas Gerais;4241;32;America/Sao_Paulo
+1502202;Capanema;-120529;-471778;0;15;Par√°;443;91;America/Sao_Paulo
+4104501;Capanema;-256691;-538055;0;41;Paran√°;7487;46;America/Sao_Paulo
+4203253;Cap√£o Alto;-279389;-505098;0;42;Santa Catarina;906;49;America/Sao_Paulo
+3510203;Cap√£o Bonito;-240113;-483482;0;35;S√£o Paulo;6305;15;America/Sao_Paulo
+4304622;Cap√£o Bonito do Sul;-281254;-513961;0;43;Rio Grande do Sul;1132;54;America/Sao_Paulo
+4304630;Cap√£o da Canoa;-297642;-500282;0;43;Rio Grande do Sul;8915;51;America/Sao_Paulo
+4304655;Cap√£o do Cip√≥;-289312;-545558;0;43;Rio Grande do Sul;1134;55;America/Sao_Paulo
+4304663;Cap√£o do Le√£o;-317565;-524889;0;43;Rio Grande do Sul;8973;53;America/Sao_Paulo
+3112109;Capara√≥;-205289;-419061;0;31;Minas Gerais;4241;32;America/Sao_Paulo
 2701704;Capela;-941504;-360826;0;27;Alagoas;2733;82;America/Sao_Paulo
 2801306;Capela;-105069;-370628;0;28;Sergipe;3125;79;America/Sao_Paulo
 4304689;Capela de Santana;-296961;-51328;0;43;Rio Grande do Sul;8443;51;America/Sao_Paulo
-3510302;Capela do Alto;-234685;-477388;0;35;S„o Paulo;6307;15;America/Sao_Paulo
+3510302;Capela do Alto;-234685;-477388;0;35;S√£o Paulo;6307;15;America/Sao_Paulo
 2906857;Capela do Alto Alegre;-116658;-398349;0;29;Bahia;3081;75;America/Sao_Paulo
 3112208;Capela Nova;-209179;-43622;0;31;Minas Gerais;4243;31;America/Sao_Paulo
 3112307;Capelinha;-176888;-425147;0;31;Minas Gerais;4245;33;America/Sao_Paulo
 3112406;Capetinga;-206163;-470571;0;31;Minas Gerais;4247;35;America/Sao_Paulo
-2504033;Capim;-691624;-351673;0;25;ParaÌba;464;83;America/Sao_Paulo
+2504033;Capim;-691624;-351673;0;25;Para√≠ba;464;83;America/Sao_Paulo
 3112505;Capim Branco;-195471;-441304;0;31;Minas Gerais;4249;31;America/Sao_Paulo
 2906873;Capim Grosso;-113797;-400089;0;29;Bahia;3083;74;America/Sao_Paulo
-3112604;CapinÛpolis;-186862;-495706;0;31;Minas Gerais;4251;34;America/Sao_Paulo
+3112604;Capin√≥polis;-186862;-495706;0;31;Minas Gerais;4251;34;America/Sao_Paulo
 4203907;Capinzal;-273473;-516057;0;42;Santa Catarina;8075;49;America/Sao_Paulo
-2102754;Capinzal do Norte;-47236;-44328;0;21;Maranh„o;142;99;America/Sao_Paulo
-2302909;Capistrano;-445569;-389048;0;23;Cear·;1357;85;America/Sao_Paulo
-4304697;Capit„o;-292674;-519853;0;43;Rio Grande do Sul;6025;51;America/Sao_Paulo
-3112653;Capit„o Andrade;-190748;-418614;0;31;Minas Gerais;2651;33;America/Sao_Paulo
-2202406;Capit„o de Campos;-4457;-41944;0;22;PiauÌ;1047;86;America/Sao_Paulo
-3112703;Capit„o EnÈas;-163265;-437084;0;31;Minas Gerais;4253;38;America/Sao_Paulo
-2202455;Capit„o Gerv·sio Oliveira;-849655;-41814;0;22;PiauÌ;296;89;America/Sao_Paulo
-4104600;Capit„o LeÙnidas Marques;-254816;-536112;0;41;Paran·;7489;45;America/Sao_Paulo
-1502301;Capit„o PoÁo;-174785;-470629;0;15;Par·;445;91;America/Sao_Paulo
-3112802;CapitÛlio;-206164;-460493;0;31;Minas Gerais;4255;37;America/Sao_Paulo
-3510401;Capivari;-229951;-475071;0;35;S„o Paulo;6309;19;America/Sao_Paulo
+2102754;Capinzal do Norte;-47236;-44328;0;21;Maranh√£o;142;99;America/Sao_Paulo
+2302909;Capistrano;-445569;-389048;0;23;Cear√°;1357;85;America/Sao_Paulo
+4304697;Capit√£o;-292674;-519853;0;43;Rio Grande do Sul;6025;51;America/Sao_Paulo
+3112653;Capit√£o Andrade;-190748;-418614;0;31;Minas Gerais;2651;33;America/Sao_Paulo
+2202406;Capit√£o de Campos;-4457;-41944;0;22;Piau√≠;1047;86;America/Sao_Paulo
+3112703;Capit√£o En√©as;-163265;-437084;0;31;Minas Gerais;4253;38;America/Sao_Paulo
+2202455;Capit√£o Gerv√°sio Oliveira;-849655;-41814;0;22;Piau√≠;296;89;America/Sao_Paulo
+4104600;Capit√£o Le√¥nidas Marques;-254816;-536112;0;41;Paran√°;7489;45;America/Sao_Paulo
+1502301;Capit√£o Po√ßo;-174785;-470629;0;15;Par√°;445;91;America/Sao_Paulo
+3112802;Capit√≥lio;-206164;-460493;0;31;Minas Gerais;4255;37;America/Sao_Paulo
+3510401;Capivari;-229951;-475071;0;35;S√£o Paulo;6309;19;America/Sao_Paulo
 4203956;Capivari de Baixo;-284498;-489631;0;42;Santa Catarina;5545;48;America/Sao_Paulo
 4304671;Capivari do Sul;-301383;-505152;0;43;Rio Grande do Sul;962;51;America/Sao_Paulo
 1200179;Capixaba;-10566;-67686;0;12;Acre;647;68;America/Rio_Branco
 2603801;Capoeiras;-873423;-366306;0;26;Pernambuco;2375;87;America/Sao_Paulo
 3112901;Caputira;-201703;-422683;0;31;Minas Gerais;4257;31;America/Sao_Paulo
-4304713;Cara·;-297869;-504316;0;43;Rio Grande do Sul;964;51;America/Sao_Paulo
-1400209;CaracaraÌ;182766;-611304;0;14;Roraima;303;95;America/Porto_Velho
-2202505;Caracol;-927933;-43329;0;22;PiauÌ;1049;89;America/Sao_Paulo
+4304713;Cara√°;-297869;-504316;0;43;Rio Grande do Sul;964;51;America/Sao_Paulo
+1400209;Caracara√≠;182766;-611304;0;14;Roraima;303;95;America/Porto_Velho
+2202505;Caracol;-927933;-43329;0;22;Piau√≠;1049;89;America/Sao_Paulo
 5002803;Caracol;-22011;-570277;0;50;Mato Grosso do Sul;9053;67;America/Porto_Velho
-3510500;Caraguatatuba;-236125;-454125;0;35;S„o Paulo;6311;12;America/Sao_Paulo
-3113008;CaraÌ;-171862;-417004;0;31;Minas Gerais;4259;33;America/Sao_Paulo
-2906899;CaraÌbas;-147177;-412603;0;29;Bahia;3271;77;America/Sao_Paulo
-4104659;CarambeÌ;-249152;-500986;0;41;Paran·;844;42;America/Sao_Paulo
-3113107;CaranaÌba;-208707;-437417;0;31;Minas Gerais;4261;31;America/Sao_Paulo
-3113206;CarandaÌ;-209566;-43811;0;31;Minas Gerais;4263;32;America/Sao_Paulo
+3510500;Caraguatatuba;-236125;-454125;0;35;S√£o Paulo;6311;12;America/Sao_Paulo
+3113008;Cara√≠;-171862;-417004;0;31;Minas Gerais;4259;33;America/Sao_Paulo
+2906899;Cara√≠bas;-147177;-412603;0;29;Bahia;3271;77;America/Sao_Paulo
+4104659;Carambe√≠;-249152;-500986;0;41;Paran√°;844;42;America/Sao_Paulo
+3113107;Carana√≠ba;-208707;-437417;0;31;Minas Gerais;4261;31;America/Sao_Paulo
+3113206;Caranda√≠;-209566;-43811;0;31;Minas Gerais;4263;32;America/Sao_Paulo
 3113305;Carangola;-207343;-420313;0;31;Minas Gerais;4265;32;America/Sao_Paulo
 3300936;Carapebus;-221821;-41663;0;33;Rio de Janeiro;772;22;America/Sao_Paulo
-3510609;CarapicuÌba;-235235;-468407;0;35;S„o Paulo;6313;11;America/Sao_Paulo
+3510609;Carapicu√≠ba;-235235;-468407;0;35;S√£o Paulo;6313;11;America/Sao_Paulo
 3113404;Caratinga;-197868;-421292;0;31;Minas Gerais;4267;33;America/Sao_Paulo
 1301001;Carauari;-488161;-669086;0;13;Amazonas;221;97;America/Porto_Velho
-2402303;Cara˙bas;-578387;-375586;0;24;Rio Grande do Norte;1645;84;America/Sao_Paulo
-2504074;Cara˙bas;-772049;-36492;0;25;ParaÌba;466;83;America/Sao_Paulo
-2202539;Cara˙bas do PiauÌ;-347525;-418425;0;22;PiauÌ;298;86;America/Sao_Paulo
+2402303;Cara√∫bas;-578387;-375586;0;24;Rio Grande do Norte;1645;84;America/Sao_Paulo
+2504074;Cara√∫bas;-772049;-36492;0;25;Para√≠ba;466;83;America/Sao_Paulo
+2202539;Cara√∫bas do Piau√≠;-347525;-418425;0;22;Piau√≠;298;86;America/Sao_Paulo
 2906907;Caravelas;-177268;-392597;0;29;Bahia;3437;73;America/Sao_Paulo
 4304705;Carazinho;-282958;-527933;0;43;Rio Grande do Sul;8591;54;America/Sao_Paulo
 3113503;Carbonita;-175255;-430137;0;31;Minas Gerais;4269;38;America/Sao_Paulo
 2907004;Cardeal da Silva;-119472;-379469;0;29;Bahia;3439;75;America/Sao_Paulo
-3510708;Cardoso;-2008;-499183;0;35;S„o Paulo;6315;17;America/Sao_Paulo
+3510708;Cardoso;-2008;-499183;0;35;S√£o Paulo;6315;17;America/Sao_Paulo
 3301157;Cardoso Moreira;-214846;-416165;0;33;Rio de Janeiro;2915;22;America/Sao_Paulo
-3113602;CareaÁu;-220424;-45696;0;31;Minas Gerais;4271;35;America/Sao_Paulo
+3113602;Carea√ßu;-220424;-45696;0;31;Minas Gerais;4271;35;America/Sao_Paulo
 1301100;Careiro;-376803;-60369;0;13;Amazonas;223;92;America/Porto_Velho
-1301159;Careiro da V·rzea;-3314;-595557;0;13;Amazonas;965;92;America/Porto_Velho
-3201308;Cariacica;-202632;-404165;0;32;EspÌrito Santo;5625;27;America/Sao_Paulo
-2303006;Caridade;-422514;-391912;0;23;Cear·;1359;85;America/Sao_Paulo
-2202554;Caridade do PiauÌ;-773435;-409848;0;22;PiauÌ;300;89;America/Sao_Paulo
+1301159;Careiro da V√°rzea;-3314;-595557;0;13;Amazonas;965;92;America/Porto_Velho
+3201308;Cariacica;-202632;-404165;0;32;Esp√≠rito Santo;5625;27;America/Sao_Paulo
+2303006;Caridade;-422514;-391912;0;23;Cear√°;1359;85;America/Sao_Paulo
+2202554;Caridade do Piau√≠;-773435;-409848;0;22;Piau√≠;300;89;America/Sao_Paulo
 2907103;Carinhanha;-142985;-437724;0;29;Bahia;3441;77;America/Sao_Paulo
 2801405;Carira;-103524;-377002;0;28;Sergipe;3127;79;America/Sao_Paulo
-2303105;CarirÈ;-394858;-40476;0;23;Cear·;1361;88;America/Sao_Paulo
+2303105;Carir√©;-394858;-40476;0;23;Cear√°;1361;88;America/Sao_Paulo
 1703867;Cariri do Tocantins;-118881;-491609;0;17;Tocantins;327;63;America/Sao_Paulo
-2303204;CaririaÁu;-702808;-392828;0;23;Cear·;1363;88;America/Sao_Paulo
-2303303;Cari˙s;-652428;-394916;0;23;Cear·;1365;88;America/Sao_Paulo
+2303204;Cariria√ßu;-702808;-392828;0;23;Cear√°;1363;88;America/Sao_Paulo
+2303303;Cari√∫s;-652428;-394916;0;23;Cear√°;1365;88;America/Sao_Paulo
 5102793;Carlinda;-994912;-558417;0;51;Mato Grosso;1034;66;America/Porto_Velho
-4104709;CarlÛpolis;-234269;-497235;0;41;Paran·;7491;43;America/Sao_Paulo
+4104709;Carl√≥polis;-234269;-497235;0;41;Paran√°;7491;43;America/Sao_Paulo
 4304804;Carlos Barbosa;-292969;-515028;0;43;Rio Grande do Sul;8593;54;America/Sao_Paulo
 3113701;Carlos Chagas;-176973;-407723;0;31;Minas Gerais;4273;33;America/Sao_Paulo
 4304853;Carlos Gomes;-277167;-519121;0;43;Rio Grande do Sul;5961;54;America/Sao_Paulo
-3113800;CarmÈsia;-190877;-431382;0;31;Minas Gerais;4275;31;America/Sao_Paulo
+3113800;Carm√©sia;-190877;-431382;0;31;Minas Gerais;4275;31;America/Sao_Paulo
 3301207;Carmo;-21931;-426046;0;33;Rio de Janeiro;5823;22;America/Sao_Paulo
 3113909;Carmo da Cachoeira;-214633;-452201;0;31;Minas Gerais;4277;35;America/Sao_Paulo
 3114006;Carmo da Mata;-205575;-448735;0;31;Minas Gerais;4279;37;America/Sao_Paulo
 3114105;Carmo de Minas;-221204;-451307;0;31;Minas Gerais;4281;35;America/Sao_Paulo
 3114204;Carmo do Cajuru;-201912;-447664;0;31;Minas Gerais;4283;37;America/Sao_Paulo
-3114303;Carmo do ParanaÌba;-18991;-463167;0;31;Minas Gerais;4285;34;America/Sao_Paulo
+3114303;Carmo do Parana√≠ba;-18991;-463167;0;31;Minas Gerais;4285;34;America/Sao_Paulo
 3114402;Carmo do Rio Claro;-209736;-461149;0;31;Minas Gerais;4287;35;America/Sao_Paulo
-5205000;Carmo do Rio Verde;-153549;-49708;0;52;Goi·s;9299;62;America/Sao_Paulo
-1703883;Carmol‚ndia;-703262;-483978;0;17;Tocantins;175;63;America/Sao_Paulo
-2801504;CarmÛpolis;-106449;-369887;0;28;Sergipe;3129;79;America/Sao_Paulo
-3114501;CarmÛpolis de Minas;-205396;-446336;0;31;Minas Gerais;4289;37;America/Sao_Paulo
-2603900;CarnaÌba;-779342;-377946;0;26;Pernambuco;2377;87;America/Sao_Paulo
-2402402;Carna˙ba dos Dantas;-655015;-365868;0;24;Rio Grande do Norte;1647;84;America/Sao_Paulo
+5205000;Carmo do Rio Verde;-153549;-49708;0;52;Goi√°s;9299;62;America/Sao_Paulo
+1703883;Carmol√¢ndia;-703262;-483978;0;17;Tocantins;175;63;America/Sao_Paulo
+2801504;Carm√≥polis;-106449;-369887;0;28;Sergipe;3129;79;America/Sao_Paulo
+3114501;Carm√≥polis de Minas;-205396;-446336;0;31;Minas Gerais;4289;37;America/Sao_Paulo
+2603900;Carna√≠ba;-779342;-377946;0;26;Pernambuco;2377;87;America/Sao_Paulo
+2402402;Carna√∫ba dos Dantas;-655015;-365868;0;24;Rio Grande do Norte;1647;84;America/Sao_Paulo
 2402501;Carnaubais;-534181;-368335;0;24;Rio Grande do Norte;1649;84;America/Sao_Paulo
-2303402;Carnaubal;-415985;-409413;0;23;Cear·;1367;88;America/Sao_Paulo
+2303402;Carnaubal;-415985;-409413;0;23;Cear√°;1367;88;America/Sao_Paulo
 2603926;Carnaubeira da Penha;-831799;-387512;0;26;Pernambuco;2635;87;America/Sao_Paulo
 3114550;Carneirinho;-196987;-506894;0;31;Minas Gerais;2685;34;America/Sao_Paulo
 2701803;Carneiros;-948476;-373773;0;27;Alagoas;2735;82;America/Sao_Paulo
 1400233;Caroebe;884203;-596959;0;14;Roraima;30;95;America/Porto_Velho
-2102804;Carolina;-733584;-474634;0;21;Maranh„o;753;99;America/Sao_Paulo
+2102804;Carolina;-733584;-474634;0;21;Maranh√£o;753;99;America/Sao_Paulo
 2604007;Carpina;-784566;-352514;0;26;Pernambuco;2379;81;America/Sao_Paulo
 3114600;Carrancas;-214898;-446446;0;31;Minas Gerais;4291;35;America/Sao_Paulo
-2504108;Carrapateira;-703414;-383399;0;25;ParaÌba;1983;83;America/Sao_Paulo
+2504108;Carrapateira;-703414;-383399;0;25;Para√≠ba;1983;83;America/Sao_Paulo
 1703891;Carrasco Bonito;-531415;-480314;0;17;Tocantins;177;63;America/Sao_Paulo
 2604106;Caruaru;-828455;-359699;0;26;Pernambuco;2381;81;America/Sao_Paulo
-2102903;Carutapera;-119696;-460085;0;21;Maranh„o;755;98;America/Sao_Paulo
-3114709;CarvalhÛpolis;-217735;-458421;0;31;Minas Gerais;4293;35;America/Sao_Paulo
+2102903;Carutapera;-119696;-460085;0;21;Maranh√£o;755;98;America/Sao_Paulo
+3114709;Carvalh√≥polis;-217735;-458421;0;31;Minas Gerais;4293;35;America/Sao_Paulo
 3114808;Carvalhos;-22;-444632;0;31;Minas Gerais;4295;35;America/Sao_Paulo
-3510807;Casa Branca;-217708;-470852;0;35;S„o Paulo;6317;19;America/Sao_Paulo
+3510807;Casa Branca;-217708;-470852;0;35;S√£o Paulo;6317;19;America/Sao_Paulo
 3114907;Casa Grande;-207925;-439343;0;31;Minas Gerais;4297;31;America/Sao_Paulo
 2907202;Casa Nova;-916408;-40974;0;29;Bahia;3443;74;America/Sao_Paulo
 4304903;Casca;-285605;-519815;0;43;Rio Grande do Sul;8595;54;America/Sao_Paulo
 3115003;Cascalho Rico;-185772;-478716;0;31;Minas Gerais;4299;34;America/Sao_Paulo
-4104808;Cascavel;-249573;-53459;0;41;Paran·;7493;45;America/Sao_Paulo
-2303501;Cascavel;-412967;-382412;0;23;Cear·;1369;85;America/Sao_Paulo
+4104808;Cascavel;-249573;-53459;0;41;Paran√°;7493;45;America/Sao_Paulo
+2303501;Cascavel;-412967;-382412;0;23;Cear√°;1369;85;America/Sao_Paulo
 1703909;Caseara;-927612;-499521;0;17;Tocantins;9717;63;America/Sao_Paulo
 4304952;Caseiros;-282582;-516861;0;43;Rio Grande do Sul;8441;54;America/Sao_Paulo
 3301306;Casimiro de Abreu;-224812;-422066;0;33;Rio de Janeiro;5825;22;America/Sao_Paulo
 2604155;Casinhas;-774084;-357206;0;26;Pernambuco;546;81;America/Sao_Paulo
-2504157;Casserengue;-677954;-358179;0;25;ParaÌba;468;83;America/Sao_Paulo
-3115102;C·ssia;-205831;-469201;0;31;Minas Gerais;4301;35;America/Sao_Paulo
-3510906;C·ssia dos Coqueiros;-212801;-471643;0;35;S„o Paulo;6319;16;America/Sao_Paulo
-5002902;Cassil‚ndia;-191179;-517313;0;50;Mato Grosso do Sul;9057;67;America/Porto_Velho
-1502400;Castanhal;-129797;-479167;0;15;Par·;447;91;America/Sao_Paulo
+2504157;Casserengue;-677954;-358179;0;25;Para√≠ba;468;83;America/Sao_Paulo
+3115102;C√°ssia;-205831;-469201;0;31;Minas Gerais;4301;35;America/Sao_Paulo
+3510906;C√°ssia dos Coqueiros;-212801;-471643;0;35;S√£o Paulo;6319;16;America/Sao_Paulo
+5002902;Cassil√¢ndia;-191179;-517313;0;50;Mato Grosso do Sul;9057;67;America/Porto_Velho
+1502400;Castanhal;-129797;-479167;0;15;Par√°;447;91;America/Sao_Paulo
 5102850;Castanheira;-111251;-586081;0;51;Mato Grosso;9783;66;America/Porto_Velho
-1100908;Castanheiras;-114253;-619482;0;11;RondÙnia;691;69;America/Porto_Velho
-5205059;Castel‚ndia;-180921;-50203;0;52;Goi·s;81;64;America/Sao_Paulo
-3201407;Castelo;-206033;-412031;0;32;EspÌrito Santo;5627;28;America/Sao_Paulo
-2202604;Castelo do PiauÌ;-531869;-415499;0;22;PiauÌ;1051;86;America/Sao_Paulo
-3511003;Castilho;-208689;-514884;0;35;S„o Paulo;6321;18;America/Sao_Paulo
-4104907;Castro;-247891;-500108;0;41;Paran·;7495;42;America/Sao_Paulo
+1100908;Castanheiras;-114253;-619482;0;11;Rond√¥nia;691;69;America/Porto_Velho
+5205059;Castel√¢ndia;-180921;-50203;0;52;Goi√°s;81;64;America/Sao_Paulo
+3201407;Castelo;-206033;-412031;0;32;Esp√≠rito Santo;5627;28;America/Sao_Paulo
+2202604;Castelo do Piau√≠;-531869;-415499;0;22;Piau√≠;1051;86;America/Sao_Paulo
+3511003;Castilho;-208689;-514884;0;35;S√£o Paulo;6321;18;America/Sao_Paulo
+4104907;Castro;-247891;-500108;0;41;Paran√°;7495;42;America/Sao_Paulo
 2907301;Castro Alves;-127579;-394248;0;29;Bahia;3445;75;America/Sao_Paulo
 3115300;Cataguases;-213924;-426896;0;31;Minas Gerais;4305;32;America/Sao_Paulo
-5205109;Catal„o;-181656;-47944;0;52;Goi·s;9301;64;America/Sao_Paulo
-3511102;Catanduva;-211314;-48977;0;35;S„o Paulo;6323;17;America/Sao_Paulo
-4105003;Catanduvas;-252044;-531548;0;41;Paran·;7497;45;America/Sao_Paulo
+5205109;Catal√£o;-181656;-47944;0;52;Goi√°s;9301;64;America/Sao_Paulo
+3511102;Catanduva;-211314;-48977;0;35;S√£o Paulo;6323;17;America/Sao_Paulo
+4105003;Catanduvas;-252044;-531548;0;41;Paran√°;7497;45;America/Sao_Paulo
 4204004;Catanduvas;-27069;-516602;0;42;Santa Catarina;8077;49;America/Sao_Paulo
-2303600;Catarina;-612291;-398736;0;23;Cear·;1371;88;America/Sao_Paulo
+2303600;Catarina;-612291;-398736;0;23;Cear√°;1371;88;America/Sao_Paulo
 3115359;Catas Altas;-200734;-434061;0;31;Minas Gerais;584;31;America/Sao_Paulo
 3115409;Catas Altas da Noruega;-206901;-434939;0;31;Minas Gerais;4307;31;America/Sao_Paulo
 2604205;Catende;-867509;-357024;0;26;Pernambuco;2383;81;America/Sao_Paulo
-3511201;Catigu·;-210519;-490616;0;35;S„o Paulo;6325;17;America/Sao_Paulo
-2504207;Catingueira;-712008;-376064;0;25;ParaÌba;1985;83;America/Sao_Paulo
-2907400;Catol‚ndia;-1231;-448648;0;29;Bahia;3447;77;America/Sao_Paulo
-2504306;CatolÈ do Rocha;-634062;-37747;0;25;ParaÌba;1987;83;America/Sao_Paulo
+3511201;Catigu√°;-210519;-490616;0;35;S√£o Paulo;6325;17;America/Sao_Paulo
+2504207;Catingueira;-712008;-376064;0;25;Para√≠ba;1985;83;America/Sao_Paulo
+2907400;Catol√¢ndia;-1231;-448648;0;29;Bahia;3447;77;America/Sao_Paulo
+2504306;Catol√© do Rocha;-634062;-37747;0;25;Para√≠ba;1987;83;America/Sao_Paulo
 2907509;Catu;-123513;-383791;0;29;Bahia;3449;71;America/Sao_Paulo
-4305009;CatuÌpe;-282554;-540132;0;43;Rio Grande do Sul;8597;55;America/Sao_Paulo
+4305009;Catu√≠pe;-282554;-540132;0;43;Rio Grande do Sul;8597;55;America/Sao_Paulo
 3115458;Catuji;-173018;-415276;0;31;Minas Gerais;2653;33;America/Sao_Paulo
-2303659;Catunda;-464336;-402;0;23;Cear·;983;88;America/Sao_Paulo
-5205208;CaturaÌ;-164447;-494936;0;52;Goi·s;9303;62;America/Sao_Paulo
+2303659;Catunda;-464336;-402;0;23;Cear√°;983;88;America/Sao_Paulo
+5205208;Catura√≠;-164447;-494936;0;52;Goi√°s;9303;62;America/Sao_Paulo
 2907558;Caturama;-133239;-422904;0;29;Bahia;3273;77;America/Sao_Paulo
-2504355;CaturitÈ;-741659;-360306;0;25;ParaÌba;470;83;America/Sao_Paulo
+2504355;Caturit√©;-741659;-360306;0;25;Para√≠ba;470;83;America/Sao_Paulo
 3115474;Catuti;-153616;-429627;0;31;Minas Gerais;586;38;America/Sao_Paulo
-2303709;Caucaia;-372797;-386619;0;23;Cear·;1373;85;America/Sao_Paulo
-5205307;Cavalcante;-137976;-474566;0;52;Goi·s;9305;62;America/Sao_Paulo
+2303709;Caucaia;-372797;-386619;0;23;Cear√°;1373;85;America/Sao_Paulo
+5205307;Cavalcante;-137976;-474566;0;52;Goi√°s;9305;62;America/Sao_Paulo
 3115508;Caxambu;-219753;-449319;0;31;Minas Gerais;4309;35;America/Sao_Paulo
 4204103;Caxambu do Sul;-271624;-528807;0;42;Santa Catarina;8079;49;America/Sao_Paulo
-2103000;Caxias;-486505;-433617;0;21;Maranh„o;757;99;America/Sao_Paulo
+2103000;Caxias;-486505;-433617;0;21;Maranh√£o;757;99;America/Sao_Paulo
 4305108;Caxias do Sul;-291629;-511792;0;43;Rio Grande do Sul;8599;54;America/Sao_Paulo
-2202653;CaxingÛ;-341904;-418955;0;22;PiauÌ;302;86;America/Sao_Paulo
-2402600;Cear·-Mirim;-564323;-354247;0;24;Rio Grande do Norte;1651;84;America/Sao_Paulo
-2103109;Cedral;-200027;-445281;0;21;Maranh„o;759;98;America/Sao_Paulo
-3511300;Cedral;-209009;-492664;0;35;S„o Paulo;6327;17;America/Sao_Paulo
-2303808;Cedro;-660034;-390609;0;23;Cear·;1375;88;America/Sao_Paulo
+2202653;Caxing√≥;-341904;-418955;0;22;Piau√≠;302;86;America/Sao_Paulo
+2402600;Cear√°-Mirim;-564323;-354247;0;24;Rio Grande do Norte;1651;84;America/Sao_Paulo
+2103109;Cedral;-200027;-445281;0;21;Maranh√£o;759;98;America/Sao_Paulo
+3511300;Cedral;-209009;-492664;0;35;S√£o Paulo;6327;17;America/Sao_Paulo
+2303808;Cedro;-660034;-390609;0;23;Cear√°;1375;88;America/Sao_Paulo
 2604304;Cedro;-771179;-392367;0;26;Pernambuco;2385;87;America/Sao_Paulo
-2801603;Cedro de S„o Jo„o;-102534;-368856;0;28;Sergipe;3131;79;America/Sao_Paulo
-3115607;Cedro do AbaetÈ;-191458;-45712;0;31;Minas Gerais;4311;37;America/Sao_Paulo
+2801603;Cedro de S√£o Jo√£o;-102534;-368856;0;28;Sergipe;3131;79;America/Sao_Paulo
+3115607;Cedro do Abaet√©;-191458;-45712;0;31;Minas Gerais;4311;37;America/Sao_Paulo
 4204152;Celso Ramos;-276327;-51335;0;42;Santa Catarina;9943;49;America/Sao_Paulo
-4305116;Centen·rio;-277615;-519984;0;43;Rio Grande do Sul;5963;54;America/Sao_Paulo
-1704105;Centen·rio;-896103;-473304;0;17;Tocantins;343;63;America/Sao_Paulo
-4105102;Centen·rio do Sul;-228188;-515973;0;41;Paran·;7499;43;America/Sao_Paulo
+4305116;Centen√°rio;-277615;-519984;0;43;Rio Grande do Sul;5963;54;America/Sao_Paulo
+1704105;Centen√°rio;-896103;-473304;0;17;Tocantins;343;63;America/Sao_Paulo
+4105102;Centen√°rio do Sul;-228188;-515973;0;41;Paran√°;7499;43;America/Sao_Paulo
 2907608;Central;-111376;-421116;0;29;Bahia;3451;74;America/Sao_Paulo
 3115706;Central de Minas;-187612;-413143;0;31;Minas Gerais;4313;33;America/Sao_Paulo
-2103125;Central do Maranh„o;-219831;-448254;0;21;Maranh„o;144;98;America/Sao_Paulo
+2103125;Central do Maranh√£o;-219831;-448254;0;21;Maranh√£o;144;98;America/Sao_Paulo
 3115805;Centralina;-185852;-492014;0;31;Minas Gerais;4315;34;America/Sao_Paulo
-2103158;Centro do Guilherme;-244891;-460345;0;21;Maranh„o;146;98;America/Sao_Paulo
-2103174;Centro Novo do Maranh„o;-212696;-461228;0;21;Maranh„o;148;98;America/Sao_Paulo
-1100056;Cerejeiras;-13187;-608168;0;11;RondÙnia;27;69;America/Porto_Velho
-5205406;Ceres;-153061;-496;0;52;Goi·s;9307;62;America/Sao_Paulo
-3511409;Cerqueira CÈsar;-23038;-491655;0;35;S„o Paulo;6329;14;America/Sao_Paulo
-3511508;Cerquilho;-231665;-477459;0;35;S„o Paulo;6331;15;America/Sao_Paulo
+2103158;Centro do Guilherme;-244891;-460345;0;21;Maranh√£o;146;98;America/Sao_Paulo
+2103174;Centro Novo do Maranh√£o;-212696;-461228;0;21;Maranh√£o;148;98;America/Sao_Paulo
+1100056;Cerejeiras;-13187;-608168;0;11;Rond√¥nia;27;69;America/Porto_Velho
+5205406;Ceres;-153061;-496;0;52;Goi√°s;9307;62;America/Sao_Paulo
+3511409;Cerqueira C√©sar;-23038;-491655;0;35;S√£o Paulo;6329;14;America/Sao_Paulo
+3511508;Cerquilho;-231665;-477459;0;35;S√£o Paulo;6331;15;America/Sao_Paulo
 4305124;Cerrito;-318419;-528004;0;43;Rio Grande do Sul;966;53;America/Sao_Paulo
-4105201;Cerro Azul;-260891;-528691;0;41;Paran·;7501;41;America/Sao_Paulo
+4105201;Cerro Azul;-260891;-528691;0;41;Paran√°;7501;41;America/Sao_Paulo
 4305132;Cerro Branco;-29657;-529406;0;43;Rio Grande do Sul;8439;51;America/Sao_Paulo
-2402709;Cerro Cor·;-603503;-363503;0;24;Rio Grande do Norte;1653;84;America/Sao_Paulo
+2402709;Cerro Cor√°;-603503;-363503;0;24;Rio Grande do Norte;1653;84;America/Sao_Paulo
 4305157;Cerro Grande;-276106;-531672;0;43;Rio Grande do Sul;8437;55;America/Sao_Paulo
 4305173;Cerro Grande do Sul;-305905;-517418;0;43;Rio Grande do Sul;8435;51;America/Sao_Paulo
 4305207;Cerro Largo;-281463;-547428;0;43;Rio Grande do Sul;8601;55;America/Sao_Paulo
 4204178;Cerro Negro;-277942;-508673;0;42;Santa Catarina;5567;49;America/Sao_Paulo
-3511607;Ces·rio Lange;-23226;-479545;0;35;S„o Paulo;6333;15;America/Sao_Paulo
-4105300;CÈu Azul;-251489;-538415;0;41;Paran·;7957;45;America/Sao_Paulo
-5205455;Cezarina;-169718;-497758;0;52;Goi·s;9785;64;America/Sao_Paulo
-2604403;Ch„ de Alegria;-800679;-35204;0;26;Pernambuco;2387;81;America/Sao_Paulo
-2604502;Ch„ Grande;-823827;-354571;0;26;Pernambuco;2389;81;America/Sao_Paulo
-2701902;Ch„ Preta;-92556;-362983;0;27;Alagoas;2737;82;America/Sao_Paulo
-3115904;Ch·cara;-216733;-43215;0;31;Minas Gerais;4317;32;America/Sao_Paulo
-3116001;ChalÈ;-200453;-416897;0;31;Minas Gerais;4319;33;America/Sao_Paulo
+3511607;Ces√°rio Lange;-23226;-479545;0;35;S√£o Paulo;6333;15;America/Sao_Paulo
+4105300;C√©u Azul;-251489;-538415;0;41;Paran√°;7957;45;America/Sao_Paulo
+5205455;Cezarina;-169718;-497758;0;52;Goi√°s;9785;64;America/Sao_Paulo
+2604403;Ch√£ de Alegria;-800679;-35204;0;26;Pernambuco;2387;81;America/Sao_Paulo
+2604502;Ch√£ Grande;-823827;-354571;0;26;Pernambuco;2389;81;America/Sao_Paulo
+2701902;Ch√£ Preta;-92556;-362983;0;27;Alagoas;2737;82;America/Sao_Paulo
+3115904;Ch√°cara;-216733;-43215;0;31;Minas Gerais;4317;32;America/Sao_Paulo
+3116001;Chal√©;-200453;-416897;0;31;Minas Gerais;4319;33;America/Sao_Paulo
 4305306;Chapada;-280559;-530665;0;43;Rio Grande do Sul;8603;54;America/Sao_Paulo
 1705102;Chapada da Natividade;-116175;-477486;0;17;Tocantins;80;63;America/Sao_Paulo
 1704600;Chapada de Areia;-101419;-491403;0;17;Tocantins;78;63;America/Sao_Paulo
 3116100;Chapada do Norte;-170881;-425392;0;31;Minas Gerais;4321;33;America/Sao_Paulo
-5103007;Chapada dos Guimar„es;-154643;-557499;0;51;Mato Grosso;9059;65;America/Porto_Velho
-3116159;Chapada Ga˙cha;-153014;-456116;0;31;Minas Gerais;588;38;America/Sao_Paulo
-5205471;Chapad„o do CÈu;-184073;-52549;0;52;Goi·s;73;64;America/Sao_Paulo
-4204194;Chapad„o do Lageado;-275905;-495539;0;42;Santa Catarina;908;47;America/Sao_Paulo
-5002951;Chapad„o do Sul;-18788;-526263;0;50;Mato Grosso do Sul;9787;67;America/Porto_Velho
-2103208;Chapadinha;-373875;-433538;0;21;Maranh„o;761;98;America/Sao_Paulo
-4204202;ChapecÛ;-271004;-526152;0;42;Santa Catarina;8081;49;America/Sao_Paulo
-3511706;Charqueada;-225096;-477755;0;35;S„o Paulo;6335;19;America/Sao_Paulo
+5103007;Chapada dos Guimar√£es;-154643;-557499;0;51;Mato Grosso;9059;65;America/Porto_Velho
+3116159;Chapada Ga√∫cha;-153014;-456116;0;31;Minas Gerais;588;38;America/Sao_Paulo
+5205471;Chapad√£o do C√©u;-184073;-52549;0;52;Goi√°s;73;64;America/Sao_Paulo
+4204194;Chapad√£o do Lageado;-275905;-495539;0;42;Santa Catarina;908;47;America/Sao_Paulo
+5002951;Chapad√£o do Sul;-18788;-526263;0;50;Mato Grosso do Sul;9787;67;America/Porto_Velho
+2103208;Chapadinha;-373875;-433538;0;21;Maranh√£o;761;98;America/Sao_Paulo
+4204202;Chapec√≥;-271004;-526152;0;42;Santa Catarina;8081;49;America/Sao_Paulo
+3511706;Charqueada;-225096;-477755;0;35;S√£o Paulo;6335;19;America/Sao_Paulo
 4305355;Charqueadas;-299625;-516289;0;43;Rio Grande do Sul;8693;51;America/Sao_Paulo
 4305371;Charrua;-279493;-52015;0;43;Rio Grande do Sul;5965;54;America/Sao_Paulo
-2303907;Chaval;-303571;-412435;0;23;Cear·;1377;88;America/Sao_Paulo
-3557204;Chavantes;-230366;-497096;0;35;S„o Paulo;6337;14;America/Sao_Paulo
-1502509;Chaves;-164154;-49987;0;15;Par·;449;91;America/Sao_Paulo
+2303907;Chaval;-303571;-412435;0;23;Cear√°;1377;88;America/Sao_Paulo
+3557204;Chavantes;-230366;-497096;0;35;S√£o Paulo;6337;14;America/Sao_Paulo
+1502509;Chaves;-164154;-49987;0;15;Par√°;449;91;America/Sao_Paulo
 3116209;Chiador;-219996;-430617;0;31;Minas Gerais;4323;32;America/Sao_Paulo
 4305405;Chiapetta;-27923;-539419;0;43;Rio Grande do Sul;8605;55;America/Sao_Paulo
-4105409;Chopinzinho;-258515;-525173;0;41;Paran·;7503;46;America/Sao_Paulo
-2303931;ChorÛ;-483906;-391344;0;23;Cear·;993;88;America/Sao_Paulo
-2303956;Chorozinho;-428873;-384986;0;23;Cear·;1239;85;America/Sao_Paulo
-2907707;ChorrochÛ;-89695;-390979;0;29;Bahia;3453;75;America/Sao_Paulo
-4305439;ChuÌ;-336866;-534594;0;43;Rio Grande do Sul;968;53;America/Sao_Paulo
-1100924;Chupinguaia;-125611;-608877;0;11;RondÙnia;6;69;America/Porto_Velho
+4105409;Chopinzinho;-258515;-525173;0;41;Paran√°;7503;46;America/Sao_Paulo
+2303931;Chor√≥;-483906;-391344;0;23;Cear√°;993;88;America/Sao_Paulo
+2303956;Chorozinho;-428873;-384986;0;23;Cear√°;1239;85;America/Sao_Paulo
+2907707;Chorroch√≥;-89695;-390979;0;29;Bahia;3453;75;America/Sao_Paulo
+4305439;Chu√≠;-336866;-534594;0;43;Rio Grande do Sul;968;53;America/Sao_Paulo
+1100924;Chupinguaia;-125611;-608877;0;11;Rond√¥nia;6;69;America/Porto_Velho
 4305447;Chuvisca;-307504;-519737;0;43;Rio Grande do Sul;970;51;America/Sao_Paulo
-4105508;Cianorte;-236599;-526054;0;41;Paran·;7505;44;America/Sao_Paulo
-2907806;CÌcero Dantas;-105897;-383794;0;29;Bahia;3455;75;America/Sao_Paulo
-4105607;Cidade Ga˙cha;-233772;-529436;0;41;Paran·;7507;44;America/Sao_Paulo
-5205497;Cidade Ocidental;-160765;-479252;0;52;Goi·s;77;61;America/Sao_Paulo
-2103257;Cidel‚ndia;-517465;-477781;0;21;Maranh„o;150;99;America/Sao_Paulo
+4105508;Cianorte;-236599;-526054;0;41;Paran√°;7505;44;America/Sao_Paulo
+2907806;C√≠cero Dantas;-105897;-383794;0;29;Bahia;3455;75;America/Sao_Paulo
+4105607;Cidade Ga√∫cha;-233772;-529436;0;41;Paran√°;7507;44;America/Sao_Paulo
+5205497;Cidade Ocidental;-160765;-479252;0;52;Goi√°s;77;61;America/Sao_Paulo
+2103257;Cidel√¢ndia;-517465;-477781;0;21;Maranh√£o;150;99;America/Sao_Paulo
 4305454;Cidreira;-301604;-502337;0;43;Rio Grande do Sul;8433;51;America/Sao_Paulo
-2907905;CipÛ;-111032;-385179;0;29;Bahia;3457;75;America/Sao_Paulo
-3116308;Cipot‚nea;-209026;-433629;0;31;Minas Gerais;4325;32;America/Sao_Paulo
-4305504;CirÌaco;-283419;-518741;0;43;Rio Grande do Sul;8607;54;America/Sao_Paulo
+2907905;Cip√≥;-111032;-385179;0;29;Bahia;3457;75;America/Sao_Paulo
+3116308;Cipot√¢nea;-209026;-433629;0;31;Minas Gerais;4325;32;America/Sao_Paulo
+4305504;Cir√≠aco;-283419;-518741;0;43;Rio Grande do Sul;8607;54;America/Sao_Paulo
 3116407;Claraval;-20397;-472768;0;31;Minas Gerais;4327;34;America/Sao_Paulo
-3116506;Claro dos PoÁıes;-17082;-442061;0;31;Minas Gerais;4329;38;America/Sao_Paulo
-5103056;Cl·udia;-115075;-548835;0;51;Mato Grosso;9789;66;America/Porto_Velho
-3116605;Cl·udio;-204437;-447673;0;31;Minas Gerais;4331;37;America/Sao_Paulo
-3511904;Clementina;-215604;-504525;0;35;S„o Paulo;6339;18;America/Sao_Paulo
-4105706;Clevel‚ndia;-264043;-523508;0;41;Paran·;7509;46;America/Sao_Paulo
+3116506;Claro dos Po√ß√µes;-17082;-442061;0;31;Minas Gerais;4329;38;America/Sao_Paulo
+5103056;Cl√°udia;-115075;-548835;0;51;Mato Grosso;9789;66;America/Porto_Velho
+3116605;Cl√°udio;-204437;-447673;0;31;Minas Gerais;4331;37;America/Sao_Paulo
+3511904;Clementina;-215604;-504525;0;35;S√£o Paulo;6339;18;America/Sao_Paulo
+4105706;Clevel√¢ndia;-264043;-523508;0;41;Paran√°;7509;46;America/Sao_Paulo
 2908002;Coaraci;-14637;-395556;0;29;Bahia;3459;73;America/Sao_Paulo
 1301209;Coari;-409412;-631441;0;13;Amazonas;225;97;America/Porto_Velho
-2202703;Cocal;-347279;-415546;0;22;PiauÌ;1053;86;America/Sao_Paulo
-2202711;Cocal de Telha;-45571;-419587;0;22;PiauÌ;304;86;America/Sao_Paulo
+2202703;Cocal;-347279;-415546;0;22;Piau√≠;1053;86;America/Sao_Paulo
+2202711;Cocal de Telha;-45571;-419587;0;22;Piau√≠;304;86;America/Sao_Paulo
 4204251;Cocal do Sul;-285986;-493335;0;42;Santa Catarina;5543;48;America/Sao_Paulo
-2202729;Cocal dos Alves;-362047;-414402;0;22;PiauÌ;306;86;America/Sao_Paulo
+2202729;Cocal dos Alves;-362047;-414402;0;22;Piau√≠;306;86;America/Sao_Paulo
 5103106;Cocalinho;-143903;-510001;0;51;Mato Grosso;9865;66;America/Porto_Velho
-5205513;Cocalzinho de Goi·s;-157914;-487747;0;52;Goi·s;55;62;America/Sao_Paulo
+5205513;Cocalzinho de Goi√°s;-157914;-487747;0;52;Goi√°s;55;62;America/Sao_Paulo
 2908101;Cocos;-141814;-445352;0;29;Bahia;3461;77;America/Sao_Paulo
-1301308;Codaj·s;-383053;-620658;0;13;Amazonas;227;97;America/Porto_Velho
-2103307;CodÛ;-445562;-438924;0;21;Maranh„o;763;99;America/Sao_Paulo
-2103406;Coelho Neto;-425245;-430108;0;21;Maranh„o;765;98;America/Sao_Paulo
+1301308;Codaj√°s;-383053;-620658;0;13;Amazonas;227;97;America/Porto_Velho
+2103307;Cod√≥;-445562;-438924;0;21;Maranh√£o;763;99;America/Sao_Paulo
+2103406;Coelho Neto;-425245;-430108;0;21;Maranh√£o;765;98;America/Sao_Paulo
 3116704;Coimbra;-208535;-428008;0;31;Minas Gerais;4333;32;America/Sao_Paulo
-2702009;CoitÈ do NÛia;-963348;-365845;0;27;Alagoas;2739;82;America/Sao_Paulo
-2202737;Coivaras;-509224;-42208;0;22;PiauÌ;995;86;America/Sao_Paulo
-1502608;Colares;-936423;-482803;0;15;Par·;451;91;America/Sao_Paulo
-3201506;Colatina;-195493;-406269;0;32;EspÌrito Santo;5629;27;America/Sao_Paulo
-5103205;ColÌder;-108135;-55461;0;51;Mato Grosso;8979;66;America/Porto_Velho
-3512001;Colina;-207114;-485387;0;35;S„o Paulo;6341;17;America/Sao_Paulo
+2702009;Coit√© do N√≥ia;-963348;-365845;0;27;Alagoas;2739;82;America/Sao_Paulo
+2202737;Coivaras;-509224;-42208;0;22;Piau√≠;995;86;America/Sao_Paulo
+1502608;Colares;-936423;-482803;0;15;Par√°;451;91;America/Sao_Paulo
+3201506;Colatina;-195493;-406269;0;32;Esp√≠rito Santo;5629;27;America/Sao_Paulo
+5103205;Col√≠der;-108135;-55461;0;51;Mato Grosso;8979;66;America/Porto_Velho
+3512001;Colina;-207114;-485387;0;35;S√£o Paulo;6341;17;America/Sao_Paulo
 4305587;Colinas;-293948;-518556;0;43;Rio Grande do Sul;6029;51;America/Sao_Paulo
-2103505;Colinas;-603199;-442543;0;21;Maranh„o;767;99;America/Sao_Paulo
-5205521;Colinas do Sul;-141528;-48076;0;52;Goi·s;9791;62;America/Sao_Paulo
+2103505;Colinas;-603199;-442543;0;21;Maranh√£o;767;99;America/Sao_Paulo
+5205521;Colinas do Sul;-141528;-48076;0;52;Goi√°s;9791;62;America/Sao_Paulo
 1705508;Colinas do Tocantins;-805764;-484757;0;17;Tocantins;9311;63;America/Sao_Paulo
-1716703;ColmÈia;-872463;-487638;0;17;Tocantins;9529;63;America/Sao_Paulo
+1716703;Colm√©ia;-872463;-487638;0;17;Tocantins;9529;63;America/Sao_Paulo
 5103254;Colniza;-946121;-592252;0;51;Mato Grosso;1080;66;America/Porto_Velho
-3512100;ColÙmbia;-201768;-486865;0;35;S„o Paulo;6343;17;America/Sao_Paulo
-4105805;Colombo;-252925;-492262;0;41;Paran·;7513;41;America/Sao_Paulo
-2202752;ColÙnia do GurguÈia;-81837;-43794;0;22;PiauÌ;2249;89;America/Sao_Paulo
-2202778;ColÙnia do PiauÌ;-722651;-421756;0;22;PiauÌ;2253;89;America/Sao_Paulo
-2702108;ColÙnia Leopoldina;-891806;-357214;0;27;Alagoas;2741;82;America/Sao_Paulo
+3512100;Col√¥mbia;-201768;-486865;0;35;S√£o Paulo;6343;17;America/Sao_Paulo
+4105805;Colombo;-252925;-492262;0;41;Paran√°;7513;41;America/Sao_Paulo
+2202752;Col√¥nia do Gurgu√©ia;-81837;-43794;0;22;Piau√≠;2249;89;America/Sao_Paulo
+2202778;Col√¥nia do Piau√≠;-722651;-421756;0;22;Piau√≠;2253;89;America/Sao_Paulo
+2702108;Col√¥nia Leopoldina;-891806;-357214;0;27;Alagoas;2741;82;America/Sao_Paulo
 4305603;Colorado;-285258;-529928;0;43;Rio Grande do Sul;8609;54;America/Sao_Paulo
-4105904;Colorado;-228374;-519743;0;41;Paran·;7515;44;America/Sao_Paulo
-1100064;Colorado do Oeste;-131174;-605454;0;11;RondÙnia;23;69;America/Porto_Velho
+4105904;Colorado;-228374;-519743;0;41;Paran√°;7515;44;America/Sao_Paulo
+1100064;Colorado do Oeste;-131174;-605454;0;11;Rond√¥nia;23;69;America/Porto_Velho
 3116803;Coluna;-182311;-428352;0;31;Minas Gerais;4335;33;America/Sao_Paulo
 1705557;Combinado;-127917;-465388;0;17;Tocantins;9697;63;America/Sao_Paulo
 3116902;Comendador Gomes;-196973;-490789;0;31;Minas Gerais;4337;34;America/Sao_Paulo
 3300951;Comendador Levy Gasparian;-220404;-43214;0;33;Rio de Janeiro;2927;24;America/Sao_Paulo
 3117009;Comercinho;-162963;-417945;0;31;Minas Gerais;4339;33;America/Sao_Paulo
 5103304;Comodoro;-136614;-597848;0;51;Mato Grosso;9883;65;America/Porto_Velho
-2504405;ConceiÁ„o;-755106;-385014;0;25;ParaÌba;1989;83;America/Sao_Paulo
-3117108;ConceiÁ„o da Aparecida;-21096;-462049;0;31;Minas Gerais;4341;35;America/Sao_Paulo
-3201605;ConceiÁ„o da Barra;-185883;-397362;0;32;EspÌrito Santo;5631;27;America/Sao_Paulo
-3115201;ConceiÁ„o da Barra de Minas;-211316;-444729;0;31;Minas Gerais;4303;32;America/Sao_Paulo
-2908200;ConceiÁ„o da Feira;-125078;-389978;0;29;Bahia;3463;75;America/Sao_Paulo
-3117306;ConceiÁ„o das Alagoas;-199172;-483839;0;31;Minas Gerais;4345;34;America/Sao_Paulo
-3117207;ConceiÁ„o das Pedras;-221576;-454562;0;31;Minas Gerais;4343;35;America/Sao_Paulo
-3117405;ConceiÁ„o de Ipanema;-199326;-416908;0;31;Minas Gerais;4347;33;America/Sao_Paulo
-3301405;ConceiÁ„o de Macabu;-220834;-418719;0;33;Rio de Janeiro;5827;22;America/Sao_Paulo
-2908309;ConceiÁ„o do Almeida;-127836;-391715;0;29;Bahia;3465;75;America/Sao_Paulo
-1502707;ConceiÁ„o do Araguaia;-826136;-492689;0;15;Par·;453;94;America/Sao_Paulo
-2202802;ConceiÁ„o do CanindÈ;-787638;-415942;0;22;PiauÌ;1055;89;America/Sao_Paulo
-3201704;ConceiÁ„o do Castelo;-203639;-412417;0;32;EspÌrito Santo;5633;28;America/Sao_Paulo
-2908408;ConceiÁ„o do CoitÈ;-1156;-392808;0;29;Bahia;3467;75;America/Sao_Paulo
-2908507;ConceiÁ„o do JacuÌpe;-123268;-387684;0;29;Bahia;3469;75;America/Sao_Paulo
-2103554;ConceiÁ„o do Lago-AÁu;-385142;-448895;0;21;Maranh„o;152;98;America/Sao_Paulo
-3117504;ConceiÁ„o do Mato Dentro;-190344;-434221;0;31;Minas Gerais;4349;31;America/Sao_Paulo
-3117603;ConceiÁ„o do Par·;-197456;-448945;0;31;Minas Gerais;4351;37;America/Sao_Paulo
-3117702;ConceiÁ„o do Rio Verde;-218778;-45087;0;31;Minas Gerais;4353;35;America/Sao_Paulo
-1705607;ConceiÁ„o do Tocantins;-122209;-472951;0;17;Tocantins;9313;63;America/Sao_Paulo
-3117801;ConceiÁ„o dos Ouros;-224078;-457996;0;31;Minas Gerais;4355;35;America/Sao_Paulo
-3512209;Conchal;-223375;-471729;0;35;S„o Paulo;6345;19;America/Sao_Paulo
-3512308;Conchas;-230154;-480134;0;35;S„o Paulo;6347;14;America/Sao_Paulo
-4204301;ConcÛrdia;-272335;-52026;0;42;Santa Catarina;8083;49;America/Sao_Paulo
-1502756;ConcÛrdia do Par·;-199238;-479422;0;15;Par·;579;91;America/Sao_Paulo
-2504504;Condado;-689831;-37606;0;25;ParaÌba;1991;83;America/Sao_Paulo
+2504405;Concei√ß√£o;-755106;-385014;0;25;Para√≠ba;1989;83;America/Sao_Paulo
+3117108;Concei√ß√£o da Aparecida;-21096;-462049;0;31;Minas Gerais;4341;35;America/Sao_Paulo
+3201605;Concei√ß√£o da Barra;-185883;-397362;0;32;Esp√≠rito Santo;5631;27;America/Sao_Paulo
+3115201;Concei√ß√£o da Barra de Minas;-211316;-444729;0;31;Minas Gerais;4303;32;America/Sao_Paulo
+2908200;Concei√ß√£o da Feira;-125078;-389978;0;29;Bahia;3463;75;America/Sao_Paulo
+3117306;Concei√ß√£o das Alagoas;-199172;-483839;0;31;Minas Gerais;4345;34;America/Sao_Paulo
+3117207;Concei√ß√£o das Pedras;-221576;-454562;0;31;Minas Gerais;4343;35;America/Sao_Paulo
+3117405;Concei√ß√£o de Ipanema;-199326;-416908;0;31;Minas Gerais;4347;33;America/Sao_Paulo
+3301405;Concei√ß√£o de Macabu;-220834;-418719;0;33;Rio de Janeiro;5827;22;America/Sao_Paulo
+2908309;Concei√ß√£o do Almeida;-127836;-391715;0;29;Bahia;3465;75;America/Sao_Paulo
+1502707;Concei√ß√£o do Araguaia;-826136;-492689;0;15;Par√°;453;94;America/Sao_Paulo
+2202802;Concei√ß√£o do Canind√©;-787638;-415942;0;22;Piau√≠;1055;89;America/Sao_Paulo
+3201704;Concei√ß√£o do Castelo;-203639;-412417;0;32;Esp√≠rito Santo;5633;28;America/Sao_Paulo
+2908408;Concei√ß√£o do Coit√©;-1156;-392808;0;29;Bahia;3467;75;America/Sao_Paulo
+2908507;Concei√ß√£o do Jacu√≠pe;-123268;-387684;0;29;Bahia;3469;75;America/Sao_Paulo
+2103554;Concei√ß√£o do Lago-A√ßu;-385142;-448895;0;21;Maranh√£o;152;98;America/Sao_Paulo
+3117504;Concei√ß√£o do Mato Dentro;-190344;-434221;0;31;Minas Gerais;4349;31;America/Sao_Paulo
+3117603;Concei√ß√£o do Par√°;-197456;-448945;0;31;Minas Gerais;4351;37;America/Sao_Paulo
+3117702;Concei√ß√£o do Rio Verde;-218778;-45087;0;31;Minas Gerais;4353;35;America/Sao_Paulo
+1705607;Concei√ß√£o do Tocantins;-122209;-472951;0;17;Tocantins;9313;63;America/Sao_Paulo
+3117801;Concei√ß√£o dos Ouros;-224078;-457996;0;31;Minas Gerais;4355;35;America/Sao_Paulo
+3512209;Conchal;-223375;-471729;0;35;S√£o Paulo;6345;19;America/Sao_Paulo
+3512308;Conchas;-230154;-480134;0;35;S√£o Paulo;6347;14;America/Sao_Paulo
+4204301;Conc√≥rdia;-272335;-52026;0;42;Santa Catarina;8083;49;America/Sao_Paulo
+1502756;Conc√≥rdia do Par√°;-199238;-479422;0;15;Par√°;579;91;America/Sao_Paulo
+2504504;Condado;-689831;-37606;0;25;Para√≠ba;1991;83;America/Sao_Paulo
 2604601;Condado;-758787;-350999;0;26;Pernambuco;2391;81;America/Sao_Paulo
-2504603;Conde;-725746;-348999;0;25;ParaÌba;1993;83;America/Sao_Paulo
+2504603;Conde;-725746;-348999;0;25;Para√≠ba;1993;83;America/Sao_Paulo
 2908606;Conde;-118179;-376131;0;29;Bahia;3471;75;America/Sao_Paulo
-2908705;Conde˙ba;-149022;-419718;0;29;Bahia;3473;77;America/Sao_Paulo
+2908705;Conde√∫ba;-149022;-419718;0;29;Bahia;3473;77;America/Sao_Paulo
 4305702;Condor;-282075;-534905;0;43;Rio Grande do Sul;8611;55;America/Sao_Paulo
-3117836;CÙnego Marinho;-152892;-444181;0;31;Minas Gerais;590;38;America/Sao_Paulo
+3117836;C√¥nego Marinho;-152892;-444181;0;31;Minas Gerais;590;38;America/Sao_Paulo
 3117876;Confins;-196282;-439931;0;31;Minas Gerais;592;31;America/Sao_Paulo
 5103353;Confresa;-106437;-515699;0;51;Mato Grosso;131;66;America/Porto_Velho
-2504702;Congo;-779078;-366581;0;25;ParaÌba;1995;83;America/Sao_Paulo
+2504702;Congo;-779078;-366581;0;25;Para√≠ba;1995;83;America/Sao_Paulo
 3117900;Congonhal;-221488;-46043;0;31;Minas Gerais;4357;35;America/Sao_Paulo
 3118007;Congonhas;-204958;-43851;0;31;Minas Gerais;4359;31;America/Sao_Paulo
 3118106;Congonhas do Norte;-188021;-436767;0;31;Minas Gerais;4361;31;America/Sao_Paulo
-4106001;Congonhinhas;-235493;-505569;0;41;Paran·;7517;43;America/Sao_Paulo
+4106001;Congonhinhas;-235493;-505569;0;41;Paran√°;7517;43;America/Sao_Paulo
 3118205;Conquista;-199312;-475492;0;31;Minas Gerais;4363;34;America/Sao_Paulo
 5103361;Conquista D'Oeste;-145381;-595444;0;51;Mato Grosso;1082;65;America/Porto_Velho
 3118304;Conselheiro Lafaiete;-206634;-437846;0;31;Minas Gerais;4365;31;America/Sao_Paulo
-4106100;Conselheiro Mairinck;-23623;-501707;0;41;Paran·;7519;43;America/Sao_Paulo
+4106100;Conselheiro Mairinck;-23623;-501707;0;41;Paran√°;7519;43;America/Sao_Paulo
 3118403;Conselheiro Pena;-191789;-414736;0;31;Minas Gerais;4367;33;America/Sao_Paulo
-3118502;ConsolaÁ„o;-225493;-459255;0;31;Minas Gerais;4369;35;America/Sao_Paulo
+3118502;Consola√ß√£o;-225493;-459255;0;31;Minas Gerais;4369;35;America/Sao_Paulo
 4305801;Constantina;-27732;-529938;0;43;Rio Grande do Sul;8613;54;America/Sao_Paulo
 3118601;Contagem;-199321;-440539;0;31;Minas Gerais;4371;31;America/Sao_Paulo
-4106209;Contenda;-256788;-49535;0;41;Paran·;7521;41;America/Sao_Paulo
-2908804;Contendas do Sincor·;-137537;-41048;0;29;Bahia;3475;77;America/Sao_Paulo
+4106209;Contenda;-256788;-49535;0;41;Paran√°;7521;41;America/Sao_Paulo
+2908804;Contendas do Sincor√°;-137537;-41048;0;29;Bahia;3475;77;America/Sao_Paulo
 3118700;Coqueiral;-211858;-454366;0;31;Minas Gerais;4373;35;America/Sao_Paulo
 4305835;Coqueiro Baixo;-291802;-520942;0;43;Rio Grande do Sul;1136;51;America/Sao_Paulo
 2702207;Coqueiro Seco;-963715;-357994;0;27;Alagoas;2743;82;America/Sao_Paulo
 4305850;Coqueiros do Sul;-281194;-527842;0;43;Rio Grande do Sul;5945;54;America/Sao_Paulo
-3118809;CoraÁ„o de Jesus;-166841;-443635;0;31;Minas Gerais;4375;38;America/Sao_Paulo
-2908903;CoraÁ„o de Maria;-122333;-387487;0;29;Bahia;3477;75;America/Sao_Paulo
-4106308;CorbÈlia;-247971;-533006;0;41;Paran·;7523;45;America/Sao_Paulo
+3118809;Cora√ß√£o de Jesus;-166841;-443635;0;31;Minas Gerais;4375;38;America/Sao_Paulo
+2908903;Cora√ß√£o de Maria;-122333;-387487;0;29;Bahia;3477;75;America/Sao_Paulo
+4106308;Corb√©lia;-247971;-533006;0;41;Paran√°;7523;45;America/Sao_Paulo
 3301504;Cordeiro;-220267;-423648;0;33;Rio de Janeiro;5829;22;America/Sao_Paulo
-3512407;CordeirÛpolis;-224778;-474519;0;35;S„o Paulo;6349;19;America/Sao_Paulo
+3512407;Cordeir√≥polis;-224778;-474519;0;35;S√£o Paulo;6349;19;America/Sao_Paulo
 2909000;Cordeiros;-150356;-419308;0;29;Bahia;3479;77;America/Sao_Paulo
 4204350;Cordilheira Alta;-269844;-526056;0;42;Santa Catarina;5579;49;America/Sao_Paulo
 3118908;Cordisburgo;-191224;-443224;0;31;Minas Gerais;4377;31;America/Sao_Paulo
-3119005;Cordisl‚ndia;-217891;-456999;0;31;Minas Gerais;4379;35;America/Sao_Paulo
-2304004;Corea˙;-35415;-406587;0;23;Cear·;1381;88;America/Sao_Paulo
-2504801;Coremas;-700712;-379346;0;25;ParaÌba;1997;83;America/Sao_Paulo
+3119005;Cordisl√¢ndia;-217891;-456999;0;31;Minas Gerais;4379;35;America/Sao_Paulo
+2304004;Corea√∫;-35415;-406587;0;23;Cear√°;1381;88;America/Sao_Paulo
+2504801;Coremas;-700712;-379346;0;25;Para√≠ba;1997;83;America/Sao_Paulo
 5003108;Corguinho;-198243;-548281;0;50;Mato Grosso do Sul;9061;67;America/Porto_Velho
 2909109;Coribe;-138232;-444586;0;29;Bahia;3481;77;America/Sao_Paulo
 3119104;Corinto;-18369;-444542;0;31;Minas Gerais;4381;38;America/Sao_Paulo
-4106407;CornÈlio ProcÛpio;-231829;-506498;0;41;Paran·;7525;43;America/Sao_Paulo
+4106407;Corn√©lio Proc√≥pio;-231829;-506498;0;41;Paran√°;7525;43;America/Sao_Paulo
 3119203;Coroaci;-186156;-422791;0;31;Minas Gerais;4383;33;America/Sao_Paulo
-3512506;Coroados;-213521;-502859;0;35;S„o Paulo;6351;18;America/Sao_Paulo
-2103604;Coroat·;-413442;-441244;0;21;Maranh„o;769;99;America/Sao_Paulo
+3512506;Coroados;-213521;-502859;0;35;S√£o Paulo;6351;18;America/Sao_Paulo
+2103604;Coroat√°;-413442;-441244;0;21;Maranh√£o;769;99;America/Sao_Paulo
 3119302;Coromandel;-184734;-471933;0;31;Minas Gerais;4385;34;America/Sao_Paulo
 4305871;Coronel Barros;-283921;-540686;0;43;Rio Grande do Sul;6055;55;America/Sao_Paulo
 4305900;Coronel Bicaco;-277197;-537022;0;43;Rio Grande do Sul;8615;55;America/Sao_Paulo
-4106456;Coronel Domingos Soares;-262277;-520356;0;41;Paran·;846;46;America/Sao_Paulo
+4106456;Coronel Domingos Soares;-262277;-520356;0;41;Paran√°;846;46;America/Sao_Paulo
 2402808;Coronel Ezequiel;-63748;-362223;0;24;Rio Grande do Norte;1655;84;America/Sao_Paulo
 3119401;Coronel Fabriciano;-195179;-426276;0;31;Minas Gerais;4387;31;America/Sao_Paulo
 4204400;Coronel Freitas;-269057;-527011;0;42;Santa Catarina;8085;49;America/Sao_Paulo
-2402907;Coronel Jo„o Pessoa;-624974;-384441;0;24;Rio Grande do Norte;1657;84;America/Sao_Paulo
-2909208;Coronel Jo„o S·;-102847;-379198;0;29;Bahia;3483;75;America/Sao_Paulo
-2202851;Coronel JosÈ Dias;-881397;-425232;0;22;PiauÌ;2255;89;America/Sao_Paulo
-3512605;Coronel Macedo;-236261;-4931;0;35;S„o Paulo;6353;14;America/Sao_Paulo
+2402907;Coronel Jo√£o Pessoa;-624974;-384441;0;24;Rio Grande do Norte;1657;84;America/Sao_Paulo
+2909208;Coronel Jo√£o S√°;-102847;-379198;0;29;Bahia;3483;75;America/Sao_Paulo
+2202851;Coronel Jos√© Dias;-881397;-425232;0;22;Piau√≠;2255;89;America/Sao_Paulo
+3512605;Coronel Macedo;-236261;-4931;0;35;S√£o Paulo;6353;14;America/Sao_Paulo
 4204459;Coronel Martins;-26511;-526694;0;42;Santa Catarina;5735;49;America/Sao_Paulo
 3119500;Coronel Murta;-166148;-42184;0;31;Minas Gerais;4389;33;America/Sao_Paulo
 3119609;Coronel Pacheco;-215898;-43256;0;31;Minas Gerais;4391;32;America/Sao_Paulo
 4305934;Coronel Pilar;-292695;-516847;0;43;Rio Grande do Sul;1138;54;America/Sao_Paulo
 5003157;Coronel Sapucaia;-232724;-555278;0;50;Mato Grosso do Sul;9997;67;America/Porto_Velho
-4106506;Coronel Vivida;-259767;-525641;0;41;Paran·;7527;46;America/Sao_Paulo
+4106506;Coronel Vivida;-259767;-525641;0;41;Paran√°;7527;46;America/Sao_Paulo
 3119708;Coronel Xavier Chaves;-210277;-442206;0;31;Minas Gerais;4393;32;America/Sao_Paulo
-3119807;CÛrrego Danta;-198198;-459032;0;31;Minas Gerais;4395;37;America/Sao_Paulo
-3119906;CÛrrego do Bom Jesus;-226269;-460241;0;31;Minas Gerais;4397;35;America/Sao_Paulo
-5205703;CÛrrego do Ouro;-162918;-505503;0;52;Goi·s;9315;64;America/Sao_Paulo
-3119955;CÛrrego Fundo;-204474;-455617;0;31;Minas Gerais;594;37;America/Sao_Paulo
-3120003;CÛrrego Novo;-198361;-423988;0;31;Minas Gerais;4399;33;America/Sao_Paulo
+3119807;C√≥rrego Danta;-198198;-459032;0;31;Minas Gerais;4395;37;America/Sao_Paulo
+3119906;C√≥rrego do Bom Jesus;-226269;-460241;0;31;Minas Gerais;4397;35;America/Sao_Paulo
+5205703;C√≥rrego do Ouro;-162918;-505503;0;52;Goi√°s;9315;64;America/Sao_Paulo
+3119955;C√≥rrego Fundo;-204474;-455617;0;31;Minas Gerais;594;37;America/Sao_Paulo
+3120003;C√≥rrego Novo;-198361;-423988;0;31;Minas Gerais;4399;33;America/Sao_Paulo
 4204558;Correia Pinto;-275877;-503614;0;42;Santa Catarina;8395;49;America/Sao_Paulo
-2202901;Corrente;-104333;-451633;0;22;PiauÌ;1057;89;America/Sao_Paulo
+2202901;Corrente;-104333;-451633;0;22;Piau√≠;1057;89;America/Sao_Paulo
 2604700;Correntes;-912117;-363244;0;26;Pernambuco;2393;87;America/Sao_Paulo
 2909307;Correntina;-133477;-446333;0;29;Bahia;3485;77;America/Sao_Paulo
-2604809;CortÍs;-847443;-355468;0;26;Pernambuco;2395;81;America/Sao_Paulo
-5003207;Corumb·;-190077;-57651;0;50;Mato Grosso do Sul;9063;67;America/Porto_Velho
-5205802;Corumb· de Goi·s;-159245;-488117;0;52;Goi·s;9317;62;America/Sao_Paulo
-5205901;CorumbaÌba;-181415;-485626;0;52;Goi·s;9319;64;America/Sao_Paulo
-3512704;CorumbataÌ;-222213;-476215;0;35;S„o Paulo;6355;19;America/Sao_Paulo
-4106555;CorumbataÌ do Sul;-24101;-521177;0;41;Paran·;8479;44;America/Sao_Paulo
-1100072;Corumbiara;-129551;-608947;0;11;RondÙnia;981;69;America/Porto_Velho
-4204509;Corup·;-264246;-49246;0;42;Santa Catarina;8087;47;America/Sao_Paulo
+2604809;Cort√™s;-847443;-355468;0;26;Pernambuco;2395;81;America/Sao_Paulo
+5003207;Corumb√°;-190077;-57651;0;50;Mato Grosso do Sul;9063;67;America/Porto_Velho
+5205802;Corumb√° de Goi√°s;-159245;-488117;0;52;Goi√°s;9317;62;America/Sao_Paulo
+5205901;Corumba√≠ba;-181415;-485626;0;52;Goi√°s;9319;64;America/Sao_Paulo
+3512704;Corumbata√≠;-222213;-476215;0;35;S√£o Paulo;6355;19;America/Sao_Paulo
+4106555;Corumbata√≠ do Sul;-24101;-521177;0;41;Paran√°;8479;44;America/Sao_Paulo
+1100072;Corumbiara;-129551;-608947;0;11;Rond√¥nia;981;69;America/Porto_Velho
+4204509;Corup√°;-264246;-49246;0;42;Santa Catarina;8087;47;America/Sao_Paulo
 2702306;Coruripe;-101276;-361717;0;27;Alagoas;2745;82;America/Sao_Paulo
-3512803;CosmÛpolis;-226419;-471926;0;35;S„o Paulo;6357;19;America/Sao_Paulo
-3512902;Cosmorama;-204755;-497827;0;35;S„o Paulo;6359;17;America/Sao_Paulo
-1100080;Costa Marques;-124367;-64228;0;11;RondÙnia;21;69;America/Porto_Velho
+3512803;Cosm√≥polis;-226419;-471926;0;35;S√£o Paulo;6357;19;America/Sao_Paulo
+3512902;Cosmorama;-204755;-497827;0;35;S√£o Paulo;6359;17;America/Sao_Paulo
+1100080;Costa Marques;-124367;-64228;0;11;Rond√¥nia;21;69;America/Porto_Velho
 5003256;Costa Rica;-185432;-531287;0;50;Mato Grosso do Sul;9803;67;America/Porto_Velho
 2909406;Cotegipe;-120228;-442566;0;29;Bahia;3487;77;America/Sao_Paulo
-3513009;Cotia;-236022;-46919;0;35;S„o Paulo;6361;11;America/Sao_Paulo
-4305959;Cotipor„;-289891;-516971;0;43;Rio Grande do Sul;8977;54;America/Sao_Paulo
-5103379;CotriguaÁu;-985656;-584192;0;51;Mato Grosso;89;66;America/Porto_Velho
-3120102;Couto de Magalh„es de Minas;-180727;-434648;0;31;Minas Gerais;4401;38;America/Sao_Paulo
-1706001;Couto Magalh„es;-828411;-492473;0;17;Tocantins;9321;63;America/Sao_Paulo
+3513009;Cotia;-236022;-46919;0;35;S√£o Paulo;6361;11;America/Sao_Paulo
+4305959;Cotipor√£;-289891;-516971;0;43;Rio Grande do Sul;8977;54;America/Sao_Paulo
+5103379;Cotrigua√ßu;-985656;-584192;0;51;Mato Grosso;89;66;America/Porto_Velho
+3120102;Couto de Magalh√£es de Minas;-180727;-434648;0;31;Minas Gerais;4401;38;America/Sao_Paulo
+1706001;Couto Magalh√£es;-828411;-492473;0;17;Tocantins;9321;63;America/Sao_Paulo
 4305975;Coxilha;-28128;-523023;0;43;Rio Grande do Sul;5797;54;America/Sao_Paulo
 5003306;Coxim;-185013;-54751;0;50;Mato Grosso do Sul;9065;67;America/Porto_Velho
-2504850;Coxixola;-762365;-366064;0;25;ParaÌba;472;83;America/Sao_Paulo
-2702355;CraÌbas;-96178;-367697;0;27;Alagoas;2889;82;America/Sao_Paulo
-2304103;Crate˙s;-516768;-406536;0;23;Cear·;1383;88;America/Sao_Paulo
-2304202;Crato;-72153;-394103;0;23;Cear·;1385;88;America/Sao_Paulo
-3513108;Cravinhos;-21338;-477324;0;35;S„o Paulo;6363;16;America/Sao_Paulo
-2909505;Cravol‚ndia;-133531;-398031;0;29;Bahia;3489;73;America/Sao_Paulo
-4204608;Crici˙ma;-286723;-493729;0;42;Santa Catarina;8089;48;America/Sao_Paulo
-3120151;CrisÛlita;-172381;-409184;0;31;Minas Gerais;596;33;America/Sao_Paulo
-2909604;CrisÛpolis;-115059;-381515;0;29;Bahia;3491;75;America/Sao_Paulo
+2504850;Coxixola;-762365;-366064;0;25;Para√≠ba;472;83;America/Sao_Paulo
+2702355;Cra√≠bas;-96178;-367697;0;27;Alagoas;2889;82;America/Sao_Paulo
+2304103;Crate√∫s;-516768;-406536;0;23;Cear√°;1383;88;America/Sao_Paulo
+2304202;Crato;-72153;-394103;0;23;Cear√°;1385;88;America/Sao_Paulo
+3513108;Cravinhos;-21338;-477324;0;35;S√£o Paulo;6363;16;America/Sao_Paulo
+2909505;Cravol√¢ndia;-133531;-398031;0;29;Bahia;3489;73;America/Sao_Paulo
+4204608;Crici√∫ma;-286723;-493729;0;42;Santa Catarina;8089;48;America/Sao_Paulo
+3120151;Cris√≥lita;-172381;-409184;0;31;Minas Gerais;596;33;America/Sao_Paulo
+2909604;Cris√≥polis;-115059;-381515;0;29;Bahia;3491;75;America/Sao_Paulo
 4306007;Crissiumal;-274999;-540994;0;43;Rio Grande do Sul;8617;55;America/Sao_Paulo
 3120201;Cristais;-208733;-455167;0;31;Minas Gerais;4403;35;America/Sao_Paulo
-3513207;Cristais Paulista;-204036;-474209;0;35;S„o Paulo;6365;16;America/Sao_Paulo
+3513207;Cristais Paulista;-204036;-474209;0;35;S√£o Paulo;6365;16;America/Sao_Paulo
 4306056;Cristal;-310046;-520436;0;43;Rio Grande do Sul;8431;51;America/Sao_Paulo
 4306072;Cristal do Sul;-27452;-532422;0;43;Rio Grande do Sul;972;55;America/Sao_Paulo
-1706100;Cristal‚ndia;-105985;-491942;0;17;Tocantins;9323;63;America/Sao_Paulo
-2203008;Cristal‚ndia do PiauÌ;-106443;-451893;0;22;PiauÌ;1059;89;America/Sao_Paulo
-3120300;Crist·lia;-16716;-428571;0;31;Minas Gerais;4405;38;America/Sao_Paulo
-5206206;Cristalina;-167676;-476131;0;52;Goi·s;9325;61;America/Sao_Paulo
+1706100;Cristal√¢ndia;-105985;-491942;0;17;Tocantins;9323;63;America/Sao_Paulo
+2203008;Cristal√¢ndia do Piau√≠;-106443;-451893;0;22;Piau√≠;1059;89;America/Sao_Paulo
+3120300;Crist√°lia;-16716;-428571;0;31;Minas Gerais;4405;38;America/Sao_Paulo
+5206206;Cristalina;-167676;-476131;0;52;Goi√°s;9325;61;America/Sao_Paulo
 3120409;Cristiano Otoni;-208324;-438166;0;31;Minas Gerais;4407;31;America/Sao_Paulo
-5206305;CristianÛpolis;-171987;-487034;0;52;Goi·s;9327;64;America/Sao_Paulo
+5206305;Cristian√≥polis;-171987;-487034;0;52;Goi√°s;9327;64;America/Sao_Paulo
 3120508;Cristina;-22208;-452673;0;31;Minas Gerais;4409;35;America/Sao_Paulo
-2801702;Cristin·polis;-114668;-377585;0;28;Sergipe;3133;79;America/Sao_Paulo
-2203107;Cristino Castro;-882273;-44223;0;22;PiauÌ;1061;89;America/Sao_Paulo
-2909703;CristÛpolis;-122249;-444214;0;29;Bahia;3493;77;America/Sao_Paulo
-5206404;Crix·s;-145412;-49974;0;52;Goi·s;9329;62;America/Sao_Paulo
-1706258;Crix·s do Tocantins;-110994;-489152;0;17;Tocantins;82;63;America/Sao_Paulo
-2304236;Croat·;-440481;-409022;0;23;Cear·;1241;88;America/Sao_Paulo
-5206503;CromÌnia;-172883;-493798;0;52;Goi·s;9331;64;America/Sao_Paulo
-3120607;Crucil‚ndia;-203923;-443334;0;31;Minas Gerais;4411;31;America/Sao_Paulo
-2304251;Cruz;-291813;-40176;0;23;Cear·;1589;88;America/Sao_Paulo
+2801702;Cristin√°polis;-114668;-377585;0;28;Sergipe;3133;79;America/Sao_Paulo
+2203107;Cristino Castro;-882273;-44223;0;22;Piau√≠;1061;89;America/Sao_Paulo
+2909703;Crist√≥polis;-122249;-444214;0;29;Bahia;3493;77;America/Sao_Paulo
+5206404;Crix√°s;-145412;-49974;0;52;Goi√°s;9329;62;America/Sao_Paulo
+1706258;Crix√°s do Tocantins;-110994;-489152;0;17;Tocantins;82;63;America/Sao_Paulo
+2304236;Croat√°;-440481;-409022;0;23;Cear√°;1241;88;America/Sao_Paulo
+5206503;Crom√≠nia;-172883;-493798;0;52;Goi√°s;9331;64;America/Sao_Paulo
+3120607;Crucil√¢ndia;-203923;-443334;0;31;Minas Gerais;4411;31;America/Sao_Paulo
+2304251;Cruz;-291813;-40176;0;23;Cear√°;1589;88;America/Sao_Paulo
 4306106;Cruz Alta;-28645;-536048;0;43;Rio Grande do Sul;8619;55;America/Sao_Paulo
 2909802;Cruz das Almas;-126675;-391008;0;29;Bahia;3495;75;America/Sao_Paulo
-2504900;Cruz do EspÌrito Santo;-713902;-350857;0;25;ParaÌba;1999;83;America/Sao_Paulo
-4106803;Cruz Machado;-260166;-51343;0;41;Paran·;7533;42;America/Sao_Paulo
-3513306;Cruz·lia;-227373;-507909;0;35;S„o Paulo;6367;18;America/Sao_Paulo
+2504900;Cruz do Esp√≠rito Santo;-713902;-350857;0;25;Para√≠ba;1999;83;America/Sao_Paulo
+4106803;Cruz Machado;-260166;-51343;0;41;Paran√°;7533;42;America/Sao_Paulo
+3513306;Cruz√°lia;-227373;-507909;0;35;S√£o Paulo;6367;18;America/Sao_Paulo
 4306130;Cruzaltense;-276672;-526522;0;43;Rio Grande do Sul;1140;54;America/Sao_Paulo
-3513405;Cruzeiro;-225728;-44969;0;35;S„o Paulo;6369;12;America/Sao_Paulo
+3513405;Cruzeiro;-225728;-44969;0;35;S√£o Paulo;6369;12;America/Sao_Paulo
 3120706;Cruzeiro da Fortaleza;-18944;-466669;0;31;Minas Gerais;4413;34;America/Sao_Paulo
-4106571;Cruzeiro do IguaÁu;-256192;-531285;0;41;Paran·;5473;46;America/Sao_Paulo
-4106605;Cruzeiro do Oeste;-237799;-530774;0;41;Paran·;7529;44;America/Sao_Paulo
-4106704;Cruzeiro do Sul;-229624;-521622;0;41;Paran·;7531;44;America/Sao_Paulo
+4106571;Cruzeiro do Igua√ßu;-256192;-531285;0;41;Paran√°;5473;46;America/Sao_Paulo
+4106605;Cruzeiro do Oeste;-237799;-530774;0;41;Paran√°;7529;44;America/Sao_Paulo
+4106704;Cruzeiro do Sul;-229624;-521622;0;41;Paran√°;7531;44;America/Sao_Paulo
 4306205;Cruzeiro do Sul;-295148;-519928;0;43;Rio Grande do Sul;8621;51;America/Sao_Paulo
 1200203;Cruzeiro do Sul;-762762;-726756;0;12;Acre;107;68;America/Rio_Branco
 2403004;Cruzeta;-640894;-367782;0;24;Rio Grande do Norte;1659;84;America/Sao_Paulo
-3120805;CruzÌlia;-2184;-448067;0;31;Minas Gerais;4415;35;America/Sao_Paulo
-4106852;Cruzmaltina;-240132;-514563;0;41;Paran·;848;43;America/Sao_Paulo
-3513504;Cubat„o;-238911;-46424;0;35;S„o Paulo;6371;13;America/Sao_Paulo
-2505006;Cubati;-686686;-363619;0;25;ParaÌba;2001;83;America/Sao_Paulo
-5103403;Cuiab·;-15601;-560974;1;51;Mato Grosso;9067;65;America/Porto_Velho
-2505105;CuitÈ;-647647;-361515;0;25;ParaÌba;2003;83;America/Sao_Paulo
-2505238;CuitÈ de Mamanguape;-691292;-352502;0;25;ParaÌba;474;83;America/Sao_Paulo
-2505204;Cuitegi;-689058;-355215;0;25;ParaÌba;2005;83;America/Sao_Paulo
-1100940;Cujubim;-936065;-625846;0;11;RondÙnia;8;69;America/Porto_Velho
-5206602;Cumari;-182644;-481511;0;52;Goi·s;9333;64;America/Sao_Paulo
+3120805;Cruz√≠lia;-2184;-448067;0;31;Minas Gerais;4415;35;America/Sao_Paulo
+4106852;Cruzmaltina;-240132;-514563;0;41;Paran√°;848;43;America/Sao_Paulo
+3513504;Cubat√£o;-238911;-46424;0;35;S√£o Paulo;6371;13;America/Sao_Paulo
+2505006;Cubati;-686686;-363619;0;25;Para√≠ba;2001;83;America/Sao_Paulo
+5103403;Cuiab√°;-15601;-560974;1;51;Mato Grosso;9067;65;America/Porto_Velho
+2505105;Cuit√©;-647647;-361515;0;25;Para√≠ba;2003;83;America/Sao_Paulo
+2505238;Cuit√© de Mamanguape;-691292;-352502;0;25;Para√≠ba;474;83;America/Sao_Paulo
+2505204;Cuitegi;-689058;-355215;0;25;Para√≠ba;2005;83;America/Sao_Paulo
+1100940;Cujubim;-936065;-625846;0;11;Rond√¥nia;8;69;America/Porto_Velho
+5206602;Cumari;-182644;-481511;0;52;Goi√°s;9333;64;America/Sao_Paulo
 2604908;Cumaru;-800827;-356957;0;26;Pernambuco;2397;81;America/Sao_Paulo
-1502764;Cumaru do Norte;-781097;-507698;0;15;Par·;385;94;America/Sao_Paulo
+1502764;Cumaru do Norte;-781097;-507698;0;15;Par√°;385;94;America/Sao_Paulo
 2801900;Cumbe;-10352;-371846;0;28;Sergipe;3137;79;America/Sao_Paulo
-3513603;Cunha;-230731;-449576;0;35;S„o Paulo;6373;12;America/Sao_Paulo
-4204707;Cunha Por„;-26895;-531662;0;42;Santa Catarina;8091;49;America/Sao_Paulo
-4204756;CunhataÌ;-269709;-530895;0;42;Santa Catarina;910;49;America/Sao_Paulo
+3513603;Cunha;-230731;-449576;0;35;S√£o Paulo;6373;12;America/Sao_Paulo
+4204707;Cunha Por√£;-26895;-531662;0;42;Santa Catarina;8091;49;America/Sao_Paulo
+4204756;Cunhata√≠;-269709;-530895;0;42;Santa Catarina;910;49;America/Sao_Paulo
 3120839;Cuparaque;-189648;-410986;0;31;Minas Gerais;598;33;America/Sao_Paulo
 2605004;Cupira;-862432;-359518;0;26;Pernambuco;2399;81;America/Sao_Paulo
-2909901;CuraÁ·;-898458;-398997;0;29;Bahia;3497;74;America/Sao_Paulo
-2203206;Curimat·;-100326;-443002;0;22;PiauÌ;1063;89;America/Sao_Paulo
-1502772;CurionÛpolis;-609965;-496068;0;15;Par·;581;94;America/Sao_Paulo
-4106902;Curitiba;-254195;-492646;1;41;Paran·;7535;41;America/Sao_Paulo
+2909901;Cura√ß√°;-898458;-398997;0;29;Bahia;3497;74;America/Sao_Paulo
+2203206;Curimat√°;-100326;-443002;0;22;Piau√≠;1063;89;America/Sao_Paulo
+1502772;Curion√≥polis;-609965;-496068;0;15;Par√°;581;94;America/Sao_Paulo
+4106902;Curitiba;-254195;-492646;1;41;Paran√°;7535;41;America/Sao_Paulo
 4204806;Curitibanos;-272824;-505816;0;42;Santa Catarina;8093;49;America/Sao_Paulo
-4107009;Curi˙va;-240362;-504576;0;41;Paran·;7537;43;America/Sao_Paulo
-2203230;Currais;-901175;-444062;0;22;PiauÌ;308;89;America/Sao_Paulo
+4107009;Curi√∫va;-240362;-504576;0;41;Paran√°;7537;43;America/Sao_Paulo
+2203230;Currais;-901175;-444062;0;22;Piau√≠;308;89;America/Sao_Paulo
 2403103;Currais Novos;-625484;-365146;0;24;Rio Grande do Norte;1661;84;America/Sao_Paulo
-2505279;Curral de Cima;-672325;-352639;0;25;ParaÌba;476;83;America/Sao_Paulo
+2505279;Curral de Cima;-672325;-352639;0;25;Para√≠ba;476;83;America/Sao_Paulo
 3120870;Curral de Dentro;-159327;-418557;0;31;Minas Gerais;600;33;America/Sao_Paulo
-2203271;Curral Novo do PiauÌ;-78313;-408957;0;22;PiauÌ;312;89;America/Sao_Paulo
-2505303;Curral Velho;-753075;-381962;0;25;ParaÌba;2007;83;America/Sao_Paulo
-1502806;Curralinho;-181179;-497952;0;15;Par·;455;91;America/Sao_Paulo
-2203255;Curralinhos;-560825;-428376;0;22;PiauÌ;310;86;America/Sao_Paulo
-1502855;Curu·;-188775;-551168;0;15;Par·;50;93;America/Sao_Paulo
-1502905;CuruÁ·;-733214;-478515;0;15;Par·;457;91;America/Sao_Paulo
-2103703;Cururupu;-181475;-448644;0;21;Maranh„o;771;98;America/Sao_Paulo
-5103437;Curvel‚ndia;-156084;-579133;0;51;Mato Grosso;1084;65;America/Porto_Velho
+2203271;Curral Novo do Piau√≠;-78313;-408957;0;22;Piau√≠;312;89;America/Sao_Paulo
+2505303;Curral Velho;-753075;-381962;0;25;Para√≠ba;2007;83;America/Sao_Paulo
+1502806;Curralinho;-181179;-497952;0;15;Par√°;455;91;America/Sao_Paulo
+2203255;Curralinhos;-560825;-428376;0;22;Piau√≠;310;86;America/Sao_Paulo
+1502855;Curu√°;-188775;-551168;0;15;Par√°;50;93;America/Sao_Paulo
+1502905;Curu√ß√°;-733214;-478515;0;15;Par√°;457;91;America/Sao_Paulo
+2103703;Cururupu;-181475;-448644;0;21;Maranh√£o;771;98;America/Sao_Paulo
+5103437;Curvel√¢ndia;-156084;-579133;0;51;Mato Grosso;1084;65;America/Porto_Velho
 3120904;Curvelo;-187527;-444303;0;31;Minas Gerais;4417;38;America/Sao_Paulo
-2605103;CustÛdia;-808546;-376443;0;26;Pernambuco;2401;87;America/Sao_Paulo
-1600212;Cutias;970761;-508005;0;16;Amap·;667;96;America/Sao_Paulo
-5206701;DamianÛpolis;-145604;-46178;0;52;Goi·s;9335;62;America/Sao_Paulo
-2505352;Dami„o;-663161;-359101;0;25;ParaÌba;478;83;America/Sao_Paulo
-5206800;Damol‚ndia;-162544;-493631;0;52;Goi·s;9337;62;America/Sao_Paulo
-1706506;DarcinÛpolis;-671591;-477597;0;17;Tocantins;179;63;America/Sao_Paulo
-2910008;D·rio Meira;-144229;-399031;0;29;Bahia;3499;73;America/Sao_Paulo
+2605103;Cust√≥dia;-808546;-376443;0;26;Pernambuco;2401;87;America/Sao_Paulo
+1600212;Cutias;970761;-508005;0;16;Amap√°;667;96;America/Sao_Paulo
+5206701;Damian√≥polis;-145604;-46178;0;52;Goi√°s;9335;62;America/Sao_Paulo
+2505352;Dami√£o;-663161;-359101;0;25;Para√≠ba;478;83;America/Sao_Paulo
+5206800;Damol√¢ndia;-162544;-493631;0;52;Goi√°s;9337;62;America/Sao_Paulo
+1706506;Darcin√≥polis;-671591;-477597;0;17;Tocantins;179;63;America/Sao_Paulo
+2910008;D√°rio Meira;-144229;-399031;0;29;Bahia;3499;73;America/Sao_Paulo
 3121001;Datas;-184478;-436591;0;31;Minas Gerais;4419;38;America/Sao_Paulo
 4306304;David Canabarro;-283849;-518482;0;43;Rio Grande do Sul;8623;54;America/Sao_Paulo
-2103752;DavinÛpolis;-554637;-474217;0;21;Maranh„o;154;99;America/Sao_Paulo
-5206909;DavinÛpolis;-181501;-475568;0;52;Goi·s;9339;64;America/Sao_Paulo
+2103752;Davin√≥polis;-554637;-474217;0;21;Maranh√£o;154;99;America/Sao_Paulo
+5206909;Davin√≥polis;-181501;-475568;0;52;Goi√°s;9339;64;America/Sao_Paulo
 3121100;Delfim Moreira;-225036;-452792;0;31;Minas Gerais;4421;35;America/Sao_Paulo
-3121209;DelfinÛpolis;-203468;-468456;0;31;Minas Gerais;4423;35;America/Sao_Paulo
+3121209;Delfin√≥polis;-203468;-468456;0;31;Minas Gerais;4423;35;America/Sao_Paulo
 2702405;Delmiro Gouveia;-938534;-379987;0;27;Alagoas;2747;82;America/Sao_Paulo
 3121258;Delta;-199721;-477841;0;31;Minas Gerais;602;34;America/Sao_Paulo
-2203305;Demerval Lob„o;-535875;-426776;0;22;PiauÌ;1065;86;America/Sao_Paulo
+2203305;Demerval Lob√£o;-535875;-426776;0;22;Piau√≠;1065;86;America/Sao_Paulo
 5103452;Denise;-147324;-570583;0;51;Mato Grosso;9833;65;America/Porto_Velho
-5003454;Deod·polis;-222763;-541682;0;50;Mato Grosso do Sul;9175;67;America/Porto_Velho
-2304269;Deputado Irapuan Pinheiro;-591485;-39257;0;23;Cear·;1243;88;America/Sao_Paulo
+5003454;Deod√°polis;-222763;-541682;0;50;Mato Grosso do Sul;9175;67;America/Porto_Velho
+2304269;Deputado Irapuan Pinheiro;-591485;-39257;0;23;Cear√°;1243;88;America/Sao_Paulo
 4306320;Derrubadas;-272642;-538645;0;43;Rio Grande do Sul;6073;55;America/Sao_Paulo
-3513702;Descalvado;-219002;-476181;0;35;S„o Paulo;6375;19;America/Sao_Paulo
+3513702;Descalvado;-219002;-476181;0;35;S√£o Paulo;6375;19;America/Sao_Paulo
 4204905;Descanso;-26827;-535034;0;42;Santa Catarina;8095;49;America/Sao_Paulo
 3121308;Descoberto;-2146;-429618;0;31;Minas Gerais;4425;32;America/Sao_Paulo
-2505402;Desterro;-7287;-370925;0;25;ParaÌba;2009;83;America/Sao_Paulo
+2505402;Desterro;-7287;-370925;0;25;Para√≠ba;2009;83;America/Sao_Paulo
 3121407;Desterro de Entre Rios;-20665;-443334;0;31;Minas Gerais;4427;31;America/Sao_Paulo
 3121506;Desterro do Melo;-21143;-435178;0;31;Minas Gerais;4429;32;America/Sao_Paulo
 4306353;Dezesseis de Novembro;-28219;-550617;0;43;Rio Grande do Sul;8429;55;America/Sao_Paulo
-3513801;Diadema;-236813;-466205;0;35;S„o Paulo;6377;11;America/Sao_Paulo
-2505600;Diamante;-741738;-382615;0;25;ParaÌba;2013;83;America/Sao_Paulo
-4107157;Diamante D'Oeste;-249419;-541052;0;41;Paran·;9915;45;America/Sao_Paulo
-4107108;Diamante do Norte;-22655;-528617;0;41;Paran·;7539;44;America/Sao_Paulo
-4107124;Diamante do Sul;-25035;-526768;0;41;Paran·;5465;45;America/Sao_Paulo
+3513801;Diadema;-236813;-466205;0;35;S√£o Paulo;6377;11;America/Sao_Paulo
+2505600;Diamante;-741738;-382615;0;25;Para√≠ba;2013;83;America/Sao_Paulo
+4107157;Diamante D'Oeste;-249419;-541052;0;41;Paran√°;9915;45;America/Sao_Paulo
+4107108;Diamante do Norte;-22655;-528617;0;41;Paran√°;7539;44;America/Sao_Paulo
+4107124;Diamante do Sul;-25035;-526768;0;41;Paran√°;5465;45;America/Sao_Paulo
 3121605;Diamantina;-182413;-436031;0;31;Minas Gerais;4431;38;America/Sao_Paulo
 5103502;Diamantino;-144037;-564366;0;51;Mato Grosso;9069;65;America/Porto_Velho
-1707009;DianÛpolis;-11624;-468198;0;17;Tocantins;9341;63;America/Sao_Paulo
-2910057;Dias d'¡vila;-126187;-382926;0;29;Bahia;3087;71;America/Sao_Paulo
+1707009;Dian√≥polis;-11624;-468198;0;17;Tocantins;9341;63;America/Sao_Paulo
+2910057;Dias d'√Åvila;-126187;-382926;0;29;Bahia;3087;71;America/Sao_Paulo
 4306379;Dilermando de Aguiar;-297054;-542122;0;43;Rio Grande do Sul;974;55;America/Sao_Paulo
 3121704;Diogo de Vasconcelos;-204879;-431953;0;31;Minas Gerais;4433;31;America/Sao_Paulo
-3121803;DionÌsio;-198433;-427701;0;31;Minas Gerais;4435;31;America/Sao_Paulo
-4205001;DionÌsio Cerqueira;-262648;-536351;0;42;Santa Catarina;8097;49;America/Sao_Paulo
-5207105;Diorama;-162329;-512543;0;52;Goi·s;9343;64;America/Sao_Paulo
-3513850;Dirce Reis;-204642;-506073;0;35;S„o Paulo;7249;17;America/Sao_Paulo
-2203354;Dirceu Arcoverde;-933939;-424348;0;22;PiauÌ;1229;89;America/Sao_Paulo
+3121803;Dion√≠sio;-198433;-427701;0;31;Minas Gerais;4435;31;America/Sao_Paulo
+4205001;Dion√≠sio Cerqueira;-262648;-536351;0;42;Santa Catarina;8097;49;America/Sao_Paulo
+5207105;Diorama;-162329;-512543;0;52;Goi√°s;9343;64;America/Sao_Paulo
+3513850;Dirce Reis;-204642;-506073;0;35;S√£o Paulo;7249;17;America/Sao_Paulo
+2203354;Dirceu Arcoverde;-933939;-424348;0;22;Piau√≠;1229;89;America/Sao_Paulo
 2802007;Divina Pastora;-106782;-371506;0;28;Sergipe;3139;79;America/Sao_Paulo
-3121902;DivinÈsia;-209917;-430003;0;31;Minas Gerais;4437;32;America/Sao_Paulo
+3121902;Divin√©sia;-209917;-430003;0;31;Minas Gerais;4437;32;America/Sao_Paulo
 3122009;Divino;-206134;-421438;0;31;Minas Gerais;4439;32;America/Sao_Paulo
 3122108;Divino das Laranjeiras;-187755;-414781;0;31;Minas Gerais;4441;33;America/Sao_Paulo
-3201803;Divino de S„o LourenÁo;-206229;-416937;0;32;EspÌrito Santo;5635;28;America/Sao_Paulo
-3513900;Divinol‚ndia;-216637;-467361;0;35;S„o Paulo;6379;19;America/Sao_Paulo
-3122207;Divinol‚ndia de Minas;-188004;-426103;0;31;Minas Gerais;4443;33;America/Sao_Paulo
-3122306;DivinÛpolis;-201446;-448912;0;31;Minas Gerais;4445;37;America/Sao_Paulo
-5208301;DivinÛpolis de Goi·s;-132853;-463999;0;52;Goi·s;9309;62;America/Sao_Paulo
-1707108;DivinÛpolis do Tocantins;-980018;-492169;0;17;Tocantins;9719;63;America/Sao_Paulo
+3201803;Divino de S√£o Louren√ßo;-206229;-416937;0;32;Esp√≠rito Santo;5635;28;America/Sao_Paulo
+3513900;Divinol√¢ndia;-216637;-467361;0;35;S√£o Paulo;6379;19;America/Sao_Paulo
+3122207;Divinol√¢ndia de Minas;-188004;-426103;0;31;Minas Gerais;4443;33;America/Sao_Paulo
+3122306;Divin√≥polis;-201446;-448912;0;31;Minas Gerais;4445;37;America/Sao_Paulo
+5208301;Divin√≥polis de Goi√°s;-132853;-463999;0;52;Goi√°s;9309;62;America/Sao_Paulo
+1707108;Divin√≥polis do Tocantins;-980018;-492169;0;17;Tocantins;9719;63;America/Sao_Paulo
 3122355;Divisa Alegre;-157221;-413463;0;31;Minas Gerais;604;33;America/Sao_Paulo
 3122405;Divisa Nova;-215092;-461904;0;31;Minas Gerais;4447;35;America/Sao_Paulo
-3122454;DivisÛpolis;-157254;-409997;0;31;Minas Gerais;2657;33;America/Sao_Paulo
-3514007;Dobrada;-215155;-483935;0;35;S„o Paulo;6381;16;America/Sao_Paulo
-3514106;Dois CÛrregos;-223673;-483819;0;35;S„o Paulo;6383;14;America/Sao_Paulo
-4306403;Dois Irm„os;-295836;-510898;0;43;Rio Grande do Sul;8625;51;America/Sao_Paulo
-4306429;Dois Irm„os das Missıes;-276621;-535304;0;43;Rio Grande do Sul;5971;55;America/Sao_Paulo
-5003488;Dois Irm„os do Buriti;-206848;-552915;0;50;Mato Grosso do Sul;9793;67;America/Porto_Velho
-1707207;Dois Irm„os do Tocantins;-925534;-490638;0;17;Tocantins;9345;63;America/Sao_Paulo
+3122454;Divis√≥polis;-157254;-409997;0;31;Minas Gerais;2657;33;America/Sao_Paulo
+3514007;Dobrada;-215155;-483935;0;35;S√£o Paulo;6381;16;America/Sao_Paulo
+3514106;Dois C√≥rregos;-223673;-483819;0;35;S√£o Paulo;6383;14;America/Sao_Paulo
+4306403;Dois Irm√£os;-295836;-510898;0;43;Rio Grande do Sul;8625;51;America/Sao_Paulo
+4306429;Dois Irm√£os das Miss√µes;-276621;-535304;0;43;Rio Grande do Sul;5971;55;America/Sao_Paulo
+5003488;Dois Irm√£os do Buriti;-206848;-552915;0;50;Mato Grosso do Sul;9793;67;America/Porto_Velho
+1707207;Dois Irm√£os do Tocantins;-925534;-490638;0;17;Tocantins;9345;63;America/Sao_Paulo
 4306452;Dois Lajeados;-28983;-518396;0;43;Rio Grande do Sul;8427;54;America/Sao_Paulo
 2702504;Dois Riachos;-938465;-370965;0;27;Alagoas;2749;82;America/Sao_Paulo
-4107207;Dois Vizinhos;-257407;-53057;0;41;Paran·;7541;46;America/Sao_Paulo
-3514205;DolcinÛpolis;-20124;-505149;0;35;S„o Paulo;6385;17;America/Sao_Paulo
+4107207;Dois Vizinhos;-257407;-53057;0;41;Paran√°;7541;46;America/Sao_Paulo
+3514205;Dolcin√≥polis;-20124;-505149;0;35;S√£o Paulo;6385;17;America/Sao_Paulo
 5103601;Dom Aquino;-158099;-549223;0;51;Mato Grosso;9071;66;America/Porto_Velho
-2910107;Dom BasÌlio;-137565;-417677;0;29;Bahia;3501;77;America/Sao_Paulo
+2910107;Dom Bas√≠lio;-137565;-417677;0;29;Bahia;3501;77;America/Sao_Paulo
 3122470;Dom Bosco;-16652;-462597;0;31;Minas Gerais;606;38;America/Sao_Paulo
 3122504;Dom Cavati;-193735;-421121;0;31;Minas Gerais;4449;33;America/Sao_Paulo
-1502939;Dom Eliseu;-419944;-478245;0;15;Par·;583;94;America/Sao_Paulo
-2203404;Dom Expedito Lopes;-695332;-416396;0;22;PiauÌ;1067;89;America/Sao_Paulo
+1502939;Dom Eliseu;-419944;-478245;0;15;Par√°;583;94;America/Sao_Paulo
+2203404;Dom Expedito Lopes;-695332;-416396;0;22;Piau√≠;1067;89;America/Sao_Paulo
 4306502;Dom Feliciano;-307004;-521026;0;43;Rio Grande do Sul;8627;51;America/Sao_Paulo
-2203453;Dom InocÍncio;-900516;-419697;0;22;PiauÌ;1289;89;America/Sao_Paulo
+2203453;Dom Inoc√™ncio;-900516;-419697;0;22;Piau√≠;1289;89;America/Sao_Paulo
 3122603;Dom Joaquim;-18961;-432544;0;31;Minas Gerais;4451;31;America/Sao_Paulo
 2910206;Dom Macedo Costa;-129016;-391923;0;29;Bahia;3503;75;America/Sao_Paulo
 4306601;Dom Pedrito;-309756;-546694;0;43;Rio Grande do Sul;8629;53;America/Sao_Paulo
-2103802;Dom Pedro;-503518;-444409;0;21;Maranh„o;773;99;America/Sao_Paulo
-4306551;Dom Pedro de Alc‚ntara;-293639;-49853;0;43;Rio Grande do Sul;976;51;America/Sao_Paulo
-3122702;Dom SilvÈrio;-201627;-429627;0;31;Minas Gerais;4453;31;America/Sao_Paulo
-3122801;Dom ViÁoso;-222511;-451643;0;31;Minas Gerais;4455;35;America/Sao_Paulo
-3201902;Domingos Martins;-203603;-406594;0;32;EspÌrito Santo;5637;27;America/Sao_Paulo
-2203420;Domingos Mour„o;-42495;-412683;0;22;PiauÌ;1141;86;America/Sao_Paulo
+2103802;Dom Pedro;-503518;-444409;0;21;Maranh√£o;773;99;America/Sao_Paulo
+4306551;Dom Pedro de Alc√¢ntara;-293639;-49853;0;43;Rio Grande do Sul;976;51;America/Sao_Paulo
+3122702;Dom Silv√©rio;-201627;-429627;0;31;Minas Gerais;4453;31;America/Sao_Paulo
+3122801;Dom Vi√ßoso;-222511;-451643;0;31;Minas Gerais;4455;35;America/Sao_Paulo
+3201902;Domingos Martins;-203603;-406594;0;32;Esp√≠rito Santo;5637;27;America/Sao_Paulo
+2203420;Domingos Mour√£o;-42495;-412683;0;22;Piau√≠;1141;86;America/Sao_Paulo
 4205100;Dona Emma;-26981;-497261;0;42;Santa Catarina;8099;47;America/Sao_Paulo
-3122900;Dona EusÈbia;-21319;-42807;0;31;Minas Gerais;4457;32;America/Sao_Paulo
+3122900;Dona Eus√©bia;-21319;-42807;0;31;Minas Gerais;4457;32;America/Sao_Paulo
 4306700;Dona Francisca;-296195;-533617;0;43;Rio Grande do Sul;8631;55;America/Sao_Paulo
-2505709;Dona InÍs;-661566;-356205;0;25;ParaÌba;2015;83;America/Sao_Paulo
+2505709;Dona In√™s;-661566;-356205;0;25;Para√≠ba;2015;83;America/Sao_Paulo
 3123007;Dores de Campos;-211139;-440207;0;31;Minas Gerais;4459;32;America/Sao_Paulo
-3123106;Dores de Guanh„es;-190516;-429254;0;31;Minas Gerais;4461;33;America/Sao_Paulo
-3123205;Dores do Indai·;-194628;-455927;0;31;Minas Gerais;4463;37;America/Sao_Paulo
-3202009;Dores do Rio Preto;-206931;-418405;0;32;EspÌrito Santo;5639;28;America/Sao_Paulo
+3123106;Dores de Guanh√£es;-190516;-429254;0;31;Minas Gerais;4461;33;America/Sao_Paulo
+3123205;Dores do Indai√°;-194628;-455927;0;31;Minas Gerais;4463;37;America/Sao_Paulo
+3202009;Dores do Rio Preto;-206931;-418405;0;32;Esp√≠rito Santo;5639;28;America/Sao_Paulo
 3123304;Dores do Turvo;-209785;-431834;0;31;Minas Gerais;4465;32;America/Sao_Paulo
-3123403;DoresÛpolis;-202868;-459007;0;31;Minas Gerais;4467;37;America/Sao_Paulo
+3123403;Dores√≥polis;-202868;-459007;0;31;Minas Gerais;4467;37;America/Sao_Paulo
 2605152;Dormentes;-844116;-407662;0;26;Pernambuco;2299;87;America/Sao_Paulo
 5003504;Douradina;-220405;-546158;0;50;Mato Grosso do Sul;9805;67;America/Porto_Velho
-4107256;Douradina;-233807;-532918;0;41;Paran·;8465;44;America/Sao_Paulo
-3514304;Dourado;-221044;-483178;0;35;S„o Paulo;6387;16;America/Sao_Paulo
+4107256;Douradina;-233807;-532918;0;41;Paran√°;8465;44;America/Sao_Paulo
+3514304;Dourado;-221044;-483178;0;35;S√£o Paulo;6387;16;America/Sao_Paulo
 3123502;Douradoquara;-184338;-475993;0;31;Minas Gerais;4469;34;America/Sao_Paulo
 5003702;Dourados;-222231;-54812;0;50;Mato Grosso do Sul;9073;67;America/Porto_Velho
-4107306;Doutor Camargo;-235582;-522178;0;41;Paran·;7543;44;America/Sao_Paulo
-4306734;Doutor MaurÌcio Cardoso;-275103;-543577;0;43;Rio Grande do Sul;8425;55;America/Sao_Paulo
+4107306;Doutor Camargo;-235582;-522178;0;41;Paran√°;7543;44;America/Sao_Paulo
+4306734;Doutor Maur√≠cio Cardoso;-275103;-543577;0;43;Rio Grande do Sul;8425;55;America/Sao_Paulo
 4205159;Doutor Pedrinho;-267174;-494795;0;42;Santa Catarina;9945;47;America/Sao_Paulo
 4306759;Doutor Ricardo;-29084;-519972;0;43;Rio Grande do Sul;978;51;America/Sao_Paulo
 2403202;Doutor Severiano;-608082;-383794;0;24;Rio Grande do Norte;1663;84;America/Sao_Paulo
-4128633;Doutor Ulysses;-245665;-494219;0;41;Paran·;5449;41;America/Sao_Paulo
-5207253;Doverl‚ndia;-167188;-523189;0;52;Goi·s;9675;64;America/Sao_Paulo
-3514403;Dracena;-214843;-51535;0;35;S„o Paulo;6389;18;America/Sao_Paulo
-3514502;Duartina;-224146;-494084;0;35;S„o Paulo;6391;14;America/Sao_Paulo
+4128633;Doutor Ulysses;-245665;-494219;0;41;Paran√°;5449;41;America/Sao_Paulo
+5207253;Doverl√¢ndia;-167188;-523189;0;52;Goi√°s;9675;64;America/Sao_Paulo
+3514403;Dracena;-214843;-51535;0;35;S√£o Paulo;6389;18;America/Sao_Paulo
+3514502;Duartina;-224146;-494084;0;35;S√£o Paulo;6391;14;America/Sao_Paulo
 3301603;Duas Barras;-220536;-425232;0;33;Rio de Janeiro;5831;22;America/Sao_Paulo
-2505808;Duas Estradas;-668499;-35418;0;25;ParaÌba;2017;83;America/Sao_Paulo
-1707306;DuerÈ;-113416;-492716;0;17;Tocantins;9347;63;America/Sao_Paulo
-3514601;Dumont;-212324;-479756;0;35;S„o Paulo;6393;16;America/Sao_Paulo
-2103901;Duque Bacelar;-415002;-429477;0;21;Maranh„o;775;98;America/Sao_Paulo
+2505808;Duas Estradas;-668499;-35418;0;25;Para√≠ba;2017;83;America/Sao_Paulo
+1707306;Duer√©;-113416;-492716;0;17;Tocantins;9347;63;America/Sao_Paulo
+3514601;Dumont;-212324;-479756;0;35;S√£o Paulo;6393;16;America/Sao_Paulo
+2103901;Duque Bacelar;-415002;-429477;0;21;Maranh√£o;775;98;America/Sao_Paulo
 3301702;Duque de Caxias;-227858;-433049;0;33;Rio de Janeiro;5833;21;America/Sao_Paulo
-3123528;DurandÈ;-202058;-417977;0;31;Minas Gerais;2675;33;America/Sao_Paulo
-3514700;Echapor„;-224326;-502038;0;35;S„o Paulo;6395;18;America/Sao_Paulo
-3202108;Ecoporanga;-183702;-40836;0;32;EspÌrito Santo;5641;27;America/Sao_Paulo
-5207352;Edealina;-174239;-496644;0;52;Goi·s;9795;64;America/Sao_Paulo
-5207402;EdÈia;-173406;-499295;0;52;Goi·s;9349;64;America/Sao_Paulo
-1301407;EirunepÈ;-665677;-698662;0;13;Amazonas;229;97;America/Rio_Branco
+3123528;Durand√©;-202058;-417977;0;31;Minas Gerais;2675;33;America/Sao_Paulo
+3514700;Echapor√£;-224326;-502038;0;35;S√£o Paulo;6395;18;America/Sao_Paulo
+3202108;Ecoporanga;-183702;-40836;0;32;Esp√≠rito Santo;5641;27;America/Sao_Paulo
+5207352;Edealina;-174239;-496644;0;52;Goi√°s;9795;64;America/Sao_Paulo
+5207402;Ed√©ia;-173406;-499295;0;52;Goi√°s;9349;64;America/Sao_Paulo
+1301407;Eirunep√©;-665677;-698662;0;13;Amazonas;229;97;America/Rio_Branco
 5003751;Eldorado;-237868;-542838;0;50;Mato Grosso do Sul;9173;67;America/Porto_Velho
-3514809;Eldorado;-245281;-481141;0;35;S„o Paulo;6397;13;America/Sao_Paulo
-1502954;Eldorado do Caraj·s;-610389;-493553;0;15;Par·;377;94;America/Sao_Paulo
+3514809;Eldorado;-245281;-481141;0;35;S√£o Paulo;6397;13;America/Sao_Paulo
+1502954;Eldorado do Caraj√°s;-610389;-493553;0;15;Par√°;377;94;America/Sao_Paulo
 4306767;Eldorado do Sul;-300847;-516187;0;43;Rio Grande do Sul;8423;51;America/Sao_Paulo
-2203503;Elesb„o Veloso;-619947;-421355;0;22;PiauÌ;1069;86;America/Sao_Paulo
-3514908;Elias Fausto;-230428;-473682;0;35;S„o Paulo;6399;19;America/Sao_Paulo
-2203602;Eliseu Martins;-809629;-436705;0;22;PiauÌ;1071;89;America/Sao_Paulo
-3514924;Elisi·rio;-211678;-491146;0;35;S„o Paulo;2975;17;America/Sao_Paulo
-2910305;ElÌsio Medrado;-129417;-395191;0;29;Bahia;3505;75;America/Sao_Paulo
-3123601;ElÛi Mendes;-216088;-455691;0;31;Minas Gerais;4471;35;America/Sao_Paulo
-2505907;Emas;-709964;-377163;0;25;ParaÌba;2019;83;America/Sao_Paulo
-3514957;Emba˙ba;-209796;-488325;0;35;S„o Paulo;7251;17;America/Sao_Paulo
-3515004;Embu das Artes;-236437;-468579;0;35;S„o Paulo;6401;11;America/Sao_Paulo
-3515103;Embu-GuaÁu;-238297;-468136;0;35;S„o Paulo;6403;11;America/Sao_Paulo
-3515129;EmilianÛpolis;-218314;-514832;0;35;S„o Paulo;2961;18;America/Sao_Paulo
+2203503;Elesb√£o Veloso;-619947;-421355;0;22;Piau√≠;1069;86;America/Sao_Paulo
+3514908;Elias Fausto;-230428;-473682;0;35;S√£o Paulo;6399;19;America/Sao_Paulo
+2203602;Eliseu Martins;-809629;-436705;0;22;Piau√≠;1071;89;America/Sao_Paulo
+3514924;Elisi√°rio;-211678;-491146;0;35;S√£o Paulo;2975;17;America/Sao_Paulo
+2910305;El√≠sio Medrado;-129417;-395191;0;29;Bahia;3505;75;America/Sao_Paulo
+3123601;El√≥i Mendes;-216088;-455691;0;31;Minas Gerais;4471;35;America/Sao_Paulo
+2505907;Emas;-709964;-377163;0;25;Para√≠ba;2019;83;America/Sao_Paulo
+3514957;Emba√∫ba;-209796;-488325;0;35;S√£o Paulo;7251;17;America/Sao_Paulo
+3515004;Embu das Artes;-236437;-468579;0;35;S√£o Paulo;6401;11;America/Sao_Paulo
+3515103;Embu-Gua√ßu;-238297;-468136;0;35;S√£o Paulo;6403;11;America/Sao_Paulo
+3515129;Emilian√≥polis;-218314;-514832;0;35;S√£o Paulo;2961;18;America/Sao_Paulo
 4306809;Encantado;-292351;-518703;0;43;Rio Grande do Sul;8633;51;America/Sao_Paulo
 2403301;Encanto;-610691;-383033;0;24;Rio Grande do Norte;1665;84;America/Sao_Paulo
 2910404;Encruzilhada;-155302;-409124;0;29;Bahia;3507;77;America/Sao_Paulo
 4306908;Encruzilhada do Sul;-30543;-525204;0;43;Rio Grande do Sul;8635;51;America/Sao_Paulo
-4107405;EnÈas Marques;-259445;-531659;0;41;Paran·;7545;46;America/Sao_Paulo
-4107504;Engenheiro Beltr„o;-23797;-522659;0;41;Paran·;7547;44;America/Sao_Paulo
+4107405;En√©as Marques;-259445;-531659;0;41;Paran√°;7545;46;America/Sao_Paulo
+4107504;Engenheiro Beltr√£o;-23797;-522659;0;41;Paran√°;7547;44;America/Sao_Paulo
 3123700;Engenheiro Caldas;-192065;-420503;0;31;Minas Gerais;4473;33;America/Sao_Paulo
-3515152;Engenheiro Coelho;-224836;-47211;0;35;S„o Paulo;2949;19;America/Sao_Paulo
+3515152;Engenheiro Coelho;-224836;-47211;0;35;S√£o Paulo;2949;19;America/Sao_Paulo
 3123809;Engenheiro Navarro;-172831;-43947;0;31;Minas Gerais;4475;38;America/Sao_Paulo
 3301801;Engenheiro Paulo de Frontin;-225498;-436827;0;33;Rio de Janeiro;5835;24;America/Sao_Paulo
 4306924;Engenho Velho;-27706;-529145;0;43;Rio Grande do Sul;5947;54;America/Sao_Paulo
@@ -1673,665 +1673,665 @@ codigo_ibge;municipio;latitude;longitude;capital;codigo_uf;estado;siafi_id;ddd;f
 2910503;Entre Rios;-119392;-380871;0;29;Bahia;3509;75;America/Sao_Paulo
 4205175;Entre Rios;-267225;-525585;0;42;Santa Catarina;912;49;America/Sao_Paulo
 3123908;Entre Rios de Minas;-206706;-440654;0;31;Minas Gerais;4477;31;America/Sao_Paulo
-4107538;Entre Rios do Oeste;-247042;-542385;0;41;Paran·;5529;45;America/Sao_Paulo
+4107538;Entre Rios do Oeste;-247042;-542385;0;41;Paran√°;5529;45;America/Sao_Paulo
 4306957;Entre Rios do Sul;-275298;-527347;0;43;Rio Grande do Sul;8421;54;America/Sao_Paulo
-4306932;Entre-IjuÌs;-283686;-542686;0;43;Rio Grande do Sul;8419;55;America/Sao_Paulo
+4306932;Entre-Iju√≠s;-283686;-542686;0;43;Rio Grande do Sul;8419;55;America/Sao_Paulo
 1301506;Envira;-743789;-700281;0;13;Amazonas;231;97;America/Rio_Branco
-1200252;Epitaciol‚ndia;-110188;-687341;0;12;Acre;651;68;America/Rio_Branco
+1200252;Epitaciol√¢ndia;-110188;-687341;0;12;Acre;651;68;America/Rio_Branco
 2403400;Equador;-693835;-36717;0;24;Rio Grande do Norte;1667;84;America/Sao_Paulo
 4306973;Erebango;-278544;-523005;0;43;Rio Grande do Sul;8417;54;America/Sao_Paulo
 4307005;Erechim;-276364;-522697;0;43;Rio Grande do Sul;8637;54;America/Sao_Paulo
-2304277;ErerÍ;-602751;-383461;0;23;Cear·;1245;88;America/Sao_Paulo
-2900504;…rico Cardoso;-134215;-421352;0;29;Bahia;3309;77;America/Sao_Paulo
+2304277;Erer√™;-602751;-383461;0;23;Cear√°;1245;88;America/Sao_Paulo
+2900504;√ârico Cardoso;-134215;-421352;0;29;Bahia;3309;77;America/Sao_Paulo
 4205191;Ermo;-289869;-49643;0;42;Santa Catarina;914;48;America/Sao_Paulo
 4307054;Ernestina;-284977;-525836;0;43;Rio Grande do Sul;8415;54;America/Sao_Paulo
 4307203;Erval Grande;-273926;-52574;0;43;Rio Grande do Sul;8641;54;America/Sao_Paulo
 4307302;Erval Seco;-275443;-535005;0;43;Rio Grande do Sul;8643;55;America/Sao_Paulo
 4205209;Erval Velho;-272743;-51443;0;42;Santa Catarina;8101;49;America/Sao_Paulo
-3124005;Erv·lia;-208403;-426544;0;31;Minas Gerais;4479;32;America/Sao_Paulo
+3124005;Erv√°lia;-208403;-426544;0;31;Minas Gerais;4479;32;America/Sao_Paulo
 2605202;Escada;-835672;-352241;0;26;Pernambuco;2403;81;America/Sao_Paulo
 4307401;Esmeralda;-280518;-511933;0;43;Rio Grande do Sul;8645;54;America/Sao_Paulo
 3124104;Esmeraldas;-19764;-443065;0;31;Minas Gerais;4481;31;America/Sao_Paulo
 3124203;Espera Feliz;-206508;-419119;0;31;Minas Gerais;4483;32;America/Sao_Paulo
-2506004;EsperanÁa;-702278;-358597;0;25;ParaÌba;2021;83;America/Sao_Paulo
-4307450;EsperanÁa do Sul;-273603;-539891;0;43;Rio Grande do Sul;980;55;America/Sao_Paulo
-4107520;EsperanÁa Nova;-237238;-53811;0;41;Paran·;850;44;America/Sao_Paulo
+2506004;Esperan√ßa;-702278;-358597;0;25;Para√≠ba;2021;83;America/Sao_Paulo
+4307450;Esperan√ßa do Sul;-273603;-539891;0;43;Rio Grande do Sul;980;55;America/Sao_Paulo
+4107520;Esperan√ßa Nova;-237238;-53811;0;41;Paran√°;850;44;America/Sao_Paulo
 1707405;Esperantina;-536593;-485378;0;17;Tocantins;181;63;America/Sao_Paulo
-2203701;Esperantina;-388863;-422324;0;22;PiauÌ;1073;86;America/Sao_Paulo
-2104008;EsperantinÛpolis;-487938;-446926;0;21;Maranh„o;777;99;America/Sao_Paulo
-4107546;Espig„o Alto do IguaÁu;-254216;-528348;0;41;Paran·;852;46;America/Sao_Paulo
-1100098;Espig„o D'Oeste;-115266;-610252;0;11;RondÙnia;25;69;America/Porto_Velho
+2203701;Esperantina;-388863;-422324;0;22;Piau√≠;1073;86;America/Sao_Paulo
+2104008;Esperantin√≥polis;-487938;-446926;0;21;Maranh√£o;777;99;America/Sao_Paulo
+4107546;Espig√£o Alto do Igua√ßu;-254216;-528348;0;41;Paran√°;852;46;America/Sao_Paulo
+1100098;Espig√£o D'Oeste;-115266;-610252;0;11;Rond√¥nia;25;69;America/Porto_Velho
 3124302;Espinosa;-149249;-42809;0;31;Minas Gerais;4485;38;America/Sao_Paulo
-2403509;EspÌrito Santo;-633563;-353052;0;24;Rio Grande do Norte;1669;84;America/Sao_Paulo
-3124401;EspÌrito Santo do Dourado;-220454;-459548;0;31;Minas Gerais;4487;35;America/Sao_Paulo
-3515186;EspÌrito Santo do Pinhal;-221909;-467477;0;35;S„o Paulo;6865;19;America/Sao_Paulo
-3515194;EspÌrito Santo do Turvo;-226925;-494341;0;35;S„o Paulo;7253;14;America/Sao_Paulo
+2403509;Esp√≠rito Santo;-633563;-353052;0;24;Rio Grande do Norte;1669;84;America/Sao_Paulo
+3124401;Esp√≠rito Santo do Dourado;-220454;-459548;0;31;Minas Gerais;4487;35;America/Sao_Paulo
+3515186;Esp√≠rito Santo do Pinhal;-221909;-467477;0;35;S√£o Paulo;6865;19;America/Sao_Paulo
+3515194;Esp√≠rito Santo do Turvo;-226925;-494341;0;35;S√£o Paulo;7253;14;America/Sao_Paulo
 2910602;Esplanada;-117942;-379432;0;29;Bahia;3511;75;America/Sao_Paulo
 4307500;Espumoso;-287286;-528461;0;43;Rio Grande do Sul;8647;54;America/Sao_Paulo
-4307559;EstaÁ„o;-279135;-522635;0;43;Rio Grande do Sul;7301;54;America/Sao_Paulo
-2802106;Est‚ncia;-112659;-374484;0;28;Sergipe;3141;79;America/Sao_Paulo
-4307609;Est‚ncia Velha;-296535;-511843;0;43;Rio Grande do Sul;8649;51;America/Sao_Paulo
+4307559;Esta√ß√£o;-279135;-522635;0;43;Rio Grande do Sul;7301;54;America/Sao_Paulo
+2802106;Est√¢ncia;-112659;-374484;0;28;Sergipe;3141;79;America/Sao_Paulo
+4307609;Est√¢ncia Velha;-296535;-511843;0;43;Rio Grande do Sul;8649;51;America/Sao_Paulo
 4307708;Esteio;-29852;-511841;0;43;Rio Grande do Sul;8651;51;America/Sao_Paulo
 3124500;Estiva;-224577;-460191;0;31;Minas Gerais;4489;35;America/Sao_Paulo
-3557303;Estiva Gerbi;-222713;-469481;0;35;S„o Paulo;2959;19;America/Sao_Paulo
-2104057;Estreito;-656077;-474431;0;21;Maranh„o;963;99;America/Sao_Paulo
+3557303;Estiva Gerbi;-222713;-469481;0;35;S√£o Paulo;2959;19;America/Sao_Paulo
+2104057;Estreito;-656077;-474431;0;21;Maranh√£o;963;99;America/Sao_Paulo
 4307807;Estrela;-295002;-519495;0;43;Rio Grande do Sul;8653;51;America/Sao_Paulo
-3515202;Estrela d'Oeste;-202875;-504049;0;35;S„o Paulo;6405;17;America/Sao_Paulo
+3515202;Estrela d'Oeste;-202875;-504049;0;35;S√£o Paulo;6405;17;America/Sao_Paulo
 3124609;Estrela Dalva;-217412;-424574;0;31;Minas Gerais;4491;32;America/Sao_Paulo
 2702553;Estrela de Alagoas;-939089;-367644;0;27;Alagoas;2643;82;America/Sao_Paulo
-3124708;Estrela do Indai·;-195169;-457859;0;31;Minas Gerais;4493;37;America/Sao_Paulo
-5207501;Estrela do Norte;-138665;-490716;0;52;Goi·s;9351;62;America/Sao_Paulo
-3515301;Estrela do Norte;-224859;-516632;0;35;S„o Paulo;6407;18;America/Sao_Paulo
+3124708;Estrela do Indai√°;-195169;-457859;0;31;Minas Gerais;4493;37;America/Sao_Paulo
+5207501;Estrela do Norte;-138665;-490716;0;52;Goi√°s;9351;62;America/Sao_Paulo
+3515301;Estrela do Norte;-224859;-516632;0;35;S√£o Paulo;6407;18;America/Sao_Paulo
 3124807;Estrela do Sul;-187399;-476956;0;31;Minas Gerais;4495;34;America/Sao_Paulo
 4307815;Estrela Velha;-291713;-531639;0;43;Rio Grande do Sul;982;51;America/Sao_Paulo
 2910701;Euclides da Cunha;-105078;-390153;0;29;Bahia;3513;75;America/Sao_Paulo
-3515350;Euclides da Cunha Paulista;-225545;-525928;0;35;S„o Paulo;7255;18;America/Sao_Paulo
-4307831;EugÍnio de Castro;-285315;-541506;0;43;Rio Grande do Sul;8413;55;America/Sao_Paulo
-3124906;EugenÛpolis;-211002;-421878;0;31;Minas Gerais;4497;32;America/Sao_Paulo
-2910727;Eun·polis;-163715;-395821;0;29;Bahia;3117;73;America/Sao_Paulo
-2304285;EusÈbio;-38925;-384559;0;23;Cear·;1247;85;America/Sao_Paulo
-3125002;Ewbank da C‚mara;-215498;-435068;0;31;Minas Gerais;4499;32;America/Sao_Paulo
+3515350;Euclides da Cunha Paulista;-225545;-525928;0;35;S√£o Paulo;7255;18;America/Sao_Paulo
+4307831;Eug√™nio de Castro;-285315;-541506;0;43;Rio Grande do Sul;8413;55;America/Sao_Paulo
+3124906;Eugen√≥polis;-211002;-421878;0;31;Minas Gerais;4497;32;America/Sao_Paulo
+2910727;Eun√°polis;-163715;-395821;0;29;Bahia;3117;73;America/Sao_Paulo
+2304285;Eus√©bio;-38925;-384559;0;23;Cear√°;1247;85;America/Sao_Paulo
+3125002;Ewbank da C√¢mara;-215498;-435068;0;31;Minas Gerais;4499;32;America/Sao_Paulo
 3125101;Extrema;-22854;-463178;0;31;Minas Gerais;4501;35;America/Sao_Paulo
 2403608;Extremoz;-570143;-353048;0;24;Rio Grande do Norte;1671;84;America/Sao_Paulo
 2605301;Exu;-750364;-397238;0;26;Pernambuco;2405;87;America/Sao_Paulo
-2506103;Fagundes;-734454;-357931;0;25;ParaÌba;2023;83;America/Sao_Paulo
+2506103;Fagundes;-734454;-357931;0;25;Para√≠ba;2023;83;America/Sao_Paulo
 4307864;Fagundes Varela;-288794;-517014;0;43;Rio Grande do Sul;8411;54;America/Sao_Paulo
-5207535;Faina;-154473;-503622;0;52;Goi·s;9797;62;America/Sao_Paulo
+5207535;Faina;-154473;-503622;0;52;Goi√°s;9797;62;America/Sao_Paulo
 3125200;Fama;-214089;-458286;0;31;Minas Gerais;4503;35;America/Sao_Paulo
 3125309;Faria Lemos;-208097;-420213;0;31;Minas Gerais;4505;32;America/Sao_Paulo
-2304301;Farias Brito;-692146;-395651;0;23;Cear·;1387;88;America/Sao_Paulo
-1503002;Faro;-216805;-567405;0;15;Par·;459;93;America/Sao_Paulo
-4107553;Farol;-240958;-526217;0;41;Paran·;5511;44;America/Sao_Paulo
+2304301;Farias Brito;-692146;-395651;0;23;Cear√°;1387;88;America/Sao_Paulo
+1503002;Faro;-216805;-567405;0;15;Par√°;459;93;America/Sao_Paulo
+4107553;Farol;-240958;-526217;0;41;Paran√°;5511;44;America/Sao_Paulo
 4307906;Farroupilha;-292227;-513419;0;43;Rio Grande do Sul;8655;54;America/Sao_Paulo
-3515400;Fartura;-233916;-495124;0;35;S„o Paulo;6409;14;America/Sao_Paulo
-2203750;Fartura do PiauÌ;-948342;-427912;0;22;PiauÌ;2257;89;America/Sao_Paulo
-1707553;F·tima;-107603;-489076;0;17;Tocantins;9683;63;America/Sao_Paulo
-2910750;F·tima;-10616;-382239;0;29;Bahia;3089;75;America/Sao_Paulo
-5003801;F·tima do Sul;-223789;-545131;0;50;Mato Grosso do Sul;9075;67;America/Porto_Velho
-4107603;Faxinal;-240077;-513227;0;41;Paran·;7549;43;America/Sao_Paulo
+3515400;Fartura;-233916;-495124;0;35;S√£o Paulo;6409;14;America/Sao_Paulo
+2203750;Fartura do Piau√≠;-948342;-427912;0;22;Piau√≠;2257;89;America/Sao_Paulo
+1707553;F√°tima;-107603;-489076;0;17;Tocantins;9683;63;America/Sao_Paulo
+2910750;F√°tima;-10616;-382239;0;29;Bahia;3089;75;America/Sao_Paulo
+5003801;F√°tima do Sul;-223789;-545131;0;50;Mato Grosso do Sul;9075;67;America/Porto_Velho
+4107603;Faxinal;-240077;-513227;0;41;Paran√°;7549;43;America/Sao_Paulo
 4308003;Faxinal do Soturno;-295788;-534484;0;43;Rio Grande do Sul;8657;55;America/Sao_Paulo
 4205308;Faxinal dos Guedes;-268451;-522596;0;42;Santa Catarina;8103;49;America/Sao_Paulo
 4308052;Faxinalzinho;-274238;-526789;0;43;Rio Grande do Sul;8409;54;America/Sao_Paulo
-5207600;Fazenda Nova;-161834;-507781;0;52;Goi·s;9353;62;America/Sao_Paulo
-4107652;Fazenda Rio Grande;-256624;-493073;0;41;Paran·;9983;41;America/Sao_Paulo
+5207600;Fazenda Nova;-161834;-507781;0;52;Goi√°s;9353;62;America/Sao_Paulo
+4107652;Fazenda Rio Grande;-256624;-493073;0;41;Paran√°;9983;41;America/Sao_Paulo
 4308078;Fazenda Vilanova;-295885;-518217;0;43;Rio Grande do Sul;984;51;America/Sao_Paulo
-1200302;FeijÛ;-817054;-70351;0;12;Acre;113;68;America/Rio_Branco
+1200302;Feij√≥;-817054;-70351;0;12;Acre;113;68;America/Rio_Branco
 2910776;Feira da Mata;-142044;-442744;0;29;Bahia;3275;77;America/Sao_Paulo
 2910800;Feira de Santana;-122664;-389663;0;29;Bahia;3515;75;America/Sao_Paulo
 2702603;Feira Grande;-989859;-366815;0;27;Alagoas;2751;82;America/Sao_Paulo
 2605400;Feira Nova;-794704;-353801;0;26;Pernambuco;2407;81;America/Sao_Paulo
 2802205;Feira Nova;-102616;-373147;0;28;Sergipe;3143;79;America/Sao_Paulo
-2104073;Feira Nova do Maranh„o;-696508;-466786;0;21;Maranh„o;156;99;America/Sao_Paulo
-3125408;FelÌcio dos Santos;-180755;-432422;0;31;Minas Gerais;4507;38;America/Sao_Paulo
+2104073;Feira Nova do Maranh√£o;-696508;-466786;0;21;Maranh√£o;156;99;America/Sao_Paulo
+3125408;Fel√≠cio dos Santos;-180755;-432422;0;31;Minas Gerais;4507;38;America/Sao_Paulo
 2403707;Felipe Guerra;-559274;-376875;0;24;Rio Grande do Norte;1673;84;America/Sao_Paulo
 3125606;Felisburgo;-166348;-407605;0;31;Minas Gerais;4511;33;America/Sao_Paulo
-3125705;Felixl‚ndia;-187507;-449004;0;31;Minas Gerais;4513;38;America/Sao_Paulo
+3125705;Felixl√¢ndia;-187507;-449004;0;31;Minas Gerais;4513;38;America/Sao_Paulo
 4308102;Feliz;-294527;-513032;0;43;Rio Grande do Sul;8659;51;America/Sao_Paulo
 2702702;Feliz Deserto;-102935;-363028;0;27;Alagoas;2753;82;America/Sao_Paulo
 5103700;Feliz Natal;-12385;-549227;0;51;Mato Grosso;1036;66;America/Porto_Velho
-4107702;FÍnix;-239135;-519805;0;41;Paran·;7551;44;America/Sao_Paulo
-4107736;Fernandes Pinheiro;-254107;-505456;0;41;Paran·;854;42;America/Sao_Paulo
+4107702;F√™nix;-239135;-519805;0;41;Paran√°;7551;44;America/Sao_Paulo
+4107736;Fernandes Pinheiro;-254107;-505456;0;41;Paran√°;854;42;America/Sao_Paulo
 3125804;Fernandes Tourinho;-191541;-420803;0;31;Minas Gerais;4515;33;America/Sao_Paulo
 2605459;Fernando de Noronha;-38396;-324107;0;26;Pernambuco;3001;81;America/Noronha
-2104081;Fernando Falc„o;-616207;-448979;0;21;Maranh„o;158;99;America/Sao_Paulo
+2104081;Fernando Falc√£o;-616207;-448979;0;21;Maranh√£o;158;99;America/Sao_Paulo
 2403756;Fernando Pedroza;-569096;-365282;0;24;Rio Grande do Norte;416;84;America/Sao_Paulo
-3515608;Fernando Prestes;-212661;-486874;0;35;S„o Paulo;6413;16;America/Sao_Paulo
-3515509;FernandÛpolis;-202806;-502471;0;35;S„o Paulo;6411;17;America/Sao_Paulo
-3515657;Fern„o;-223607;-495187;0;35;S„o Paulo;796;14;America/Sao_Paulo
-3515707;Ferraz de Vasconcelos;-235411;-46371;0;35;S„o Paulo;6415;11;America/Sao_Paulo
-1600238;Ferreira Gomes;857256;-511795;0;16;Amap·;611;96;America/Sao_Paulo
+3515608;Fernando Prestes;-212661;-486874;0;35;S√£o Paulo;6413;16;America/Sao_Paulo
+3515509;Fernand√≥polis;-202806;-502471;0;35;S√£o Paulo;6411;17;America/Sao_Paulo
+3515657;Fern√£o;-223607;-495187;0;35;S√£o Paulo;796;14;America/Sao_Paulo
+3515707;Ferraz de Vasconcelos;-235411;-46371;0;35;S√£o Paulo;6415;11;America/Sao_Paulo
+1600238;Ferreira Gomes;857256;-511795;0;16;Amap√°;611;96;America/Sao_Paulo
 2605509;Ferreiros;-744666;-352373;0;26;Pernambuco;2409;81;America/Sao_Paulo
 3125903;Ferros;-192343;-430192;0;31;Minas Gerais;4517;31;America/Sao_Paulo
 3125952;Fervedouro;-20726;-42279;0;31;Minas Gerais;2683;32;America/Sao_Paulo
-4107751;Figueira;-238455;-504031;0;41;Paran·;8457;43;America/Sao_Paulo
-5003900;Figueir„o;-186782;-53638;0;50;Mato Grosso do Sul;1178;67;America/Porto_Velho
-1707652;FigueirÛpolis;-121312;-491748;0;17;Tocantins;9667;63;America/Sao_Paulo
-5103809;FigueirÛpolis D'Oeste;-154439;-587391;0;51;Mato Grosso;9881;65;America/Porto_Velho
-1707702;FiladÈlfia;-733501;-474954;0;17;Tocantins;9355;63;America/Sao_Paulo
-2910859;FiladÈlfia;-107405;-401437;0;29;Bahia;3091;74;America/Sao_Paulo
+4107751;Figueira;-238455;-504031;0;41;Paran√°;8457;43;America/Sao_Paulo
+5003900;Figueir√£o;-186782;-53638;0;50;Mato Grosso do Sul;1178;67;America/Porto_Velho
+1707652;Figueir√≥polis;-121312;-491748;0;17;Tocantins;9667;63;America/Sao_Paulo
+5103809;Figueir√≥polis D'Oeste;-154439;-587391;0;51;Mato Grosso;9881;65;America/Porto_Velho
+1707702;Filad√©lfia;-733501;-474954;0;17;Tocantins;9355;63;America/Sao_Paulo
+2910859;Filad√©lfia;-107405;-401437;0;29;Bahia;3091;74;America/Sao_Paulo
 2910909;Firmino Alves;-149823;-399269;0;29;Bahia;3517;73;America/Sao_Paulo
-5207808;FirminÛpolis;-165778;-50304;0;52;Goi·s;9357;64;America/Sao_Paulo
+5207808;Firmin√≥polis;-165778;-50304;0;52;Goi√°s;9357;64;America/Sao_Paulo
 2702801;Flexeiras;-927281;-357139;0;27;Alagoas;2755;82;America/Sao_Paulo
-4107850;Flor da Serra do Sul;-262523;-533092;0;41;Paran·;5475;46;America/Sao_Paulo
-4205357;Flor do Sert„o;-267811;-533505;0;42;Santa Catarina;916;49;America/Sao_Paulo
-3515806;Flora Rica;-216727;-513821;0;35;S„o Paulo;6417;18;America/Sao_Paulo
-4107801;FloraÌ;-233178;-523029;0;41;Paran·;7553;44;America/Sao_Paulo
-2403806;Flor‚nia;-612264;-368226;0;24;Rio Grande do Norte;1675;84;America/Sao_Paulo
-3515905;Floreal;-206752;-501513;0;35;S„o Paulo;6419;17;America/Sao_Paulo
+4107850;Flor da Serra do Sul;-262523;-533092;0;41;Paran√°;5475;46;America/Sao_Paulo
+4205357;Flor do Sert√£o;-267811;-533505;0;42;Santa Catarina;916;49;America/Sao_Paulo
+3515806;Flora Rica;-216727;-513821;0;35;S√£o Paulo;6417;18;America/Sao_Paulo
+4107801;Flora√≠;-233178;-523029;0;41;Paran√°;7553;44;America/Sao_Paulo
+2403806;Flor√¢nia;-612264;-368226;0;24;Rio Grande do Norte;1675;84;America/Sao_Paulo
+3515905;Floreal;-206752;-501513;0;35;S√£o Paulo;6419;17;America/Sao_Paulo
 2605608;Flores;-785842;-379715;0;26;Pernambuco;2411;87;America/Sao_Paulo
 4308201;Flores da Cunha;-290261;-511875;0;43;Rio Grande do Sul;8661;54;America/Sao_Paulo
-5207907;Flores de Goi·s;-144451;-470417;0;52;Goi·s;9359;62;America/Sao_Paulo
-2203800;Flores do PiauÌ;-778793;-42918;0;22;PiauÌ;1075;89;America/Sao_Paulo
-4107900;Floresta;-236031;-520807;0;41;Paran·;7555;44;America/Sao_Paulo
+5207907;Flores de Goi√°s;-144451;-470417;0;52;Goi√°s;9359;62;America/Sao_Paulo
+2203800;Flores do Piau√≠;-778793;-42918;0;22;Piau√≠;1075;89;America/Sao_Paulo
+4107900;Floresta;-236031;-520807;0;41;Paran√°;7555;44;America/Sao_Paulo
 2605707;Floresta;-860307;-385687;0;26;Pernambuco;2413;87;America/Sao_Paulo
 2911006;Floresta Azul;-148629;-396579;0;29;Bahia;3519;73;America/Sao_Paulo
-1503044;Floresta do Araguaia;-755335;-497125;0;15;Par·;52;94;America/Sao_Paulo
-2203859;Floresta do PiauÌ;-746682;-417883;0;22;PiauÌ;314;89;America/Sao_Paulo
+1503044;Floresta do Araguaia;-755335;-497125;0;15;Par√°;52;94;America/Sao_Paulo
+2203859;Floresta do Piau√≠;-746682;-417883;0;22;Piau√≠;314;89;America/Sao_Paulo
 3126000;Florestal;-19888;-444318;0;31;Minas Gerais;4519;31;America/Sao_Paulo
-4108007;FlorestÛpolis;-228623;-513882;0;41;Paran·;7557;43;America/Sao_Paulo
-2203909;Floriano;-677182;-430241;0;22;PiauÌ;1077;89;America/Sao_Paulo
+4108007;Florest√≥polis;-228623;-513882;0;41;Paran√°;7557;43;America/Sao_Paulo
+2203909;Floriano;-677182;-430241;0;22;Piau√≠;1077;89;America/Sao_Paulo
 4308250;Floriano Peixoto;-278614;-520838;0;43;Rio Grande do Sul;986;54;America/Sao_Paulo
-4205407;FlorianÛpolis;-275945;-485477;1;42;Santa Catarina;8105;48;America/Sao_Paulo
-4108106;FlÛrida;-230847;-519546;0;41;Paran·;7559;44;America/Sao_Paulo
-3516002;FlÛrida Paulista;-216127;-511724;0;35;S„o Paulo;6421;18;America/Sao_Paulo
-3516101;FlorÌnia;-22868;-506814;0;35;S„o Paulo;6423;18;America/Sao_Paulo
+4205407;Florian√≥polis;-275945;-485477;1;42;Santa Catarina;8105;48;America/Sao_Paulo
+4108106;Fl√≥rida;-230847;-519546;0;41;Paran√°;7559;44;America/Sao_Paulo
+3516002;Fl√≥rida Paulista;-216127;-511724;0;35;S√£o Paulo;6421;18;America/Sao_Paulo
+3516101;Flor√≠nia;-22868;-506814;0;35;S√£o Paulo;6423;18;America/Sao_Paulo
 1301605;Fonte Boa;-252342;-660942;0;13;Amazonas;233;97;America/Porto_Velho
 4308300;Fontoura Xavier;-289817;-523445;0;43;Rio Grande do Sul;8663;54;America/Sao_Paulo
 3126109;Formiga;-204618;-454268;0;31;Minas Gerais;4521;37;America/Sao_Paulo
 4308409;Formigueiro;-300035;-534959;0;43;Rio Grande do Sul;8665;55;America/Sao_Paulo
-5208004;Formosa;-1554;-47337;0;52;Goi·s;9361;61;America/Sao_Paulo
-2104099;Formosa da Serra Negra;-644017;-461916;0;21;Maranh„o;160;99;America/Sao_Paulo
-4108205;Formosa do Oeste;-242951;-533114;0;41;Paran·;7561;44;America/Sao_Paulo
+5208004;Formosa;-1554;-47337;0;52;Goi√°s;9361;61;America/Sao_Paulo
+2104099;Formosa da Serra Negra;-644017;-461916;0;21;Maranh√£o;160;99;America/Sao_Paulo
+4108205;Formosa do Oeste;-242951;-533114;0;41;Paran√°;7561;44;America/Sao_Paulo
 2911105;Formosa do Rio Preto;-110328;-45193;0;29;Bahia;3521;77;America/Sao_Paulo
 4205431;Formosa do Sul;-266453;-527946;0;42;Santa Catarina;5581;49;America/Sao_Paulo
-5208103;Formoso;-136499;-488775;0;52;Goi·s;9363;62;America/Sao_Paulo
+5208103;Formoso;-136499;-488775;0;52;Goi√°s;9363;62;America/Sao_Paulo
 3126208;Formoso;-149446;-462371;0;31;Minas Gerais;4523;38;America/Sao_Paulo
 1708205;Formoso do Araguaia;-117976;-495316;0;17;Tocantins;9365;63;America/Sao_Paulo
 4308433;Forquetinha;-293828;-520981;0;43;Rio Grande do Sul;1142;51;America/Sao_Paulo
-2304350;Forquilha;-379945;-402634;0;23;Cear·;1591;88;America/Sao_Paulo
+2304350;Forquilha;-379945;-402634;0;23;Cear√°;1591;88;America/Sao_Paulo
 4205456;Forquilhinha;-287454;-494785;0;42;Santa Catarina;973;48;America/Sao_Paulo
-2304400;Fortaleza;-371664;-385423;1;23;Cear·;1389;85;America/Sao_Paulo
+2304400;Fortaleza;-371664;-385423;1;23;Cear√°;1389;85;America/Sao_Paulo
 3126307;Fortaleza de Minas;-208508;-46712;0;31;Minas Gerais;4525;35;America/Sao_Paulo
-1708254;Fortaleza do Taboc„o;-905611;-485206;0;17;Tocantins;345;63;America/Sao_Paulo
-2104107;Fortaleza dos Nogueiras;-695983;-461749;0;21;Maranh„o;779;99;America/Sao_Paulo
+1708254;Fortaleza do Taboc√£o;-905611;-485206;0;17;Tocantins;345;63;America/Sao_Paulo
+2104107;Fortaleza dos Nogueiras;-695983;-461749;0;21;Maranh√£o;779;99;America/Sao_Paulo
 4308458;Fortaleza dos Valos;-287986;-532249;0;43;Rio Grande do Sul;9827;55;America/Sao_Paulo
-2304459;Fortim;-445126;-377981;0;23;Cear·;987;88;America/Sao_Paulo
-2104206;Fortuna;-572792;-441565;0;21;Maranh„o;781;99;America/Sao_Paulo
+2304459;Fortim;-445126;-377981;0;23;Cear√°;987;88;America/Sao_Paulo
+2104206;Fortuna;-572792;-441565;0;21;Maranh√£o;781;99;America/Sao_Paulo
 3126406;Fortuna de Minas;-195578;-444472;0;31;Minas Gerais;4527;31;America/Sao_Paulo
-4108304;Foz do IguaÁu;-255427;-545827;0;41;Paran·;7563;45;America/Sao_Paulo
-4108452;Foz do Jord„o;-257371;-521188;0;41;Paran·;856;42;America/Sao_Paulo
+4108304;Foz do Igua√ßu;-255427;-545827;0;41;Paran√°;7563;45;America/Sao_Paulo
+4108452;Foz do Jord√£o;-257371;-521188;0;41;Paran√°;856;42;America/Sao_Paulo
 4205506;Fraiburgo;-270233;-5092;0;42;Santa Catarina;8107;49;America/Sao_Paulo
-3516200;Franca;-205352;-474039;0;35;S„o Paulo;6425;16;America/Sao_Paulo
-2204006;FrancinÛpolis;-639334;-422591;0;22;PiauÌ;1079;89;America/Sao_Paulo
-4108320;Francisco Alves;-240667;-538461;0;41;Paran·;7977;44;America/Sao_Paulo
-2204105;Francisco Ayres;-662606;-426881;0;22;PiauÌ;1081;89;America/Sao_Paulo
-3126505;Francisco BadarÛ;-169883;-423568;0;31;Minas Gerais;4529;33;America/Sao_Paulo
-4108403;Francisco Beltr„o;-260817;-530535;0;41;Paran·;7565;46;America/Sao_Paulo
+3516200;Franca;-205352;-474039;0;35;S√£o Paulo;6425;16;America/Sao_Paulo
+2204006;Francin√≥polis;-639334;-422591;0;22;Piau√≠;1079;89;America/Sao_Paulo
+4108320;Francisco Alves;-240667;-538461;0;41;Paran√°;7977;44;America/Sao_Paulo
+2204105;Francisco Ayres;-662606;-426881;0;22;Piau√≠;1081;89;America/Sao_Paulo
+3126505;Francisco Badar√≥;-169883;-423568;0;31;Minas Gerais;4529;33;America/Sao_Paulo
+4108403;Francisco Beltr√£o;-260817;-530535;0;41;Paran√°;7565;46;America/Sao_Paulo
 2403905;Francisco Dantas;-607234;-381212;0;24;Rio Grande do Norte;1677;84;America/Sao_Paulo
 3126604;Francisco Dumont;-173107;-442317;0;31;Minas Gerais;4531;38;America/Sao_Paulo
-2204154;Francisco Macedo;-7331;-40788;0;22;PiauÌ;316;89;America/Sao_Paulo
-3516309;Francisco Morato;-232792;-467448;0;35;S„o Paulo;6427;11;America/Sao_Paulo
-3126703;Francisco S·;-164827;-434896;0;31;Minas Gerais;4533;38;America/Sao_Paulo
-2204204;Francisco Santos;-699491;-411288;0;22;PiauÌ;1083;89;America/Sao_Paulo
-3126752;FranciscÛpolis;-179578;-420094;0;31;Minas Gerais;608;33;America/Sao_Paulo
-3516408;Franco da Rocha;-233229;-46729;0;35;S„o Paulo;6429;11;America/Sao_Paulo
-2304509;Frecheirinha;-375557;-40818;0;23;Cear·;1391;88;America/Sao_Paulo
+2204154;Francisco Macedo;-7331;-40788;0;22;Piau√≠;316;89;America/Sao_Paulo
+3516309;Francisco Morato;-232792;-467448;0;35;S√£o Paulo;6427;11;America/Sao_Paulo
+3126703;Francisco S√°;-164827;-434896;0;31;Minas Gerais;4533;38;America/Sao_Paulo
+2204204;Francisco Santos;-699491;-411288;0;22;Piau√≠;1083;89;America/Sao_Paulo
+3126752;Francisc√≥polis;-179578;-420094;0;31;Minas Gerais;608;33;America/Sao_Paulo
+3516408;Franco da Rocha;-233229;-46729;0;35;S√£o Paulo;6429;11;America/Sao_Paulo
+2304509;Frecheirinha;-375557;-40818;0;23;Cear√°;1391;88;America/Sao_Paulo
 4308508;Frederico Westphalen;-273586;-533958;0;43;Rio Grande do Sul;8667;55;America/Sao_Paulo
 3126802;Frei Gaspar;-180709;-414325;0;31;Minas Gerais;4535;33;America/Sao_Paulo
-3126901;Frei InocÍncio;-185556;-419121;0;31;Minas Gerais;4537;33;America/Sao_Paulo
+3126901;Frei Inoc√™ncio;-185556;-419121;0;31;Minas Gerais;4537;33;America/Sao_Paulo
 3126950;Frei Lagonegro;-181751;-427617;0;31;Minas Gerais;610;33;America/Sao_Paulo
-2506202;Frei Martinho;-639759;-364526;0;25;ParaÌba;2025;83;America/Sao_Paulo
+2506202;Frei Martinho;-639759;-364526;0;25;Para√≠ba;2025;83;America/Sao_Paulo
 2605806;Frei Miguelinho;-793918;-359113;0;26;Pernambuco;2415;81;America/Sao_Paulo
 2802304;Frei Paulo;-105513;-375279;0;28;Sergipe;3145;79;America/Sao_Paulo
-4205555;Frei RogÈrio;-27175;-508076;0;42;Santa Catarina;918;49;America/Sao_Paulo
+4205555;Frei Rog√©rio;-27175;-508076;0;42;Santa Catarina;918;49;America/Sao_Paulo
 3127008;Fronteira;-202748;-491984;0;31;Minas Gerais;4539;34;America/Sao_Paulo
 3127057;Fronteira dos Vales;-168898;-40923;0;31;Minas Gerais;4935;33;America/Sao_Paulo
-2204303;Fronteiras;-708173;-406146;0;22;PiauÌ;1085;89;America/Sao_Paulo
+2204303;Fronteiras;-708173;-406146;0;22;Piau√≠;1085;89;America/Sao_Paulo
 3127073;Fruta de Leite;-161225;-425288;0;31;Minas Gerais;612;38;America/Sao_Paulo
 3127107;Frutal;-200259;-489355;0;31;Minas Gerais;4541;34;America/Sao_Paulo
 2404002;Frutuoso Gomes;-615669;-378375;0;24;Rio Grande do Norte;1751;84;America/Sao_Paulo
-3202207;Fund„o;-19937;-404078;0;32;EspÌrito Santo;5643;27;America/Sao_Paulo
-3127206;Funil‚ndia;-193661;-44061;0;31;Minas Gerais;4543;31;America/Sao_Paulo
-3516507;Gabriel Monteiro;-215294;-505573;0;35;S„o Paulo;6431;18;America/Sao_Paulo
-2506251;Gado Bravo;-758279;-357899;0;25;ParaÌba;480;83;America/Sao_Paulo
-3516606;G·lia;-222918;-495504;0;35;S„o Paulo;6433;14;America/Sao_Paulo
-3127305;GalilÈia;-190005;-415387;0;31;Minas Gerais;4545;33;America/Sao_Paulo
+3202207;Fund√£o;-19937;-404078;0;32;Esp√≠rito Santo;5643;27;America/Sao_Paulo
+3127206;Funil√¢ndia;-193661;-44061;0;31;Minas Gerais;4543;31;America/Sao_Paulo
+3516507;Gabriel Monteiro;-215294;-505573;0;35;S√£o Paulo;6431;18;America/Sao_Paulo
+2506251;Gado Bravo;-758279;-357899;0;25;Para√≠ba;480;83;America/Sao_Paulo
+3516606;G√°lia;-222918;-495504;0;35;S√£o Paulo;6433;14;America/Sao_Paulo
+3127305;Galil√©ia;-190005;-415387;0;31;Minas Gerais;4545;33;America/Sao_Paulo
 2404101;Galinhos;-50909;-362754;0;24;Rio Grande do Norte;1679;84;America/Sao_Paulo
-4205605;Galv„o;-264549;-526875;0;42;Santa Catarina;8109;49;America/Sao_Paulo
+4205605;Galv√£o;-264549;-526875;0;42;Santa Catarina;8109;49;America/Sao_Paulo
 2605905;Gameleira;-85798;-353846;0;26;Pernambuco;2417;81;America/Sao_Paulo
-5208152;Gameleira de Goi·s;-164854;-486454;0;52;Goi·s;1072;62;America/Sao_Paulo
+5208152;Gameleira de Goi√°s;-164854;-486454;0;52;Goi√°s;1072;62;America/Sao_Paulo
 3127339;Gameleiras;-150829;-43125;0;31;Minas Gerais;614;38;America/Sao_Paulo
 2911204;Gandu;-137441;-394747;0;29;Bahia;3523;73;America/Sao_Paulo
 2606002;Garanhuns;-888243;-364966;0;26;Pernambuco;2419;87;America/Sao_Paulo
 2802403;Gararu;-99722;-370869;0;28;Sergipe;3149;79;America/Sao_Paulo
-3516705;GarÁa;-222125;-496546;0;35;S„o Paulo;6435;14;America/Sao_Paulo
+3516705;Gar√ßa;-222125;-496546;0;35;S√£o Paulo;6435;14;America/Sao_Paulo
 4308607;Garibaldi;-29259;-515352;0;43;Rio Grande do Sul;8669;54;America/Sao_Paulo
 4205704;Garopaba;-280275;-486192;0;42;Santa Catarina;8113;48;America/Sao_Paulo
-1503077;Garraf„o do Norte;-192986;-470505;0;15;Par·;585;91;America/Sao_Paulo
+1503077;Garraf√£o do Norte;-192986;-470505;0;15;Par√°;585;91;America/Sao_Paulo
 4308656;Garruchos;-281944;-556383;0;43;Rio Grande do Sul;6081;55;America/Sao_Paulo
 4205803;Garuva;-260292;-48852;0;42;Santa Catarina;8115;47;America/Sao_Paulo
 4205902;Gaspar;-269336;-489534;0;42;Santa Catarina;8117;47;America/Sao_Paulo
-3516804;Gast„o Vidigal;-207948;-501912;0;35;S„o Paulo;6437;17;America/Sao_Paulo
-5103858;Ga˙cha do Norte;-132443;-530809;0;51;Mato Grosso;1038;66;America/Porto_Velho
+3516804;Gast√£o Vidigal;-207948;-501912;0;35;S√£o Paulo;6437;17;America/Sao_Paulo
+5103858;Ga√∫cha do Norte;-132443;-530809;0;51;Mato Grosso;1038;66;America/Porto_Velho
 4308706;Gaurama;-275856;-520915;0;43;Rio Grande do Sul;8671;54;America/Sao_Paulo
-2911253;Gavi„o;-114688;-397757;0;29;Bahia;3093;75;America/Sao_Paulo
-3516853;Gavi„o Peixoto;-218367;-484957;0;35;S„o Paulo;798;16;America/Sao_Paulo
-2204352;Geminiano;-715476;-413409;0;22;PiauÌ;318;89;America/Sao_Paulo
-4308805;General C‚mara;-299032;-517612;0;43;Rio Grande do Sul;8673;51;America/Sao_Paulo
+2911253;Gavi√£o;-114688;-397757;0;29;Bahia;3093;75;America/Sao_Paulo
+3516853;Gavi√£o Peixoto;-218367;-484957;0;35;S√£o Paulo;798;16;America/Sao_Paulo
+2204352;Geminiano;-715476;-413409;0;22;Piau√≠;318;89;America/Sao_Paulo
+4308805;General C√¢mara;-299032;-517612;0;43;Rio Grande do Sul;8673;51;America/Sao_Paulo
 5103908;General Carneiro;-157094;-527574;0;51;Mato Grosso;9077;66;America/Porto_Velho
-4108502;General Carneiro;-26425;-513172;0;41;Paran·;7567;42;America/Sao_Paulo
+4108502;General Carneiro;-26425;-513172;0;41;Paran√°;7567;42;America/Sao_Paulo
 2802502;General Maynard;-106835;-369838;0;28;Sergipe;3147;79;America/Sao_Paulo
-3516903;General Salgado;-206485;-50364;0;35;S„o Paulo;6439;17;America/Sao_Paulo
-2304608;General Sampaio;-404351;-39454;0;23;Cear·;1393;85;America/Sao_Paulo
+3516903;General Salgado;-206485;-50364;0;35;S√£o Paulo;6439;17;America/Sao_Paulo
+2304608;General Sampaio;-404351;-39454;0;23;Cear√°;1393;85;America/Sao_Paulo
 4308854;Gentil;-284316;-520337;0;43;Rio Grande do Sul;5799;54;America/Sao_Paulo
 2911303;Gentio do Ouro;-114342;-425077;0;29;Bahia;3525;74;America/Sao_Paulo
-3517000;Getulina;-217961;-499312;0;35;S„o Paulo;6441;14;America/Sao_Paulo
-4308904;Get˙lio Vargas;-278911;-522294;0;43;Rio Grande do Sul;8677;54;America/Sao_Paulo
-2204402;GilbuÈs;-983001;-453423;0;22;PiauÌ;1087;89;America/Sao_Paulo
+3517000;Getulina;-217961;-499312;0;35;S√£o Paulo;6441;14;America/Sao_Paulo
+4308904;Get√∫lio Vargas;-278911;-522294;0;43;Rio Grande do Sul;8677;54;America/Sao_Paulo
+2204402;Gilbu√©s;-983001;-453423;0;22;Piau√≠;1087;89;America/Sao_Paulo
 2702900;Girau do Ponciano;-988404;-368316;0;27;Alagoas;2757;82;America/Sao_Paulo
-4309001;Giru·;-280297;-543517;0;43;Rio Grande do Sul;8679;55;America/Sao_Paulo
-3127354;Glaucil‚ndia;-168481;-43692;0;31;Minas Gerais;616;38;America/Sao_Paulo
-3517109;GlicÈrio;-213812;-502123;0;35;S„o Paulo;6443;18;America/Sao_Paulo
-2911402;GlÛria;-934382;-382544;0;29;Bahia;3527;75;America/Sao_Paulo
-5103957;GlÛria D'Oeste;-15768;-583108;0;51;Mato Grosso;135;65;America/Porto_Velho
-5004007;GlÛria de Dourados;-224136;-542335;0;50;Mato Grosso do Sul;9079;67;America/Porto_Velho
-2606101;GlÛria do Goit·;-800568;-352904;0;26;Pernambuco;2421;81;America/Sao_Paulo
+4309001;Giru√°;-280297;-543517;0;43;Rio Grande do Sul;8679;55;America/Sao_Paulo
+3127354;Glaucil√¢ndia;-168481;-43692;0;31;Minas Gerais;616;38;America/Sao_Paulo
+3517109;Glic√©rio;-213812;-502123;0;35;S√£o Paulo;6443;18;America/Sao_Paulo
+2911402;Gl√≥ria;-934382;-382544;0;29;Bahia;3527;75;America/Sao_Paulo
+5103957;Gl√≥ria D'Oeste;-15768;-583108;0;51;Mato Grosso;135;65;America/Porto_Velho
+5004007;Gl√≥ria de Dourados;-224136;-542335;0;50;Mato Grosso do Sul;9079;67;America/Porto_Velho
+2606101;Gl√≥ria do Goit√°;-800568;-352904;0;26;Pernambuco;2421;81;America/Sao_Paulo
 4309050;Glorinha;-298798;-507734;0;43;Rio Grande do Sul;8407;51;America/Sao_Paulo
-2104305;Godofredo Viana;-140259;-457795;0;21;Maranh„o;783;98;America/Sao_Paulo
-4108551;Godoy Moreira;-24173;-519246;0;41;Paran·;9947;43;America/Sao_Paulo
+2104305;Godofredo Viana;-140259;-457795;0;21;Maranh√£o;783;98;America/Sao_Paulo
+4108551;Godoy Moreira;-24173;-519246;0;41;Paran√°;9947;43;America/Sao_Paulo
 3127370;Goiabeira;-189807;-412235;0;31;Minas Gerais;618;33;America/Sao_Paulo
-3127388;Goian·;-21536;-431957;0;31;Minas Gerais;620;32;America/Sao_Paulo
+3127388;Goian√°;-21536;-431957;0;31;Minas Gerais;620;32;America/Sao_Paulo
 2606200;Goiana;-75606;-349959;0;26;Pernambuco;2423;81;America/Sao_Paulo
-5208400;Goian·polis;-165098;-490234;0;52;Goi·s;9367;62;America/Sao_Paulo
-5208509;Goiandira;-181352;-480875;0;52;Goi·s;9369;64;America/Sao_Paulo
-5208608;GoianÈsia;-153118;-491162;0;52;Goi·s;9371;62;America/Sao_Paulo
-1503093;GoianÈsia do Par·;-384338;-490974;0;15;Par·;627;94;America/Sao_Paulo
-5208707;Goi‚nia;-166864;-492643;1;52;Goi·s;9373;62;America/Sao_Paulo
+5208400;Goian√°polis;-165098;-490234;0;52;Goi√°s;9367;62;America/Sao_Paulo
+5208509;Goiandira;-181352;-480875;0;52;Goi√°s;9369;64;America/Sao_Paulo
+5208608;Goian√©sia;-153118;-491162;0;52;Goi√°s;9371;62;America/Sao_Paulo
+1503093;Goian√©sia do Par√°;-384338;-490974;0;15;Par√°;627;94;America/Sao_Paulo
+5208707;Goi√¢nia;-166864;-492643;1;52;Goi√°s;9373;62;America/Sao_Paulo
 2404200;Goianinha;-626486;-351943;0;24;Rio Grande do Norte;1681;84;America/Sao_Paulo
-5208806;Goianira;-164947;-49427;0;52;Goi·s;9375;62;America/Sao_Paulo
+5208806;Goianira;-164947;-49427;0;52;Goi√°s;9375;62;America/Sao_Paulo
 1708304;Goianorte;-877413;-489313;0;17;Tocantins;9699;63;America/Sao_Paulo
-5208905;Goi·s;-159333;-5014;0;52;Goi·s;9377;62;America/Sao_Paulo
+5208905;Goi√°s;-159333;-5014;0;52;Goi√°s;9377;62;America/Sao_Paulo
 1709005;Goiatins;-771478;-473252;0;17;Tocantins;9533;63;America/Sao_Paulo
-5209101;Goiatuba;-180105;-493658;0;52;Goi·s;9379;64;America/Sao_Paulo
-4108601;GoioerÍ;-241835;-530248;0;41;Paran·;7569;44;America/Sao_Paulo
-4108650;Goioxim;-251927;-519911;0;41;Paran·;858;42;America/Sao_Paulo
-3127404;GonÁalves;-226545;-458556;0;31;Minas Gerais;4547;35;America/Sao_Paulo
-2104404;GonÁalves Dias;-51475;-443013;0;21;Maranh„o;785;99;America/Sao_Paulo
+5209101;Goiatuba;-180105;-493658;0;52;Goi√°s;9379;64;America/Sao_Paulo
+4108601;Goioer√™;-241835;-530248;0;41;Paran√°;7569;44;America/Sao_Paulo
+4108650;Goioxim;-251927;-519911;0;41;Paran√°;858;42;America/Sao_Paulo
+3127404;Gon√ßalves;-226545;-458556;0;31;Minas Gerais;4547;35;America/Sao_Paulo
+2104404;Gon√ßalves Dias;-51475;-443013;0;21;Maranh√£o;785;99;America/Sao_Paulo
 2911501;Gongogi;-143195;-39469;0;29;Bahia;3529;73;America/Sao_Paulo
 3127503;Gonzaga;-188196;-424769;0;31;Minas Gerais;4549;33;America/Sao_Paulo
 3127602;Gouveia;-184519;-437423;0;31;Minas Gerais;4551;38;America/Sao_Paulo
-5209150;Gouvel‚ndia;-186238;-500805;0;52;Goi·s;9799;64;America/Sao_Paulo
-2104503;Governador Archer;-502078;-442754;0;21;Maranh„o;787;99;America/Sao_Paulo
+5209150;Gouvel√¢ndia;-186238;-500805;0;52;Goi√°s;9799;64;America/Sao_Paulo
+2104503;Governador Archer;-502078;-442754;0;21;Maranh√£o;787;99;America/Sao_Paulo
 4206009;Governador Celso Ramos;-273172;-485576;0;42;Santa Catarina;8111;48;America/Sao_Paulo
 2404309;Governador Dix-Sept Rosado;-544887;-375183;0;24;Rio Grande do Norte;1683;84;America/Sao_Paulo
-2104552;Governador Edison Lob„o;-574973;-473646;0;21;Maranh„o;162;99;America/Sao_Paulo
-2104602;Governador EugÍnio Barros;-531897;-442469;0;21;Maranh„o;789;99;America/Sao_Paulo
-1101005;Governador Jorge Teixeira;-1061;-627371;0;11;RondÙnia;693;69;America/Porto_Velho
-3202256;Governador Lindenberg;-191864;-404473;0;32;EspÌrito Santo;1114;27;America/Sao_Paulo
-2104628;Governador Luiz Rocha;-547835;-440774;0;21;Maranh„o;164;99;America/Sao_Paulo
+2104552;Governador Edison Lob√£o;-574973;-473646;0;21;Maranh√£o;162;99;America/Sao_Paulo
+2104602;Governador Eug√™nio Barros;-531897;-442469;0;21;Maranh√£o;789;99;America/Sao_Paulo
+1101005;Governador Jorge Teixeira;-1061;-627371;0;11;Rond√¥nia;693;69;America/Porto_Velho
+3202256;Governador Lindenberg;-191864;-404473;0;32;Esp√≠rito Santo;1114;27;America/Sao_Paulo
+2104628;Governador Luiz Rocha;-547835;-440774;0;21;Maranh√£o;164;99;America/Sao_Paulo
 2911600;Governador Mangabeira;-125994;-390412;0;29;Bahia;3531;75;America/Sao_Paulo
-2104651;Governador Newton Bello;-343245;-456619;0;21;Maranh„o;166;98;America/Sao_Paulo
-2104677;Governador Nunes Freire;-212899;-458777;0;21;Maranh„o;168;98;America/Sao_Paulo
+2104651;Governador Newton Bello;-343245;-456619;0;21;Maranh√£o;166;98;America/Sao_Paulo
+2104677;Governador Nunes Freire;-212899;-458777;0;21;Maranh√£o;168;98;America/Sao_Paulo
 3127701;Governador Valadares;-188545;-419555;0;31;Minas Gerais;4553;33;America/Sao_Paulo
-2304657;GraÁa;-404422;-40749;0;23;Cear·;1249;88;America/Sao_Paulo
-2104701;GraÁa Aranha;-540547;-443358;0;21;Maranh„o;791;99;America/Sao_Paulo
+2304657;Gra√ßa;-404422;-40749;0;23;Cear√°;1249;88;America/Sao_Paulo
+2104701;Gra√ßa Aranha;-540547;-443358;0;21;Maranh√£o;791;99;America/Sao_Paulo
 2802601;Gracho Cardoso;-102252;-372006;0;28;Sergipe;3151;79;America/Sao_Paulo
-2104800;Graja˙;-581367;-461462;0;21;Maranh„o;793;99;America/Sao_Paulo
+2104800;Graja√∫;-581367;-461462;0;21;Maranh√£o;793;99;America/Sao_Paulo
 4309100;Gramado;-293734;-508762;0;43;Rio Grande do Sul;8681;54;America/Sao_Paulo
 4309126;Gramado dos Loureiros;-274429;-529149;0;43;Rio Grande do Sul;5949;54;America/Sao_Paulo
 4309159;Gramado Xavier;-292706;-525795;0;43;Rio Grande do Sul;5763;51;America/Sao_Paulo
-4108700;Grandes Rios;-241466;-515094;0;41;Paran·;7959;43;America/Sao_Paulo
+4108700;Grandes Rios;-241466;-515094;0;41;Paran√°;7959;43;America/Sao_Paulo
 2606309;Granito;-770711;-39615;0;26;Pernambuco;2425;87;America/Sao_Paulo
-2304707;Granja;-312788;-408372;0;23;Cear·;1395;88;America/Sao_Paulo
-2304806;Granjeiro;-688134;-392144;0;23;Cear·;1397;88;America/Sao_Paulo
-3127800;Gr„o Mogol;-165662;-428923;0;31;Minas Gerais;4555;38;America/Sao_Paulo
-4206108;Gr„o Par·;-281809;-492252;0;42;Santa Catarina;8119;48;America/Sao_Paulo
-2606408;Gravat·;-821118;-355675;0;26;Pernambuco;2427;81;America/Sao_Paulo
-4309209;GravataÌ;-299413;-509869;0;43;Rio Grande do Sul;8683;51;America/Sao_Paulo
+2304707;Granja;-312788;-408372;0;23;Cear√°;1395;88;America/Sao_Paulo
+2304806;Granjeiro;-688134;-392144;0;23;Cear√°;1397;88;America/Sao_Paulo
+3127800;Gr√£o Mogol;-165662;-428923;0;31;Minas Gerais;4555;38;America/Sao_Paulo
+4206108;Gr√£o Par√°;-281809;-492252;0;42;Santa Catarina;8119;48;America/Sao_Paulo
+2606408;Gravat√°;-821118;-355675;0;26;Pernambuco;2427;81;America/Sao_Paulo
+4309209;Gravata√≠;-299413;-509869;0;43;Rio Grande do Sul;8683;51;America/Sao_Paulo
 4206207;Gravatal;-283208;-490427;0;42;Santa Catarina;8121;48;America/Sao_Paulo
-2304905;GroaÌras;-391787;-403852;0;23;Cear·;1399;88;America/Sao_Paulo
+2304905;Groa√≠ras;-391787;-403852;0;23;Cear√°;1399;88;America/Sao_Paulo
 2404408;Grossos;-498068;-371621;0;24;Rio Grande do Norte;1685;84;America/Sao_Paulo
 3127909;Grupiara;-185003;-477318;0;31;Minas Gerais;4557;34;America/Sao_Paulo
 4309258;Guabiju;-285421;-516948;0;43;Rio Grande do Sul;8405;54;America/Sao_Paulo
 4206306;Guabiruba;-270808;-489804;0;42;Santa Catarina;8123;47;America/Sao_Paulo
-3202306;GuaÁuÌ;-207668;-416734;0;32;EspÌrito Santo;5645;28;America/Sao_Paulo
-2204501;Guadalupe;-678285;-435594;0;22;PiauÌ;1089;89;America/Sao_Paulo
-4309308;GuaÌba;-301086;-513233;0;43;Rio Grande do Sul;8685;51;America/Sao_Paulo
-3517208;GuaiÁara;-216195;-498013;0;35;S„o Paulo;6445;14;America/Sao_Paulo
-3517307;GuaimbÍ;-219091;-498986;0;35;S„o Paulo;6447;14;America/Sao_Paulo
-3517406;GuaÌra;-203196;-48312;0;35;S„o Paulo;6449;17;America/Sao_Paulo
-4108809;GuaÌra;-24085;-542573;0;41;Paran·;7571;44;America/Sao_Paulo
-4108908;GuairaÁ·;-22932;-526906;0;41;Paran·;7573;44;America/Sao_Paulo
-2304954;Guai˙ba;-404057;-386404;0;23;Cear·;1251;85;America/Sao_Paulo
-1301654;Guajar·;-753797;-725907;0;13;Amazonas;967;97;America/Rio_Branco
-1100106;Guajar·-Mirim;-107889;-653296;0;11;RondÙnia;1;69;America/Porto_Velho
+3202306;Gua√ßu√≠;-207668;-416734;0;32;Esp√≠rito Santo;5645;28;America/Sao_Paulo
+2204501;Guadalupe;-678285;-435594;0;22;Piau√≠;1089;89;America/Sao_Paulo
+4309308;Gua√≠ba;-301086;-513233;0;43;Rio Grande do Sul;8685;51;America/Sao_Paulo
+3517208;Guai√ßara;-216195;-498013;0;35;S√£o Paulo;6445;14;America/Sao_Paulo
+3517307;Guaimb√™;-219091;-498986;0;35;S√£o Paulo;6447;14;America/Sao_Paulo
+3517406;Gua√≠ra;-203196;-48312;0;35;S√£o Paulo;6449;17;America/Sao_Paulo
+4108809;Gua√≠ra;-24085;-542573;0;41;Paran√°;7571;44;America/Sao_Paulo
+4108908;Guaira√ß√°;-22932;-526906;0;41;Paran√°;7573;44;America/Sao_Paulo
+2304954;Guai√∫ba;-404057;-386404;0;23;Cear√°;1251;85;America/Sao_Paulo
+1301654;Guajar√°;-753797;-725907;0;13;Amazonas;967;97;America/Rio_Branco
+1100106;Guajar√°-Mirim;-107889;-653296;0;11;Rond√¥nia;1;69;America/Porto_Velho
 2911659;Guajeru;-145467;-419381;0;29;Bahia;3095;77;America/Sao_Paulo
-2404507;GuamarÈ;-510619;-363222;0;24;Rio Grande do Norte;1687;84;America/Sao_Paulo
-4108957;Guamiranga;-251912;-508021;0;41;Paran·;860;42;America/Sao_Paulo
+2404507;Guamar√©;-510619;-363222;0;24;Rio Grande do Norte;1687;84;America/Sao_Paulo
+4108957;Guamiranga;-251912;-508021;0;41;Paran√°;860;42;America/Sao_Paulo
 2911709;Guanambi;-142231;-427799;0;29;Bahia;3533;77;America/Sao_Paulo
-3128006;Guanh„es;-187713;-429312;0;31;Minas Gerais;4559;33;America/Sao_Paulo
-3128105;GuapÈ;-207631;-459152;0;31;Minas Gerais;4561;35;America/Sao_Paulo
-3517505;GuapiaÁu;-207959;-492172;0;35;S„o Paulo;6451;17;America/Sao_Paulo
-3517604;Guapiara;-241892;-485295;0;35;S„o Paulo;6453;15;America/Sao_Paulo
+3128006;Guanh√£es;-187713;-429312;0;31;Minas Gerais;4559;33;America/Sao_Paulo
+3128105;Guap√©;-207631;-459152;0;31;Minas Gerais;4561;35;America/Sao_Paulo
+3517505;Guapia√ßu;-207959;-492172;0;35;S√£o Paulo;6451;17;America/Sao_Paulo
+3517604;Guapiara;-241892;-485295;0;35;S√£o Paulo;6453;15;America/Sao_Paulo
 3301850;Guapimirim;-225347;-429895;0;33;Rio de Janeiro;2907;21;America/Sao_Paulo
-4109005;Guapirama;-235203;-500407;0;41;Paran·;7575;43;America/Sao_Paulo
-5209200;GuapÛ;-168297;-495345;0;52;Goi·s;9381;62;America/Sao_Paulo
-4309407;GuaporÈ;-288399;-518895;0;43;Rio Grande do Sul;8687;54;America/Sao_Paulo
-4109104;Guaporema;-233402;-527786;0;41;Paran·;7577;44;America/Sao_Paulo
-3517703;Guar·;-204302;-478236;0;35;S„o Paulo;6455;16;America/Sao_Paulo
-2506301;Guarabira;-685064;-35485;0;25;ParaÌba;2027;83;America/Sao_Paulo
-3517802;GuaraÁaÌ;-210292;-512119;0;35;S„o Paulo;6457;18;America/Sao_Paulo
-3517901;Guaraci;-204977;-489391;0;35;S„o Paulo;6459;17;America/Sao_Paulo
-4109203;Guaraci;-229694;-516504;0;41;Paran·;7579;43;America/Sao_Paulo
+4109005;Guapirama;-235203;-500407;0;41;Paran√°;7575;43;America/Sao_Paulo
+5209200;Guap√≥;-168297;-495345;0;52;Goi√°s;9381;62;America/Sao_Paulo
+4309407;Guapor√©;-288399;-518895;0;43;Rio Grande do Sul;8687;54;America/Sao_Paulo
+4109104;Guaporema;-233402;-527786;0;41;Paran√°;7577;44;America/Sao_Paulo
+3517703;Guar√°;-204302;-478236;0;35;S√£o Paulo;6455;16;America/Sao_Paulo
+2506301;Guarabira;-685064;-35485;0;25;Para√≠ba;2027;83;America/Sao_Paulo
+3517802;Guara√ßa√≠;-210292;-512119;0;35;S√£o Paulo;6457;18;America/Sao_Paulo
+3517901;Guaraci;-204977;-489391;0;35;S√£o Paulo;6459;17;America/Sao_Paulo
+4109203;Guaraci;-229694;-516504;0;41;Paran√°;7579;43;America/Sao_Paulo
 3128204;Guaraciaba;-205716;-430094;0;31;Minas Gerais;4563;31;America/Sao_Paulo
 4206405;Guaraciaba;-266042;-535243;0;42;Santa Catarina;8125;49;America/Sao_Paulo
-2305001;Guaraciaba do Norte;-415814;-407476;0;23;Cear·;1401;88;America/Sao_Paulo
+2305001;Guaraciaba do Norte;-415814;-407476;0;23;Cear√°;1401;88;America/Sao_Paulo
 3128253;Guaraciama;-170142;-436675;0;31;Minas Gerais;622;38;America/Sao_Paulo
-1709302;GuaraÌ;-883543;-485114;0;17;Tocantins;9627;63;America/Sao_Paulo
-5209291;GuaraÌta;-156121;-500265;0;52;Goi·s;65;62;America/Sao_Paulo
-2305100;Guaramiranga;-426248;-38932;0;23;Cear·;1403;85;America/Sao_Paulo
+1709302;Guara√≠;-883543;-485114;0;17;Tocantins;9627;63;America/Sao_Paulo
+5209291;Guara√≠ta;-156121;-500265;0;52;Goi√°s;65;62;America/Sao_Paulo
+2305100;Guaramiranga;-426248;-38932;0;23;Cear√°;1403;85;America/Sao_Paulo
 4206504;Guaramirim;-264688;-490026;0;42;Santa Catarina;8127;47;America/Sao_Paulo
-3128303;GuaranÈsia;-213009;-467964;0;31;Minas Gerais;4565;35;America/Sao_Paulo
+3128303;Guaran√©sia;-213009;-467964;0;31;Minas Gerais;4565;35;America/Sao_Paulo
 3128402;Guarani;-213563;-430328;0;31;Minas Gerais;4567;32;America/Sao_Paulo
-3518008;Guarani d'Oeste;-200746;-503411;0;35;S„o Paulo;6461;17;America/Sao_Paulo
-4309506;Guarani das Missıes;-281491;-545629;0;43;Rio Grande do Sul;8689;55;America/Sao_Paulo
-5209408;Guarani de Goi·s;-139421;-464868;0;52;Goi·s;9383;62;America/Sao_Paulo
-4109302;GuaraniaÁu;-250968;-528755;0;41;Paran·;7581;45;America/Sao_Paulo
-3518107;Guarant„;-218942;-495914;0;35;S„o Paulo;6463;14;America/Sao_Paulo
-5104104;Guarant„ do Norte;-996218;-549121;0;51;Mato Grosso;9887;66;America/Porto_Velho
-3202405;Guarapari;-206772;-405093;0;32;EspÌrito Santo;5647;27;America/Sao_Paulo
-4109401;Guarapuava;-253902;-514623;0;41;Paran·;7583;42;America/Sao_Paulo
-4109500;GuaraqueÁaba;-253071;-483204;0;41;Paran·;7585;41;America/Sao_Paulo
-3128501;Guarar·;-217304;-430334;0;31;Minas Gerais;4569;32;America/Sao_Paulo
-3518206;Guararapes;-212544;-506453;0;35;S„o Paulo;6465;18;America/Sao_Paulo
-3518305;Guararema;-234112;-460369;0;35;S„o Paulo;6467;11;America/Sao_Paulo
+3518008;Guarani d'Oeste;-200746;-503411;0;35;S√£o Paulo;6461;17;America/Sao_Paulo
+4309506;Guarani das Miss√µes;-281491;-545629;0;43;Rio Grande do Sul;8689;55;America/Sao_Paulo
+5209408;Guarani de Goi√°s;-139421;-464868;0;52;Goi√°s;9383;62;America/Sao_Paulo
+4109302;Guarania√ßu;-250968;-528755;0;41;Paran√°;7581;45;America/Sao_Paulo
+3518107;Guarant√£;-218942;-495914;0;35;S√£o Paulo;6463;14;America/Sao_Paulo
+5104104;Guarant√£ do Norte;-996218;-549121;0;51;Mato Grosso;9887;66;America/Porto_Velho
+3202405;Guarapari;-206772;-405093;0;32;Esp√≠rito Santo;5647;27;America/Sao_Paulo
+4109401;Guarapuava;-253902;-514623;0;41;Paran√°;7583;42;America/Sao_Paulo
+4109500;Guaraque√ßaba;-253071;-483204;0;41;Paran√°;7585;41;America/Sao_Paulo
+3128501;Guarar√°;-217304;-430334;0;31;Minas Gerais;4569;32;America/Sao_Paulo
+3518206;Guararapes;-212544;-506453;0;35;S√£o Paulo;6465;18;America/Sao_Paulo
+3518305;Guararema;-234112;-460369;0;35;S√£o Paulo;6467;11;America/Sao_Paulo
 2911808;Guaratinga;-165833;-397847;0;29;Bahia;3535;73;America/Sao_Paulo
-3518404;Guaratinguet·;-228075;-451938;0;35;S„o Paulo;6469;12;America/Sao_Paulo
-4109609;Guaratuba;-258817;-485752;0;41;Paran·;7587;41;America/Sao_Paulo
+3518404;Guaratinguet√°;-228075;-451938;0;35;S√£o Paulo;6469;12;America/Sao_Paulo
+4109609;Guaratuba;-258817;-485752;0;41;Paran√°;7587;41;America/Sao_Paulo
 3128600;Guarda-Mor;-177673;-470998;0;31;Minas Gerais;4571;38;America/Sao_Paulo
-3518503;GuareÌ;-233714;-481837;0;35;S„o Paulo;6471;15;America/Sao_Paulo
-3518602;Guariba;-213594;-482316;0;35;S„o Paulo;6473;16;America/Sao_Paulo
-2204550;Guaribas;-938647;-436943;0;22;PiauÌ;320;89;America/Sao_Paulo
-5209457;Guarinos;-147292;-497006;0;52;Goi·s;9993;62;America/Sao_Paulo
-3518701;Guaruj·;-239888;-46258;0;35;S„o Paulo;6475;13;America/Sao_Paulo
-4206603;Guaruj· do Sul;-263858;-535296;0;42;Santa Catarina;8129;49;America/Sao_Paulo
-3518800;Guarulhos;-234538;-465333;0;35;S„o Paulo;6477;11;America/Sao_Paulo
-4206652;Guatamb˙;-271341;-527887;0;42;Santa Catarina;5583;49;America/Sao_Paulo
-3518859;Guatapar·;-214944;-480356;0;35;S„o Paulo;7257;16;America/Sao_Paulo
-3128709;GuaxupÈ;-21305;-467081;0;31;Minas Gerais;4573;35;America/Sao_Paulo
+3518503;Guare√≠;-233714;-481837;0;35;S√£o Paulo;6471;15;America/Sao_Paulo
+3518602;Guariba;-213594;-482316;0;35;S√£o Paulo;6473;16;America/Sao_Paulo
+2204550;Guaribas;-938647;-436943;0;22;Piau√≠;320;89;America/Sao_Paulo
+5209457;Guarinos;-147292;-497006;0;52;Goi√°s;9993;62;America/Sao_Paulo
+3518701;Guaruj√°;-239888;-46258;0;35;S√£o Paulo;6475;13;America/Sao_Paulo
+4206603;Guaruj√° do Sul;-263858;-535296;0;42;Santa Catarina;8129;49;America/Sao_Paulo
+3518800;Guarulhos;-234538;-465333;0;35;S√£o Paulo;6477;11;America/Sao_Paulo
+4206652;Guatamb√∫;-271341;-527887;0;42;Santa Catarina;5583;49;America/Sao_Paulo
+3518859;Guatapar√°;-214944;-480356;0;35;S√£o Paulo;7257;16;America/Sao_Paulo
+3128709;Guaxup√©;-21305;-467081;0;31;Minas Gerais;4573;35;America/Sao_Paulo
 5004106;Guia Lopes da Laguna;-214583;-561117;0;50;Mato Grosso do Sul;9081;67;America/Porto_Velho
 3128808;Guidoval;-21155;-427887;0;31;Minas Gerais;4575;32;America/Sao_Paulo
-2104909;Guimar„es;-212755;-44602;0;21;Maranh„o;795;98;America/Sao_Paulo
-3128907;Guimar‚nia;-188425;-467901;0;31;Minas Gerais;4577;34;America/Sao_Paulo
+2104909;Guimar√£es;-212755;-44602;0;21;Maranh√£o;795;98;America/Sao_Paulo
+3128907;Guimar√¢nia;-188425;-467901;0;31;Minas Gerais;4577;34;America/Sao_Paulo
 5104203;Guiratinga;-16346;-537575;0;51;Mato Grosso;9083;66;America/Porto_Velho
 3129004;Guiricema;-210098;-427207;0;31;Minas Gerais;4579;32;America/Sao_Paulo
-3129103;Gurinhat„;-192143;-497876;0;31;Minas Gerais;4581;34;America/Sao_Paulo
-2506400;GurinhÈm;-71233;-354222;0;25;ParaÌba;2029;83;America/Sao_Paulo
-2506509;Gurj„o;-724833;-364923;0;25;ParaÌba;2031;83;America/Sao_Paulo
-1503101;Gurup·;-141412;-516338;0;15;Par·;461;91;America/Sao_Paulo
+3129103;Gurinhat√£;-192143;-497876;0;31;Minas Gerais;4581;34;America/Sao_Paulo
+2506400;Gurinh√©m;-71233;-354222;0;25;Para√≠ba;2029;83;America/Sao_Paulo
+2506509;Gurj√£o;-724833;-364923;0;25;Para√≠ba;2031;83;America/Sao_Paulo
+1503101;Gurup√°;-141412;-516338;0;15;Par√°;461;91;America/Sao_Paulo
 1709500;Gurupi;-117279;-49068;0;17;Tocantins;9385;63;America/Sao_Paulo
-3518909;Guzol‚ndia;-206467;-506645;0;35;S„o Paulo;6479;17;America/Sao_Paulo
+3518909;Guzol√¢ndia;-206467;-506645;0;35;S√£o Paulo;6479;17;America/Sao_Paulo
 4309555;Harmonia;-295456;-514185;0;43;Rio Grande do Sul;8403;51;America/Sao_Paulo
-5209606;HeitoraÌ;-15719;-498268;0;52;Goi·s;9387;62;America/Sao_Paulo
+5209606;Heitora√≠;-15719;-498268;0;52;Goi√°s;9387;62;America/Sao_Paulo
 3129202;Heliodora;-220644;-455453;0;31;Minas Gerais;4583;35;America/Sao_Paulo
-2911857;HeliÛpolis;-106825;-382907;0;29;Bahia;3097;75;America/Sao_Paulo
-3519006;Hercul‚ndia;-220038;-503907;0;35;S„o Paulo;6481;14;America/Sao_Paulo
+2911857;Heli√≥polis;-106825;-382907;0;29;Bahia;3097;75;America/Sao_Paulo
+3519006;Hercul√¢ndia;-220038;-503907;0;35;S√£o Paulo;6481;14;America/Sao_Paulo
 4307104;Herval;-32024;-533944;0;43;Rio Grande do Sul;8639;53;America/Sao_Paulo
 4206702;Herval d'Oeste;-271903;-514917;0;42;Santa Catarina;8131;49;America/Sao_Paulo
 4309571;Herveiras;-294552;-526553;0;43;Rio Grande do Sul;988;51;America/Sao_Paulo
-5209705;Hidrol‚ndia;-169626;-492265;0;52;Goi·s;9389;62;America/Sao_Paulo
-2305209;Hidrol‚ndia;-440958;-404056;0;23;Cear·;1405;88;America/Sao_Paulo
-5209804;Hidrolina;-147261;-494634;0;52;Goi·s;9391;62;America/Sao_Paulo
-3519055;Holambra;-226405;-470487;0;35;S„o Paulo;2953;19;America/Sao_Paulo
-4109658;HonÛrio Serpa;-26139;-523848;0;41;Paran·;9981;46;America/Sao_Paulo
-2305233;Horizonte;-41209;-384707;0;23;Cear·;1253;85;America/Sao_Paulo
+5209705;Hidrol√¢ndia;-169626;-492265;0;52;Goi√°s;9389;62;America/Sao_Paulo
+2305209;Hidrol√¢ndia;-440958;-404056;0;23;Cear√°;1405;88;America/Sao_Paulo
+5209804;Hidrolina;-147261;-494634;0;52;Goi√°s;9391;62;America/Sao_Paulo
+3519055;Holambra;-226405;-470487;0;35;S√£o Paulo;2953;19;America/Sao_Paulo
+4109658;Hon√≥rio Serpa;-26139;-523848;0;41;Paran√°;9981;46;America/Sao_Paulo
+2305233;Horizonte;-41209;-384707;0;23;Cear√°;1253;85;America/Sao_Paulo
 4309605;Horizontina;-276282;-543053;0;43;Rio Grande do Sul;8691;55;America/Sao_Paulo
-3519071;Hortol‚ndia;-228529;-472143;0;35;S„o Paulo;2951;19;America/Sao_Paulo
-2204600;Hugo Napole„o;-59886;-425598;0;22;PiauÌ;1091;86;America/Sao_Paulo
+3519071;Hortol√¢ndia;-228529;-472143;0;35;S√£o Paulo;2951;19;America/Sao_Paulo
+2204600;Hugo Napole√£o;-59886;-425598;0;22;Piau√≠;1091;86;America/Sao_Paulo
 4309654;Hulha Negra;-314067;-538667;0;43;Rio Grande do Sul;6085;53;America/Sao_Paulo
-4309704;Humait·;-275691;-539695;0;43;Rio Grande do Sul;8695;55;America/Sao_Paulo
-1301704;Humait·;-751171;-630327;0;13;Amazonas;235;97;America/Porto_Velho
-2105005;Humberto de Campos;-259828;-434649;0;21;Maranh„o;797;98;America/Sao_Paulo
-3519105;Iacanga;-218896;-49031;0;35;S„o Paulo;6483;14;America/Sao_Paulo
-5209903;Iaciara;-141011;-466335;0;52;Goi·s;9393;62;America/Sao_Paulo
-3519204;Iacri;-218572;-506932;0;35;S„o Paulo;6485;14;America/Sao_Paulo
-2911907;IaÁu;-127666;-402056;0;29;Bahia;3537;75;America/Sao_Paulo
+4309704;Humait√°;-275691;-539695;0;43;Rio Grande do Sul;8695;55;America/Sao_Paulo
+1301704;Humait√°;-751171;-630327;0;13;Amazonas;235;97;America/Porto_Velho
+2105005;Humberto de Campos;-259828;-434649;0;21;Maranh√£o;797;98;America/Sao_Paulo
+3519105;Iacanga;-218896;-49031;0;35;S√£o Paulo;6483;14;America/Sao_Paulo
+5209903;Iaciara;-141011;-466335;0;52;Goi√°s;9393;62;America/Sao_Paulo
+3519204;Iacri;-218572;-506932;0;35;S√£o Paulo;6485;14;America/Sao_Paulo
+2911907;Ia√ßu;-127666;-402056;0;29;Bahia;3537;75;America/Sao_Paulo
 3129301;Iapu;-194387;-422147;0;31;Minas Gerais;4585;33;America/Sao_Paulo
-3519253;Iaras;-228682;-491634;0;35;S„o Paulo;7259;14;America/Sao_Paulo
+3519253;Iaras;-228682;-491634;0;35;S√£o Paulo;7259;14;America/Sao_Paulo
 2606507;Iati;-904559;-368498;0;26;Pernambuco;2429;87;America/Sao_Paulo
-4109708;Ibaiti;-238478;-501932;0;41;Paran·;7589;43;America/Sao_Paulo
+4109708;Ibaiti;-238478;-501932;0;41;Paran√°;7589;43;America/Sao_Paulo
 4309753;Ibarama;-294203;-531295;0;43;Rio Grande do Sul;8401;51;America/Sao_Paulo
-2305266;Ibaretama;-480376;-387501;0;23;Cear·;1255;88;America/Sao_Paulo
-3519303;IbatÈ;-219584;-479882;0;35;S„o Paulo;6487;16;America/Sao_Paulo
+2305266;Ibaretama;-480376;-387501;0;23;Cear√°;1255;88;America/Sao_Paulo
+3519303;Ibat√©;-219584;-479882;0;35;S√£o Paulo;6487;16;America/Sao_Paulo
 2703007;Ibateguara;-897823;-359373;0;27;Alagoas;2759;82;America/Sao_Paulo
-3202454;Ibatiba;-202347;-415087;0;32;EspÌrito Santo;5709;28;America/Sao_Paulo
-4109757;Ibema;-251193;-530072;0;41;Paran·;9949;45;America/Sao_Paulo
+3202454;Ibatiba;-202347;-415087;0;32;Esp√≠rito Santo;5709;28;America/Sao_Paulo
+4109757;Ibema;-251193;-530072;0;41;Paran√°;9949;45;America/Sao_Paulo
 3129400;Ibertioga;-21433;-439639;0;31;Minas Gerais;4587;32;America/Sao_Paulo
-3129509;Ibi·;-194749;-465474;0;31;Minas Gerais;4589;34;America/Sao_Paulo
-4309803;IbiaÁ·;-280566;-518599;0;43;Rio Grande do Sul;8697;54;America/Sao_Paulo
-3129608;IbiaÌ;-168591;-449046;0;31;Minas Gerais;4591;38;America/Sao_Paulo
+3129509;Ibi√°;-194749;-465474;0;31;Minas Gerais;4589;34;America/Sao_Paulo
+4309803;Ibia√ß√°;-280566;-518599;0;43;Rio Grande do Sul;8697;54;America/Sao_Paulo
+3129608;Ibia√≠;-168591;-449046;0;31;Minas Gerais;4591;38;America/Sao_Paulo
 4206751;Ibiam;-271847;-512352;0;42;Santa Catarina;920;49;America/Sao_Paulo
-2305308;Ibiapina;-392403;-408911;0;23;Cear·;1407;88;America/Sao_Paulo
-2506608;Ibiara;-747957;-384059;0;25;ParaÌba;2033;83;America/Sao_Paulo
-2912004;IbiassucÍ;-142711;-42257;0;29;Bahia;3539;77;America/Sao_Paulo
-2912103;IbicaraÌ;-148579;-395914;0;29;Bahia;3541;73;America/Sao_Paulo
-4206801;IbicarÈ;-270881;-513681;0;42;Santa Catarina;8133;49;America/Sao_Paulo
+2305308;Ibiapina;-392403;-408911;0;23;Cear√°;1407;88;America/Sao_Paulo
+2506608;Ibiara;-747957;-384059;0;25;Para√≠ba;2033;83;America/Sao_Paulo
+2912004;Ibiassuc√™;-142711;-42257;0;29;Bahia;3539;77;America/Sao_Paulo
+2912103;Ibicara√≠;-148579;-395914;0;29;Bahia;3541;73;America/Sao_Paulo
+4206801;Ibicar√©;-270881;-513681;0;42;Santa Catarina;8133;49;America/Sao_Paulo
 2912202;Ibicoara;-134059;-41284;0;29;Bahia;3543;77;America/Sao_Paulo
-2912301;IbicuÌ;-14845;-399879;0;29;Bahia;3545;73;America/Sao_Paulo
-2305332;Ibicuitinga;-496999;-386362;0;23;Cear·;1257;88;America/Sao_Paulo
+2912301;Ibicu√≠;-14845;-399879;0;29;Bahia;3545;73;America/Sao_Paulo
+2305332;Ibicuitinga;-496999;-386362;0;23;Cear√°;1257;88;America/Sao_Paulo
 2606606;Ibimirim;-854026;-377032;0;26;Pernambuco;2431;87;America/Sao_Paulo
 2912400;Ibipeba;-116438;-420195;0;29;Bahia;3547;74;America/Sao_Paulo
 2912509;Ibipitanga;-128804;-424856;0;29;Bahia;3551;77;America/Sao_Paulo
-4109807;Ibipor„;-232659;-510522;0;41;Paran·;7591;43;America/Sao_Paulo
+4109807;Ibipor√£;-232659;-510522;0;41;Paran√°;7591;43;America/Sao_Paulo
 2912608;Ibiquera;-126444;-409338;0;29;Bahia;3553;75;America/Sao_Paulo
-3519402;Ibir·;-21083;-492448;0;35;S„o Paulo;6489;17;America/Sao_Paulo
+3519402;Ibir√°;-21083;-492448;0;35;S√£o Paulo;6489;17;America/Sao_Paulo
 3129657;Ibiracatu;-156605;-441667;0;31;Minas Gerais;624;38;America/Sao_Paulo
 3129707;Ibiraci;-204611;-471222;0;31;Minas Gerais;4593;35;America/Sao_Paulo
-3202504;IbiraÁu;-198366;-403732;0;32;EspÌrito Santo;5649;27;America/Sao_Paulo
+3202504;Ibira√ßu;-198366;-403732;0;32;Esp√≠rito Santo;5649;27;America/Sao_Paulo
 4309902;Ibiraiaras;-283741;-516377;0;43;Rio Grande do Sul;8699;54;America/Sao_Paulo
 2606705;Ibirajuba;-857633;-361812;0;26;Pernambuco;2433;87;America/Sao_Paulo
 4206900;Ibirama;-270547;-495193;0;42;Santa Catarina;8135;47;America/Sao_Paulo
 2912707;Ibirapitanga;-141649;-393787;0;29;Bahia;3555;73;America/Sao_Paulo
-2912806;Ibirapu„;-176832;-401129;0;29;Bahia;3557;73;America/Sao_Paulo
-4309951;Ibirapuit„;-286247;-525158;0;43;Rio Grande do Sul;7299;54;America/Sao_Paulo
-3519501;Ibirarema;-228185;-500739;0;35;S„o Paulo;6491;14;America/Sao_Paulo
+2912806;Ibirapu√£;-176832;-401129;0;29;Bahia;3557;73;America/Sao_Paulo
+4309951;Ibirapuit√£;-286247;-525158;0;43;Rio Grande do Sul;7299;54;America/Sao_Paulo
+3519501;Ibirarema;-228185;-500739;0;35;S√£o Paulo;6491;14;America/Sao_Paulo
 2912905;Ibirataia;-140643;-396459;0;29;Bahia;3559;73;America/Sao_Paulo
-3129806;IbiritÈ;-200252;-440569;0;31;Minas Gerais;4595;31;America/Sao_Paulo
-4310009;Ibirub·;-286302;-530961;0;43;Rio Grande do Sul;8701;54;America/Sao_Paulo
+3129806;Ibirit√©;-200252;-440569;0;31;Minas Gerais;4595;31;America/Sao_Paulo
+4310009;Ibirub√°;-286302;-530961;0;43;Rio Grande do Sul;8701;54;America/Sao_Paulo
 2913002;Ibitiara;-126502;-422179;0;29;Bahia;3561;77;America/Sao_Paulo
-3519600;Ibitinga;-217562;-488319;0;35;S„o Paulo;6493;16;America/Sao_Paulo
-3202553;Ibitirama;-205466;-416667;0;32;EspÌrito Santo;6011;28;America/Sao_Paulo
-2913101;Ibitit·;-115414;-419748;0;29;Bahia;3563;74;America/Sao_Paulo
-3129905;Ibiti˙ra de Minas;-220604;-464368;0;31;Minas Gerais;4597;35;America/Sao_Paulo
+3519600;Ibitinga;-217562;-488319;0;35;S√£o Paulo;6493;16;America/Sao_Paulo
+3202553;Ibitirama;-205466;-416667;0;32;Esp√≠rito Santo;6011;28;America/Sao_Paulo
+2913101;Ibitit√°;-115414;-419748;0;29;Bahia;3563;74;America/Sao_Paulo
+3129905;Ibiti√∫ra de Minas;-220604;-464368;0;31;Minas Gerais;4597;35;America/Sao_Paulo
 3130002;Ibituruna;-211541;-447479;0;31;Minas Gerais;4599;35;America/Sao_Paulo
-3519709;Ibi˙na;-236596;-47223;0;35;S„o Paulo;6495;15;America/Sao_Paulo
+3519709;Ibi√∫na;-236596;-47223;0;35;S√£o Paulo;6495;15;America/Sao_Paulo
 2913200;Ibotirama;-121779;-432167;0;29;Bahia;3565;77;America/Sao_Paulo
-2305357;IcapuÌ;-471206;-373531;0;23;Cear·;1593;88;America/Sao_Paulo
-4207007;IÁara;-287132;-493087;0;42;Santa Catarina;8137;48;America/Sao_Paulo
-3130051;IcaraÌ de Minas;-16214;-449034;0;31;Minas Gerais;2693;38;America/Sao_Paulo
-4109906;IcaraÌma;-233944;-53615;0;41;Paran·;7593;44;America/Sao_Paulo
-2105104;Icatu;-277206;-440501;0;21;Maranh„o;799;98;America/Sao_Paulo
-3519808;IcÈm;-203391;-491915;0;35;S„o Paulo;6497;17;America/Sao_Paulo
+2305357;Icapu√≠;-471206;-373531;0;23;Cear√°;1593;88;America/Sao_Paulo
+4207007;I√ßara;-287132;-493087;0;42;Santa Catarina;8137;48;America/Sao_Paulo
+3130051;Icara√≠ de Minas;-16214;-449034;0;31;Minas Gerais;2693;38;America/Sao_Paulo
+4109906;Icara√≠ma;-233944;-53615;0;41;Paran√°;7593;44;America/Sao_Paulo
+2105104;Icatu;-277206;-440501;0;21;Maranh√£o;799;98;America/Sao_Paulo
+3519808;Ic√©m;-203391;-491915;0;35;S√£o Paulo;6497;17;America/Sao_Paulo
 2913309;Ichu;-117431;-391905;0;29;Bahia;3567;75;America/Sao_Paulo
-2305407;IcÛ;-639627;-388554;0;23;Cear·;1409;88;America/Sao_Paulo
-3202603;Iconha;-207913;-408132;0;32;EspÌrito Santo;5651;28;America/Sao_Paulo
+2305407;Ic√≥;-639627;-388554;0;23;Cear√°;1409;88;America/Sao_Paulo
+3202603;Iconha;-207913;-408132;0;32;Esp√≠rito Santo;5651;28;America/Sao_Paulo
 2404606;Ielmo Marinho;-582447;-3555;0;24;Rio Grande do Norte;1689;84;America/Sao_Paulo
-3519907;IepÍ;-226602;-510779;0;35;S„o Paulo;6499;18;America/Sao_Paulo
+3519907;Iep√™;-226602;-510779;0;35;S√£o Paulo;6499;18;America/Sao_Paulo
 2703106;Igaci;-953768;-366372;0;27;Alagoas;2761;82;America/Sao_Paulo
-2913408;Igapor„;-13774;-427155;0;29;Bahia;3569;77;America/Sao_Paulo
-3520004;IgaraÁu do TietÍ;-22509;-485597;0;35;S„o Paulo;6501;14;America/Sao_Paulo
-2502607;Igaracy;-717184;-381478;0;25;ParaÌba;1953;83;America/Sao_Paulo
-3520103;Igarapava;-200407;-477466;0;35;S„o Paulo;6503;16;America/Sao_Paulo
-3130101;IgarapÈ;-200707;-442994;0;31;Minas Gerais;4601;31;America/Sao_Paulo
-2105153;IgarapÈ do Meio;-365771;-452114;0;21;Maranh„o;170;98;America/Sao_Paulo
-2105203;IgarapÈ Grande;-46625;-448558;0;21;Maranh„o;801;99;America/Sao_Paulo
-1503200;IgarapÈ-AÁu;-112539;-47626;0;15;Par·;463;91;America/Sao_Paulo
-1503309;IgarapÈ-Miri;-197533;-489575;0;15;Par·;465;91;America/Sao_Paulo
+2913408;Igapor√£;-13774;-427155;0;29;Bahia;3569;77;America/Sao_Paulo
+3520004;Igara√ßu do Tiet√™;-22509;-485597;0;35;S√£o Paulo;6501;14;America/Sao_Paulo
+2502607;Igaracy;-717184;-381478;0;25;Para√≠ba;1953;83;America/Sao_Paulo
+3520103;Igarapava;-200407;-477466;0;35;S√£o Paulo;6503;16;America/Sao_Paulo
+3130101;Igarap√©;-200707;-442994;0;31;Minas Gerais;4601;31;America/Sao_Paulo
+2105153;Igarap√© do Meio;-365771;-452114;0;21;Maranh√£o;170;98;America/Sao_Paulo
+2105203;Igarap√© Grande;-46625;-448558;0;21;Maranh√£o;801;99;America/Sao_Paulo
+1503200;Igarap√©-A√ßu;-112539;-47626;0;15;Par√°;463;91;America/Sao_Paulo
+1503309;Igarap√©-Miri;-197533;-489575;0;15;Par√°;465;91;America/Sao_Paulo
 2606804;Igarassu;-782881;-349013;0;26;Pernambuco;2435;81;America/Sao_Paulo
-3520202;Igarat·;-232037;-46157;0;35;S„o Paulo;6505;11;America/Sao_Paulo
+3520202;Igarat√°;-232037;-46157;0;35;S√£o Paulo;6505;11;America/Sao_Paulo
 3130200;Igaratinga;-199476;-447063;0;31;Minas Gerais;4603;37;America/Sao_Paulo
-2913457;Igrapi˙na;-138295;-391361;0;29;Bahia;3277;73;America/Sao_Paulo
+2913457;Igrapi√∫na;-138295;-391361;0;29;Bahia;3277;73;America/Sao_Paulo
 2703205;Igreja Nova;-101235;-366597;0;27;Alagoas;2763;82;America/Sao_Paulo
 4310108;Igrejinha;-295693;-507919;0;43;Rio Grande do Sul;8703;51;America/Sao_Paulo
 3301876;Iguaba Grande;-228495;-422299;0;33;Rio de Janeiro;774;22;America/Sao_Paulo
-2913507;IguaÌ;-147528;-400894;0;29;Bahia;3571;73;America/Sao_Paulo
-3520301;Iguape;-24699;-475537;0;35;S„o Paulo;6507;13;America/Sao_Paulo
-4110003;IguaraÁu;-231949;-518256;0;41;Paran·;7595;44;America/Sao_Paulo
+2913507;Igua√≠;-147528;-400894;0;29;Bahia;3571;73;America/Sao_Paulo
+3520301;Iguape;-24699;-475537;0;35;S√£o Paulo;6507;13;America/Sao_Paulo
+4110003;Iguara√ßu;-231949;-518256;0;41;Paran√°;7595;44;America/Sao_Paulo
 2606903;Iguaracy;-783222;-375082;0;26;Pernambuco;2437;87;America/Sao_Paulo
 3130309;Iguatama;-201776;-457111;0;31;Minas Gerais;4605;37;America/Sao_Paulo
 5004304;Iguatemi;-236736;-545637;0;50;Mato Grosso do Sul;9085;67;America/Porto_Velho
-2305506;Iguatu;-636281;-392892;0;23;Cear·;1411;88;America/Sao_Paulo
-4110052;Iguatu;-247153;-530827;0;41;Paran·;5467;45;America/Sao_Paulo
+2305506;Iguatu;-636281;-392892;0;23;Cear√°;1411;88;America/Sao_Paulo
+4110052;Iguatu;-247153;-530827;0;41;Paran√°;5467;45;America/Sao_Paulo
 3130408;Ijaci;-211738;-449233;0;31;Minas Gerais;4607;35;America/Sao_Paulo
-4310207;IjuÌ;-28388;-5392;0;43;Rio Grande do Sul;8705;55;America/Sao_Paulo
-3520426;Ilha Comprida;-247307;-475383;0;35;S„o Paulo;2969;13;America/Sao_Paulo
+4310207;Iju√≠;-28388;-5392;0;43;Rio Grande do Sul;8705;55;America/Sao_Paulo
+3520426;Ilha Comprida;-247307;-475383;0;35;S√£o Paulo;2969;13;America/Sao_Paulo
 2802700;Ilha das Flores;-104425;-365479;0;28;Sergipe;3153;79;America/Sao_Paulo
-2607604;Ilha de Itamarac·;-774766;-348303;0;26;Pernambuco;2451;81;America/Sao_Paulo
-2204659;Ilha Grande;-285774;-418186;0;22;PiauÌ;322;86;America/Sao_Paulo
-3520442;Ilha Solteira;-204326;-513426;0;35;S„o Paulo;2943;18;America/Sao_Paulo
-3520400;Ilhabela;-237785;-453552;0;35;S„o Paulo;6509;12;America/Sao_Paulo
-2913606;IlhÈus;-14793;-39046;0;29;Bahia;3573;73;America/Sao_Paulo
+2607604;Ilha de Itamarac√°;-774766;-348303;0;26;Pernambuco;2451;81;America/Sao_Paulo
+2204659;Ilha Grande;-285774;-418186;0;22;Piau√≠;322;86;America/Sao_Paulo
+3520442;Ilha Solteira;-204326;-513426;0;35;S√£o Paulo;2943;18;America/Sao_Paulo
+3520400;Ilhabela;-237785;-453552;0;35;S√£o Paulo;6509;12;America/Sao_Paulo
+2913606;Ilh√©us;-14793;-39046;0;29;Bahia;3573;73;America/Sao_Paulo
 4207106;Ilhota;-269023;-488251;0;42;Santa Catarina;8139;47;America/Sao_Paulo
-3130507;IlicÌnea;-209402;-458308;0;31;Minas Gerais;4609;35;America/Sao_Paulo
-4310306;IlÛpolis;-289282;-521258;0;43;Rio Grande do Sul;8707;51;America/Sao_Paulo
-2506707;Imaculada;-73889;-375079;0;25;ParaÌba;2035;83;America/Sao_Paulo
-4207205;ImaruÌ;-283339;-48817;0;42;Santa Catarina;8141;48;America/Sao_Paulo
-4110078;Imba˙;-24448;-507533;0;41;Paran·;862;42;America/Sao_Paulo
-4310330;ImbÈ;-299753;-501281;0;43;Rio Grande do Sul;7297;51;America/Sao_Paulo
-3130556;ImbÈ de Minas;-196017;-419695;0;31;Minas Gerais;626;33;America/Sao_Paulo
+3130507;Ilic√≠nea;-209402;-458308;0;31;Minas Gerais;4609;35;America/Sao_Paulo
+4310306;Il√≥polis;-289282;-521258;0;43;Rio Grande do Sul;8707;51;America/Sao_Paulo
+2506707;Imaculada;-73889;-375079;0;25;Para√≠ba;2035;83;America/Sao_Paulo
+4207205;Imaru√≠;-283339;-48817;0;42;Santa Catarina;8141;48;America/Sao_Paulo
+4110078;Imba√∫;-24448;-507533;0;41;Paran√°;862;42;America/Sao_Paulo
+4310330;Imb√©;-299753;-501281;0;43;Rio Grande do Sul;7297;51;America/Sao_Paulo
+3130556;Imb√© de Minas;-196017;-419695;0;31;Minas Gerais;626;33;America/Sao_Paulo
 4207304;Imbituba;-282284;-486659;0;42;Santa Catarina;8143;48;America/Sao_Paulo
-4110102;Imbituva;-252285;-505989;0;41;Paran·;7597;42;America/Sao_Paulo
+4110102;Imbituva;-252285;-505989;0;41;Paran√°;7597;42;America/Sao_Paulo
 4207403;Imbuia;-274908;-494218;0;42;Santa Catarina;8145;47;America/Sao_Paulo
 4310363;Imigrante;-293508;-517748;0;43;Rio Grande do Sul;7295;51;America/Sao_Paulo
-2105302;Imperatriz;-551847;-474777;0;21;Maranh„o;803;99;America/Sao_Paulo
-4110201;In·cio Martins;-255704;-510769;0;41;Paran·;7599;42;America/Sao_Paulo
-5209937;Inaciol‚ndia;-184869;-499888;0;52;Goi·s;69;64;America/Sao_Paulo
-2607000;Inaj·;-890206;-378351;0;26;Pernambuco;2439;87;America/Sao_Paulo
-4110300;Inaj·;-227509;-521995;0;41;Paran·;7601;44;America/Sao_Paulo
+2105302;Imperatriz;-551847;-474777;0;21;Maranh√£o;803;99;America/Sao_Paulo
+4110201;In√°cio Martins;-255704;-510769;0;41;Paran√°;7599;42;America/Sao_Paulo
+5209937;Inaciol√¢ndia;-184869;-499888;0;52;Goi√°s;69;64;America/Sao_Paulo
+2607000;Inaj√°;-890206;-378351;0;26;Pernambuco;2439;87;America/Sao_Paulo
+4110300;Inaj√°;-227509;-521995;0;41;Paran√°;7601;44;America/Sao_Paulo
 3130606;Inconfidentes;-223136;-463264;0;31;Minas Gerais;4611;35;America/Sao_Paulo
 3130655;Indaiabira;-154911;-422005;0;31;Minas Gerais;628;38;America/Sao_Paulo
 4207502;Indaial;-268992;-492354;0;42;Santa Catarina;8147;47;America/Sao_Paulo
-3520509;Indaiatuba;-230816;-472101;0;35;S„o Paulo;6511;19;America/Sao_Paulo
-4310405;IndependÍncia;-278354;-541886;0;43;Rio Grande do Sul;8709;55;America/Sao_Paulo
-2305605;IndependÍncia;-538789;-403085;0;23;Cear·;1413;88;America/Sao_Paulo
-3520608;Indiana;-221738;-512555;0;35;S„o Paulo;6513;18;America/Sao_Paulo
-4110409;IndianÛpolis;-234762;-526989;0;41;Paran·;7961;44;America/Sao_Paulo
-3130705;IndianÛpolis;-190341;-479155;0;31;Minas Gerais;4613;34;America/Sao_Paulo
-3520707;Indiapor„;-19979;-502909;0;35;S„o Paulo;6515;17;America/Sao_Paulo
-5209952;Indiara;-171387;-499862;0;52;Goi·s;9681;64;America/Sao_Paulo
+3520509;Indaiatuba;-230816;-472101;0;35;S√£o Paulo;6511;19;America/Sao_Paulo
+4310405;Independ√™ncia;-278354;-541886;0;43;Rio Grande do Sul;8709;55;America/Sao_Paulo
+2305605;Independ√™ncia;-538789;-403085;0;23;Cear√°;1413;88;America/Sao_Paulo
+3520608;Indiana;-221738;-512555;0;35;S√£o Paulo;6513;18;America/Sao_Paulo
+4110409;Indian√≥polis;-234762;-526989;0;41;Paran√°;7961;44;America/Sao_Paulo
+3130705;Indian√≥polis;-190341;-479155;0;31;Minas Gerais;4613;34;America/Sao_Paulo
+3520707;Indiapor√£;-19979;-502909;0;35;S√£o Paulo;6515;17;America/Sao_Paulo
+5209952;Indiara;-171387;-499862;0;52;Goi√°s;9681;64;America/Sao_Paulo
 2802809;Indiaroba;-115157;-37515;0;28;Sergipe;3155;79;America/Sao_Paulo
-5104500;IndiavaÌ;-154921;-585802;0;51;Mato Grosso;9877;65;America/Porto_Velho
-2506806;Ing·;-728144;-35605;0;25;ParaÌba;2037;83;America/Sao_Paulo
-3130804;IngaÌ;-214024;-449152;0;31;Minas Gerais;4615;35;America/Sao_Paulo
+5104500;Indiava√≠;-154921;-585802;0;51;Mato Grosso;9877;65;America/Porto_Velho
+2506806;Ing√°;-728144;-35605;0;25;Para√≠ba;2037;83;America/Sao_Paulo
+3130804;Inga√≠;-214024;-449152;0;31;Minas Gerais;4615;35;America/Sao_Paulo
 2607109;Ingazeira;-766909;-374576;0;26;Pernambuco;2441;87;America/Sao_Paulo
-4310413;Inhacor·;-278752;-54015;0;43;Rio Grande do Sul;6051;55;America/Sao_Paulo
+4310413;Inhacor√°;-278752;-54015;0;43;Rio Grande do Sul;6051;55;America/Sao_Paulo
 2913705;Inhambupe;-11781;-38355;0;29;Bahia;3575;75;America/Sao_Paulo
-1503408;Inhangapi;-14349;-479114;0;15;Par·;467;91;America/Sao_Paulo
+1503408;Inhangapi;-14349;-479114;0;15;Par√°;467;91;America/Sao_Paulo
 2703304;Inhapi;-922594;-377509;0;27;Alagoas;2765;82;America/Sao_Paulo
 3130903;Inhapim;-195476;-421147;0;31;Minas Gerais;4617;33;America/Sao_Paulo
-3131000;Inha˙ma;-194898;-443934;0;31;Minas Gerais;4619;31;America/Sao_Paulo
-2204709;Inhuma;-6665;-417041;0;22;PiauÌ;1093;89;America/Sao_Paulo
-5210000;Inhumas;-163611;-495001;0;52;Goi·s;9395;62;America/Sao_Paulo
+3131000;Inha√∫ma;-194898;-443934;0;31;Minas Gerais;4619;31;America/Sao_Paulo
+2204709;Inhuma;-6665;-417041;0;22;Piau√≠;1093;89;America/Sao_Paulo
+5210000;Inhumas;-163611;-495001;0;52;Goi√°s;9395;62;America/Sao_Paulo
 3131109;Inimutaba;-187271;-443584;0;31;Minas Gerais;4621;38;America/Sao_Paulo
-5004403;InocÍncia;-197277;-519281;0;50;Mato Grosso do Sul;9087;67;America/Porto_Velho
-3520806;In˙bia Paulista;-217695;-509633;0;35;S„o Paulo;6517;18;America/Sao_Paulo
-4207577;IomerÍ;-270019;-512442;0;42;Santa Catarina;922;49;America/Sao_Paulo
+5004403;Inoc√™ncia;-197277;-519281;0;50;Mato Grosso do Sul;9087;67;America/Porto_Velho
+3520806;In√∫bia Paulista;-217695;-509633;0;35;S√£o Paulo;6517;18;America/Sao_Paulo
+4207577;Iomer√™;-270019;-512442;0;42;Santa Catarina;922;49;America/Sao_Paulo
 3131158;Ipaba;-194158;-424139;0;31;Minas Gerais;2665;31;America/Sao_Paulo
-5210109;Ipameri;-177215;-481581;0;52;Goi·s;9397;64;America/Sao_Paulo
+5210109;Ipameri;-177215;-481581;0;52;Goi√°s;9397;64;America/Sao_Paulo
 3131208;Ipanema;-197992;-417164;0;31;Minas Gerais;4623;33;America/Sao_Paulo
-2404705;IpanguaÁu;-548984;-368501;0;24;Rio Grande do Norte;1691;84;America/Sao_Paulo
-2305654;Ipaporanga;-489764;-407537;0;23;Cear·;1259;88;America/Sao_Paulo
+2404705;Ipangua√ßu;-548984;-368501;0;24;Rio Grande do Norte;1691;84;America/Sao_Paulo
+2305654;Ipaporanga;-489764;-407537;0;23;Cear√°;1259;88;America/Sao_Paulo
 3131307;Ipatinga;-194703;-425476;0;31;Minas Gerais;4625;31;America/Sao_Paulo
-2305704;Ipaumirim;-678265;-387179;0;23;Cear·;1415;88;America/Sao_Paulo
-3520905;Ipaussu;-230575;-496279;0;35;S„o Paulo;6519;14;America/Sao_Paulo
-4310439;IpÍ;-288171;-512859;0;43;Rio Grande do Sul;8399;54;America/Sao_Paulo
-2913804;Ipecaet·;-123028;-393069;0;29;Bahia;3577;75;America/Sao_Paulo
-3521002;IperÛ;-233513;-476927;0;35;S„o Paulo;6521;15;America/Sao_Paulo
-3521101;Ipe˙na;-224355;-477151;0;35;S„o Paulo;6523;19;America/Sao_Paulo
-3131406;IpiaÁu;-186927;-499436;0;31;Minas Gerais;4627;34;America/Sao_Paulo
-2913903;Ipia˙;-141226;-397353;0;29;Bahia;3579;73;America/Sao_Paulo
-3521150;Ipigu·;-206557;-493842;0;35;S„o Paulo;800;17;America/Sao_Paulo
-2914000;Ipir·;-121561;-397359;0;29;Bahia;3581;75;America/Sao_Paulo
+2305704;Ipaumirim;-678265;-387179;0;23;Cear√°;1415;88;America/Sao_Paulo
+3520905;Ipaussu;-230575;-496279;0;35;S√£o Paulo;6519;14;America/Sao_Paulo
+4310439;Ip√™;-288171;-512859;0;43;Rio Grande do Sul;8399;54;America/Sao_Paulo
+2913804;Ipecaet√°;-123028;-393069;0;29;Bahia;3577;75;America/Sao_Paulo
+3521002;Iper√≥;-233513;-476927;0;35;S√£o Paulo;6521;15;America/Sao_Paulo
+3521101;Ipe√∫na;-224355;-477151;0;35;S√£o Paulo;6523;19;America/Sao_Paulo
+3131406;Ipia√ßu;-186927;-499436;0;31;Minas Gerais;4627;34;America/Sao_Paulo
+2913903;Ipia√∫;-141226;-397353;0;29;Bahia;3579;73;America/Sao_Paulo
+3521150;Ipigu√°;-206557;-493842;0;35;S√£o Paulo;800;17;America/Sao_Paulo
+2914000;Ipir√°;-121561;-397359;0;29;Bahia;3581;75;America/Sao_Paulo
 4207601;Ipira;-274038;-517758;0;42;Santa Catarina;8149;49;America/Sao_Paulo
-4110508;Ipiranga;-250238;-505794;0;41;Paran·;7603;42;America/Sao_Paulo
-5210158;Ipiranga de Goi·s;-151689;-496695;0;52;Goi·s;1074;62;America/Sao_Paulo
+4110508;Ipiranga;-250238;-505794;0;41;Paran√°;7603;42;America/Sao_Paulo
+5210158;Ipiranga de Goi√°s;-151689;-496695;0;52;Goi√°s;1074;62;America/Sao_Paulo
 5104526;Ipiranga do Norte;-122408;-561531;0;51;Mato Grosso;1184;65;America/Porto_Velho
-2204808;Ipiranga do PiauÌ;-682421;-417381;0;22;PiauÌ;1095;89;America/Sao_Paulo
+2204808;Ipiranga do Piau√≠;-682421;-417381;0;22;Piau√≠;1095;89;America/Sao_Paulo
 4310462;Ipiranga do Sul;-279404;-524271;0;43;Rio Grande do Sul;7399;54;America/Sao_Paulo
 1301803;Ipixuna;-704791;-716934;0;13;Amazonas;239;97;America/Rio_Branco
-1503457;Ipixuna do Par·;-255992;-475059;0;15;Par·;621;91;America/Sao_Paulo
+1503457;Ipixuna do Par√°;-255992;-475059;0;15;Par√°;621;91;America/Sao_Paulo
 2607208;Ipojuca;-839303;-350609;0;26;Pernambuco;2443;81;America/Sao_Paulo
-4110607;Ipor„;-240083;-53706;0;41;Paran·;7605;44;America/Sao_Paulo
-5210208;Ipor·;-164398;-51118;0;52;Goi·s;9399;64;America/Sao_Paulo
-4207650;Ipor„ do Oeste;-269854;-535355;0;42;Santa Catarina;9951;49;America/Sao_Paulo
-3521200;Iporanga;-245847;-485971;0;35;S„o Paulo;6525;15;America/Sao_Paulo
-2305803;Ipu;-431748;-407059;0;23;Cear·;1417;88;America/Sao_Paulo
-3521309;Ipu„;-204438;-480129;0;35;S„o Paulo;6527;16;America/Sao_Paulo
-4207684;IpuaÁu;-26635;-524556;0;42;Santa Catarina;5737;49;America/Sao_Paulo
+4110607;Ipor√£;-240083;-53706;0;41;Paran√°;7605;44;America/Sao_Paulo
+5210208;Ipor√°;-164398;-51118;0;52;Goi√°s;9399;64;America/Sao_Paulo
+4207650;Ipor√£ do Oeste;-269854;-535355;0;42;Santa Catarina;9951;49;America/Sao_Paulo
+3521200;Iporanga;-245847;-485971;0;35;S√£o Paulo;6525;15;America/Sao_Paulo
+2305803;Ipu;-431748;-407059;0;23;Cear√°;1417;88;America/Sao_Paulo
+3521309;Ipu√£;-204438;-480129;0;35;S√£o Paulo;6527;16;America/Sao_Paulo
+4207684;Ipua√ßu;-26635;-524556;0;42;Santa Catarina;5737;49;America/Sao_Paulo
 2607307;Ipubi;-764505;-401476;0;26;Pernambuco;2445;87;America/Sao_Paulo
 2404804;Ipueira;-680596;-372045;0;24;Rio Grande do Norte;1693;84;America/Sao_Paulo
 1709807;Ipueiras;-112329;-4846;0;17;Tocantins;84;63;America/Sao_Paulo
-2305902;Ipueiras;-453802;-407118;0;23;Cear·;1419;88;America/Sao_Paulo
-3131505;Ipui˙na;-221013;-461915;0;31;Minas Gerais;4629;35;America/Sao_Paulo
+2305902;Ipueiras;-453802;-407118;0;23;Cear√°;1419;88;America/Sao_Paulo
+3131505;Ipui√∫na;-221013;-461915;0;31;Minas Gerais;4629;35;America/Sao_Paulo
 4207700;Ipumirim;-270772;-521289;0;42;Santa Catarina;8151;49;America/Sao_Paulo
 2914109;Ipupiara;-118219;-426179;0;29;Bahia;3583;77;America/Sao_Paulo
 1400282;Iracema;218305;-610415;0;14;Roraima;32;95;America/Porto_Velho
-2306009;Iracema;-58124;-382919;0;23;Cear·;1421;88;America/Sao_Paulo
-4110656;Iracema do Oeste;-244262;-533528;0;41;Paran·;5485;44;America/Sao_Paulo
-3521408;Iracem·polis;-225832;-47523;0;35;S„o Paulo;6529;19;America/Sao_Paulo
+2306009;Iracema;-58124;-382919;0;23;Cear√°;1421;88;America/Sao_Paulo
+4110656;Iracema do Oeste;-244262;-533528;0;41;Paran√°;5485;44;America/Sao_Paulo
+3521408;Iracem√°polis;-225832;-47523;0;35;S√£o Paulo;6529;19;America/Sao_Paulo
 4207759;Iraceminha;-268215;-532767;0;42;Santa Catarina;9953;49;America/Sao_Paulo
-4310504;IraÌ;-271951;-532543;0;43;Rio Grande do Sul;8711;55;America/Sao_Paulo
-3131604;IraÌ de Minas;-189819;-47461;0;31;Minas Gerais;4631;34;America/Sao_Paulo
+4310504;Ira√≠;-271951;-532543;0;43;Rio Grande do Sul;8711;55;America/Sao_Paulo
+3131604;Ira√≠ de Minas;-189819;-47461;0;31;Minas Gerais;4631;34;America/Sao_Paulo
 2914208;Irajuba;-132563;-400848;0;29;Bahia;3585;73;America/Sao_Paulo
 2914307;Iramaia;-132902;-409595;0;29;Bahia;3587;77;America/Sao_Paulo
 1301852;Iranduba;-327479;-6019;0;13;Amazonas;9835;92;America/Porto_Velho
 4207809;Irani;-270287;-519012;0;42;Santa Catarina;8153;49;America/Sao_Paulo
-3521507;Irapu„;-212768;-494164;0;35;S„o Paulo;6531;17;America/Sao_Paulo
-3521606;Irapuru;-215684;-513472;0;35;S„o Paulo;6533;18;America/Sao_Paulo
+3521507;Irapu√£;-212768;-494164;0;35;S√£o Paulo;6531;17;America/Sao_Paulo
+3521606;Irapuru;-215684;-513472;0;35;S√£o Paulo;6533;18;America/Sao_Paulo
 2914406;Iraquara;-122429;-416155;0;29;Bahia;3589;75;America/Sao_Paulo
-2914505;Irar·;-120504;-387631;0;29;Bahia;3591;75;America/Sao_Paulo
-4110706;Irati;-254697;-506493;0;41;Paran·;7607;42;America/Sao_Paulo
+2914505;Irar√°;-120504;-387631;0;29;Bahia;3591;75;America/Sao_Paulo
+4110706;Irati;-254697;-506493;0;41;Paran√°;7607;42;America/Sao_Paulo
 4207858;Irati;-266539;-528955;0;42;Santa Catarina;5585;49;America/Sao_Paulo
-2306108;IrauÁuba;-374737;-397843;0;23;Cear·;1423;88;America/Sao_Paulo
-2914604;IrecÍ;-113033;-418535;0;29;Bahia;3593;74;America/Sao_Paulo
-4110805;Iretama;-244253;-521012;0;41;Paran·;7609;44;America/Sao_Paulo
-4207908;IrineÛpolis;-26242;-507957;0;42;Santa Catarina;8155;47;America/Sao_Paulo
-1503507;Irituia;-176984;-47446;0;15;Par·;469;91;America/Sao_Paulo
-3202652;Irupi;-203501;-416444;0;32;EspÌrito Santo;2931;28;America/Sao_Paulo
-2204907;IsaÌas Coelho;-773597;-416735;0;22;PiauÌ;1097;89;America/Sao_Paulo
-5210307;Israel‚ndia;-163144;-509087;0;52;Goi·s;9401;64;America/Sao_Paulo
-4208005;It·;-272907;-523212;0;42;Santa Catarina;8157;49;America/Sao_Paulo
+2306108;Irau√ßuba;-374737;-397843;0;23;Cear√°;1423;88;America/Sao_Paulo
+2914604;Irec√™;-113033;-418535;0;29;Bahia;3593;74;America/Sao_Paulo
+4110805;Iretama;-244253;-521012;0;41;Paran√°;7609;44;America/Sao_Paulo
+4207908;Irine√≥polis;-26242;-507957;0;42;Santa Catarina;8155;47;America/Sao_Paulo
+1503507;Irituia;-176984;-47446;0;15;Par√°;469;91;America/Sao_Paulo
+3202652;Irupi;-203501;-416444;0;32;Esp√≠rito Santo;2931;28;America/Sao_Paulo
+2204907;Isa√≠as Coelho;-773597;-416735;0;22;Piau√≠;1097;89;America/Sao_Paulo
+5210307;Israel√¢ndia;-163144;-509087;0;52;Goi√°s;9401;64;America/Sao_Paulo
+4208005;It√°;-272907;-523212;0;42;Santa Catarina;8157;49;America/Sao_Paulo
 4310538;Itaara;-296013;-537725;0;43;Rio Grande do Sul;990;55;America/Sao_Paulo
-2506905;Itabaiana;-733167;-353317;0;25;ParaÌba;2039;83;America/Sao_Paulo
+2506905;Itabaiana;-733167;-353317;0;25;Para√≠ba;2039;83;America/Sao_Paulo
 2802908;Itabaiana;-106826;-374273;0;28;Sergipe;3157;79;America/Sao_Paulo
 2803005;Itabaianinha;-112693;-377875;0;28;Sergipe;3159;79;America/Sao_Paulo
 2914653;Itabela;-165732;-395593;0;29;Bahia;3279;73;America/Sao_Paulo
-3521705;Itaber·;-238638;-4914;0;35;S„o Paulo;6535;15;America/Sao_Paulo
+3521705;Itaber√°;-238638;-4914;0;35;S√£o Paulo;6535;15;America/Sao_Paulo
 2914703;Itaberaba;-125242;-403059;0;29;Bahia;3595;75;America/Sao_Paulo
-5210406;ItaberaÌ;-160206;-49806;0;52;Goi·s;9403;62;America/Sao_Paulo
+5210406;Itabera√≠;-160206;-49806;0;52;Goi√°s;9403;62;America/Sao_Paulo
 2803104;Itabi;-101248;-371056;0;28;Sergipe;3161;79;America/Sao_Paulo
 3131703;Itabira;-196239;-432312;0;31;Minas Gerais;4633;31;America/Sao_Paulo
 3131802;Itabirinha;-185712;-41234;0;31;Minas Gerais;4635;33;America/Sao_Paulo
 3131901;Itabirito;-202501;-438038;0;31;Minas Gerais;4637;31;America/Sao_Paulo
-3301900;ItaboraÌ;-227565;-428639;0;33;Rio de Janeiro;5837;21;America/Sao_Paulo
+3301900;Itabora√≠;-227565;-428639;0;33;Rio de Janeiro;5837;21;America/Sao_Paulo
 2914802;Itabuna;-147876;-392781;0;29;Bahia;3597;73;America/Sao_Paulo
-1710508;Itacaj·;-839293;-477726;0;17;Tocantins;9405;63;America/Sao_Paulo
+1710508;Itacaj√°;-839293;-477726;0;17;Tocantins;9405;63;America/Sao_Paulo
 3132008;Itacambira;-170625;-433069;0;31;Minas Gerais;4639;38;America/Sao_Paulo
 3132107;Itacarambi;-15089;-44095;0;31;Minas Gerais;4641;38;America/Sao_Paulo
-2914901;ItacarÈ;-142784;-389959;0;29;Bahia;3599;73;America/Sao_Paulo
+2914901;Itacar√©;-142784;-389959;0;29;Bahia;3599;73;America/Sao_Paulo
 1301902;Itacoatiara;-313861;-584449;0;13;Amazonas;241;92;America/Porto_Velho
 2607406;Itacuruba;-882231;-386975;0;26;Pernambuco;2447;87;America/Sao_Paulo
 4310553;Itacurubi;-287913;-552447;0;43;Rio Grande do Sul;7397;55;America/Sao_Paulo
-2915007;ItaetÈ;-129831;-409677;0;29;Bahia;3601;75;America/Sao_Paulo
+2915007;Itaet√©;-129831;-409677;0;29;Bahia;3601;75;America/Sao_Paulo
 2915106;Itagi;-141615;-400131;0;29;Bahia;3603;73;America/Sao_Paulo
-2915205;Itagib·;-142782;-398449;0;29;Bahia;3605;73;America/Sao_Paulo
+2915205;Itagib√°;-142782;-398449;0;29;Bahia;3605;73;America/Sao_Paulo
 2915304;Itagimirim;-160819;-396133;0;29;Bahia;3607;73;America/Sao_Paulo
-3202702;ItaguaÁu;-198018;-408601;0;32;EspÌrito Santo;5653;27;America/Sao_Paulo
-2915353;ItaguaÁu da Bahia;-110147;-423997;0;29;Bahia;3281;74;America/Sao_Paulo
-3302007;ItaguaÌ;-228636;-437798;0;33;Rio de Janeiro;5839;21;America/Sao_Paulo
-4110904;ItaguajÈ;-226183;-519674;0;41;Paran·;7611;44;America/Sao_Paulo
+3202702;Itagua√ßu;-198018;-408601;0;32;Esp√≠rito Santo;5653;27;America/Sao_Paulo
+2915353;Itagua√ßu da Bahia;-110147;-423997;0;29;Bahia;3281;74;America/Sao_Paulo
+3302007;Itagua√≠;-228636;-437798;0;33;Rio de Janeiro;5839;21;America/Sao_Paulo
+4110904;Itaguaj√©;-226183;-519674;0;41;Paran√°;7611;44;America/Sao_Paulo
 3132206;Itaguara;-203947;-444875;0;31;Minas Gerais;4643;31;America/Sao_Paulo
-5210562;Itaguari;-15918;-496071;0;52;Goi·s;9919;62;America/Sao_Paulo
-5210604;Itaguaru;-157565;-496354;0;52;Goi·s;9407;62;America/Sao_Paulo
+5210562;Itaguari;-15918;-496071;0;52;Goi√°s;9919;62;America/Sao_Paulo
+5210604;Itaguaru;-157565;-496354;0;52;Goi√°s;9407;62;America/Sao_Paulo
 1710706;Itaguatins;-577267;-474864;0;17;Tocantins;9409;63;America/Sao_Paulo
-3521804;ItaÌ;-234213;-49092;0;35;S„o Paulo;6537;14;America/Sao_Paulo
-2607505;ItaÌba;-894569;-374173;0;26;Pernambuco;2449;87;America/Sao_Paulo
-2306207;ItaiÁaba;-467146;-37833;0;23;Cear·;1425;88;America/Sao_Paulo
-2205003;ItainÛpolis;-744336;-414687;0;22;PiauÌ;1099;89;America/Sao_Paulo
-4208104;ItaiÛpolis;-26339;-499092;0;42;Santa Catarina;8159;47;America/Sao_Paulo
-2105351;Itaipava do Graja˙;-514252;-457877;0;21;Maranh„o;172;99;America/Sao_Paulo
-3132305;ItaipÈ;-174014;-416697;0;31;Minas Gerais;4645;33;America/Sao_Paulo
-4110953;Itaipul‚ndia;-251366;-543001;0;41;Paran·;5525;45;America/Sao_Paulo
-2306256;Itaitinga;-396577;-385298;0;23;Cear·;991;85;America/Sao_Paulo
-1503606;Itaituba;-42667;-559926;0;15;Par·;471;93;America/Sao_Paulo
-2404853;Itaj·;-563894;-368712;0;24;Rio Grande do Norte;418;84;America/Sao_Paulo
-5210802;Itaj·;-190673;-515495;0;52;Goi·s;9411;64;America/Sao_Paulo
-4208203;ItajaÌ;-269101;-486705;0;42;Santa Catarina;8161;47;America/Sao_Paulo
-3521903;Itajobi;-213123;-490629;0;35;S„o Paulo;6539;17;America/Sao_Paulo
-3522000;Itaju;-219857;-488116;0;35;S„o Paulo;6541;14;America/Sao_Paulo
-2915403;Itaju do ColÙnia;-151366;-397283;0;29;Bahia;3609;73;America/Sao_Paulo
-3132404;Itajub·;-224225;-454598;0;31;Minas Gerais;4647;35;America/Sao_Paulo
-2915502;ItajuÌpe;-146788;-393698;0;29;Bahia;3611;73;America/Sao_Paulo
+3521804;Ita√≠;-234213;-49092;0;35;S√£o Paulo;6537;14;America/Sao_Paulo
+2607505;Ita√≠ba;-894569;-374173;0;26;Pernambuco;2449;87;America/Sao_Paulo
+2306207;Itai√ßaba;-467146;-37833;0;23;Cear√°;1425;88;America/Sao_Paulo
+2205003;Itain√≥polis;-744336;-414687;0;22;Piau√≠;1099;89;America/Sao_Paulo
+4208104;Itai√≥polis;-26339;-499092;0;42;Santa Catarina;8159;47;America/Sao_Paulo
+2105351;Itaipava do Graja√∫;-514252;-457877;0;21;Maranh√£o;172;99;America/Sao_Paulo
+3132305;Itaip√©;-174014;-416697;0;31;Minas Gerais;4645;33;America/Sao_Paulo
+4110953;Itaipul√¢ndia;-251366;-543001;0;41;Paran√°;5525;45;America/Sao_Paulo
+2306256;Itaitinga;-396577;-385298;0;23;Cear√°;991;85;America/Sao_Paulo
+1503606;Itaituba;-42667;-559926;0;15;Par√°;471;93;America/Sao_Paulo
+2404853;Itaj√°;-563894;-368712;0;24;Rio Grande do Norte;418;84;America/Sao_Paulo
+5210802;Itaj√°;-190673;-515495;0;52;Goi√°s;9411;64;America/Sao_Paulo
+4208203;Itaja√≠;-269101;-486705;0;42;Santa Catarina;8161;47;America/Sao_Paulo
+3521903;Itajobi;-213123;-490629;0;35;S√£o Paulo;6539;17;America/Sao_Paulo
+3522000;Itaju;-219857;-488116;0;35;S√£o Paulo;6541;14;America/Sao_Paulo
+2915403;Itaju do Col√¥nia;-151366;-397283;0;29;Bahia;3609;73;America/Sao_Paulo
+3132404;Itajub√°;-224225;-454598;0;31;Minas Gerais;4647;35;America/Sao_Paulo
+2915502;Itaju√≠pe;-146788;-393698;0;29;Bahia;3611;73;America/Sao_Paulo
 3302056;Italva;-214296;-417014;0;33;Rio de Janeiro;5929;22;America/Sao_Paulo
 2915601;Itamaraju;-170378;-395386;0;29;Bahia;3613;73;America/Sao_Paulo
 3132503;Itamarandiba;-178552;-428561;0;31;Minas Gerais;4649;38;America/Sao_Paulo
@@ -2339,531 +2339,531 @@ codigo_ibge;municipio;latitude;longitude;capital;codigo_uf;estado;siafi_id;ddd;f
 3132602;Itamarati de Minas;-214179;-42813;0;31;Minas Gerais;4651;32;America/Sao_Paulo
 2915700;Itamari;-137782;-39683;0;29;Bahia;3615;73;America/Sao_Paulo
 3132701;Itambacuri;-18035;-41683;0;31;Minas Gerais;4653;33;America/Sao_Paulo
-4111001;Itambarac·;-230181;-504097;0;41;Paran·;7613;43;America/Sao_Paulo
-4111100;ItambÈ;-236601;-519912;0;41;Paran·;7615;44;America/Sao_Paulo
-2607653;ItambÈ;-741403;-350963;0;26;Pernambuco;2597;81;America/Sao_Paulo
-2915809;ItambÈ;-152429;-4063;0;29;Bahia;3617;77;America/Sao_Paulo
-3132800;ItambÈ do Mato Dentro;-194158;-433182;0;31;Minas Gerais;4655;31;America/Sao_Paulo
+4111001;Itambarac√°;-230181;-504097;0;41;Paran√°;7613;43;America/Sao_Paulo
+4111100;Itamb√©;-236601;-519912;0;41;Paran√°;7615;44;America/Sao_Paulo
+2607653;Itamb√©;-741403;-350963;0;26;Pernambuco;2597;81;America/Sao_Paulo
+2915809;Itamb√©;-152429;-4063;0;29;Bahia;3617;77;America/Sao_Paulo
+3132800;Itamb√© do Mato Dentro;-194158;-433182;0;31;Minas Gerais;4655;31;America/Sao_Paulo
 3132909;Itamogi;-210758;-47046;0;31;Minas Gerais;4657;35;America/Sao_Paulo
 3133006;Itamonte;-222859;-44868;0;31;Minas Gerais;4659;35;America/Sao_Paulo
 2915908;Itanagra;-122614;-380436;0;29;Bahia;3619;75;America/Sao_Paulo
-3522109;ItanhaÈm;-241736;-46788;0;35;S„o Paulo;6543;13;America/Sao_Paulo
+3522109;Itanha√©m;-241736;-46788;0;35;S√£o Paulo;6543;13;America/Sao_Paulo
 3133105;Itanhandu;-222942;-449382;0;31;Minas Gerais;4661;35;America/Sao_Paulo
-5104542;Itanhang·;-122259;-566463;0;51;Mato Grosso;1186;66;America/Porto_Velho
-2916005;ItanhÈm;-171642;-403321;0;29;Bahia;3621;73;America/Sao_Paulo
+5104542;Itanhang√°;-122259;-566463;0;51;Mato Grosso;1186;66;America/Porto_Velho
+2916005;Itanh√©m;-171642;-403321;0;29;Bahia;3621;73;America/Sao_Paulo
 3133204;Itanhomi;-191736;-41863;0;31;Minas Gerais;4663;33;America/Sao_Paulo
 3133303;Itaobim;-165571;-415017;0;31;Minas Gerais;4665;33;America/Sao_Paulo
-3522158;ItaÛca;-246393;-488413;0;35;S„o Paulo;3053;15;America/Sao_Paulo
+3522158;Ita√≥ca;-246393;-488413;0;35;S√£o Paulo;3053;15;America/Sao_Paulo
 3302106;Itaocara;-216748;-420758;0;33;Rio de Janeiro;5841;22;America/Sao_Paulo
-5210901;Itapaci;-149522;-495511;0;52;Goi·s;9413;62;America/Sao_Paulo
+5210901;Itapaci;-149522;-495511;0;52;Goi√°s;9413;62;America/Sao_Paulo
 3133402;Itapagipe;-199062;-493781;0;31;Minas Gerais;4667;34;America/Sao_Paulo
-2306306;ItapajÈ;-368314;-395855;0;23;Cear·;1427;85;America/Sao_Paulo
+2306306;Itapaj√©;-368314;-395855;0;23;Cear√°;1427;85;America/Sao_Paulo
 2916104;Itaparica;-128932;-3868;0;29;Bahia;3623;71;America/Sao_Paulo
-2916203;ItapÈ;-148876;-394239;0;29;Bahia;3625;73;America/Sao_Paulo
+2916203;Itap√©;-148876;-394239;0;29;Bahia;3625;73;America/Sao_Paulo
 2916302;Itapebi;-159551;-395329;0;29;Bahia;3627;73;America/Sao_Paulo
 3133501;Itapecerica;-204704;-45127;0;31;Minas Gerais;4669;37;America/Sao_Paulo
-3522208;Itapecerica da Serra;-237161;-468572;0;35;S„o Paulo;6545;11;America/Sao_Paulo
-2105401;Itapecuru Mirim;-340202;-443508;0;21;Maranh„o;807;98;America/Sao_Paulo
-4111209;Itapejara d'Oeste;-259619;-528152;0;41;Paran·;7617;46;America/Sao_Paulo
+3522208;Itapecerica da Serra;-237161;-468572;0;35;S√£o Paulo;6545;11;America/Sao_Paulo
+2105401;Itapecuru Mirim;-340202;-443508;0;21;Maranh√£o;807;98;America/Sao_Paulo
+4111209;Itapejara d'Oeste;-259619;-528152;0;41;Paran√°;7617;46;America/Sao_Paulo
 4208302;Itapema;-270861;-48616;0;42;Santa Catarina;8163;47;America/Sao_Paulo
-3202801;Itapemirim;-210095;-408307;0;32;EspÌrito Santo;5655;28;America/Sao_Paulo
-4111258;ItaperuÁu;-252193;-493454;0;41;Paran·;5451;41;America/Sao_Paulo
+3202801;Itapemirim;-210095;-408307;0;32;Esp√≠rito Santo;5655;28;America/Sao_Paulo
+4111258;Itaperu√ßu;-252193;-493454;0;41;Paran√°;5451;41;America/Sao_Paulo
 3302205;Itaperuna;-211997;-418799;0;33;Rio de Janeiro;5843;22;America/Sao_Paulo
 2607703;Itapetim;-737178;-371863;0;26;Pernambuco;2453;87;America/Sao_Paulo
 2916401;Itapetinga;-152475;-402482;0;29;Bahia;3629;77;America/Sao_Paulo
-3522307;Itapetininga;-235886;-480483;0;35;S„o Paulo;6547;15;America/Sao_Paulo
-3522406;Itapeva;-239788;-488764;0;35;S„o Paulo;6549;15;America/Sao_Paulo
+3522307;Itapetininga;-235886;-480483;0;35;S√£o Paulo;6547;15;America/Sao_Paulo
+3522406;Itapeva;-239788;-488764;0;35;S√£o Paulo;6549;15;America/Sao_Paulo
 3133600;Itapeva;-227665;-462241;0;31;Minas Gerais;4671;35;America/Sao_Paulo
-3522505;Itapevi;-235488;-469327;0;35;S„o Paulo;6551;11;America/Sao_Paulo
+3522505;Itapevi;-235488;-469327;0;35;S√£o Paulo;6551;11;America/Sao_Paulo
 2916500;Itapicuru;-113088;-382262;0;29;Bahia;3631;75;America/Sao_Paulo
-2306405;Itapipoca;-349933;-395836;0;23;Cear·;1429;88;America/Sao_Paulo
-3522604;Itapira;-224357;-468224;0;35;S„o Paulo;6553;19;America/Sao_Paulo
+2306405;Itapipoca;-349933;-395836;0;23;Cear√°;1429;88;America/Sao_Paulo
+3522604;Itapira;-224357;-468224;0;35;S√£o Paulo;6553;19;America/Sao_Paulo
 1302009;Itapiranga;-274081;-580293;0;13;Amazonas;243;92;America/Porto_Velho
 4208401;Itapiranga;-271659;-537166;0;42;Santa Catarina;8165;49;America/Sao_Paulo
-5211008;Itapirapu„;-158205;-506094;0;52;Goi·s;9415;62;America/Sao_Paulo
-3522653;Itapirapu„ Paulista;-24572;-491661;0;35;S„o Paulo;3055;15;America/Sao_Paulo
+5211008;Itapirapu√£;-158205;-506094;0;52;Goi√°s;9415;62;America/Sao_Paulo
+3522653;Itapirapu√£ Paulista;-24572;-491661;0;35;S√£o Paulo;3055;15;America/Sao_Paulo
 1710904;Itapiratins;-837982;-481072;0;17;Tocantins;347;63;America/Sao_Paulo
 2607752;Itapissuma;-776798;-348971;0;26;Pernambuco;2633;81;America/Sao_Paulo
 2916609;Itapitanga;-144139;-395657;0;29;Bahia;3633;73;America/Sao_Paulo
-2306504;Itapi˙na;-455516;-389281;0;23;Cear·;1431;88;America/Sao_Paulo
-4208450;Itapo·;-261158;-486182;0;42;Santa Catarina;9985;47;America/Sao_Paulo
-3522703;It·polis;-215942;-488149;0;35;S„o Paulo;6555;16;America/Sao_Paulo
-5004502;Itapor„;-2208;-547934;0;50;Mato Grosso do Sul;9089;67;America/Porto_Velho
-1711100;Itapor„ do Tocantins;-857172;-486895;0;17;Tocantins;9417;63;America/Sao_Paulo
-3522802;Itaporanga;-237043;-494819;0;35;S„o Paulo;6557;15;America/Sao_Paulo
-2507002;Itaporanga;-730202;-381504;0;25;ParaÌba;2041;83;America/Sao_Paulo
+2306504;Itapi√∫na;-455516;-389281;0;23;Cear√°;1431;88;America/Sao_Paulo
+4208450;Itapo√°;-261158;-486182;0;42;Santa Catarina;9985;47;America/Sao_Paulo
+3522703;It√°polis;-215942;-488149;0;35;S√£o Paulo;6555;16;America/Sao_Paulo
+5004502;Itapor√£;-2208;-547934;0;50;Mato Grosso do Sul;9089;67;America/Porto_Velho
+1711100;Itapor√£ do Tocantins;-857172;-486895;0;17;Tocantins;9417;63;America/Sao_Paulo
+3522802;Itaporanga;-237043;-494819;0;35;S√£o Paulo;6557;15;America/Sao_Paulo
+2507002;Itaporanga;-730202;-381504;0;25;Para√≠ba;2041;83;America/Sao_Paulo
 2803203;Itaporanga d'Ajuda;-1099;-373078;0;28;Sergipe;3163;79;America/Sao_Paulo
-2507101;Itapororoca;-682374;-352406;0;25;ParaÌba;2043;83;America/Sao_Paulo
-1101104;Itapu„ do Oeste;-919687;-631809;0;11;RondÙnia;683;69;America/Porto_Velho
+2507101;Itapororoca;-682374;-352406;0;25;Para√≠ba;2043;83;America/Sao_Paulo
+1101104;Itapu√£ do Oeste;-919687;-631809;0;11;Rond√¥nia;683;69;America/Porto_Velho
 4310579;Itapuca;-287768;-521693;0;43;Rio Grande do Sul;6027;51;America/Sao_Paulo
-3522901;ItapuÌ;-222324;-487197;0;35;S„o Paulo;6559;14;America/Sao_Paulo
-3523008;Itapura;-206419;-515063;0;35;S„o Paulo;6561;18;America/Sao_Paulo
-5211206;Itapuranga;-155606;-49949;0;52;Goi·s;9419;62;America/Sao_Paulo
-3523107;Itaquaquecetuba;-234835;-463457;0;35;S„o Paulo;6563;11;America/Sao_Paulo
+3522901;Itapu√≠;-222324;-487197;0;35;S√£o Paulo;6559;14;America/Sao_Paulo
+3523008;Itapura;-206419;-515063;0;35;S√£o Paulo;6561;18;America/Sao_Paulo
+5211206;Itapuranga;-155606;-49949;0;52;Goi√°s;9419;62;America/Sao_Paulo
+3523107;Itaquaquecetuba;-234835;-463457;0;35;S√£o Paulo;6563;11;America/Sao_Paulo
 2916708;Itaquara;-134459;-399378;0;29;Bahia;3635;73;America/Sao_Paulo
 4310603;Itaqui;-291311;-565515;0;43;Rio Grande do Sul;8713;55;America/Sao_Paulo
-5004601;ItaquiraÌ;-234779;-54187;0;50;Mato Grosso do Sul;9807;67;America/Porto_Velho
+5004601;Itaquira√≠;-234779;-54187;0;50;Mato Grosso do Sul;9807;67;America/Porto_Velho
 2607802;Itaquitinga;-766373;-351002;0;26;Pernambuco;2455;81;America/Sao_Paulo
-3202900;Itarana;-19875;-408753;0;32;EspÌrito Santo;5657;27;America/Sao_Paulo
+3202900;Itarana;-19875;-408753;0;32;Esp√≠rito Santo;5657;27;America/Sao_Paulo
 2916807;Itarantim;-156528;-40065;0;29;Bahia;3637;73;America/Sao_Paulo
-3523206;ItararÈ;-241085;-493352;0;35;S„o Paulo;6565;15;America/Sao_Paulo
-2306553;Itarema;-29248;-399167;0;23;Cear·;1595;88;America/Sao_Paulo
-3523305;Itariri;-242834;-471736;0;35;S„o Paulo;6567;13;America/Sao_Paulo
-5211305;Itarum„;-187646;-513485;0;52;Goi·s;9421;64;America/Sao_Paulo
+3523206;Itarar√©;-241085;-493352;0;35;S√£o Paulo;6565;15;America/Sao_Paulo
+2306553;Itarema;-29248;-399167;0;23;Cear√°;1595;88;America/Sao_Paulo
+3523305;Itariri;-242834;-471736;0;35;S√£o Paulo;6567;13;America/Sao_Paulo
+5211305;Itarum√£;-187646;-513485;0;52;Goi√°s;9421;64;America/Sao_Paulo
 4310652;Itati;-294974;-501016;0;43;Rio Grande do Sul;1144;51;America/Sao_Paulo
 3302254;Itatiaia;-224897;-445675;0;33;Rio de Janeiro;6003;24;America/Sao_Paulo
-3133709;ItatiaiuÁu;-201983;-444211;0;31;Minas Gerais;4673;31;America/Sao_Paulo
-3523404;Itatiba;-230035;-468464;0;35;S„o Paulo;6569;11;America/Sao_Paulo
+3133709;Itatiaiu√ßu;-201983;-444211;0;31;Minas Gerais;4673;31;America/Sao_Paulo
+3523404;Itatiba;-230035;-468464;0;35;S√£o Paulo;6569;11;America/Sao_Paulo
 4310702;Itatiba do Sul;-273846;-524538;0;43;Rio Grande do Sul;8715;54;America/Sao_Paulo
 2916856;Itatim;-127099;-396952;0;29;Bahia;3283;75;America/Sao_Paulo
-3523503;Itatinga;-231047;-486157;0;35;S„o Paulo;6571;14;America/Sao_Paulo
-2306603;Itatira;-452608;-396202;0;23;Cear·;1433;88;America/Sao_Paulo
-2507200;Itatuba;-738115;-35638;0;25;ParaÌba;2045;83;America/Sao_Paulo
-2404903;Ita˙;-58363;-379912;0;24;Rio Grande do Norte;1695;84;America/Sao_Paulo
-3133758;Ita˙ de Minas;-207375;-467525;0;31;Minas Gerais;5731;35;America/Sao_Paulo
-5104559;Ita˙ba;-110614;-552766;0;51;Mato Grosso;9901;66;America/Porto_Velho
-1600253;Itaubal;602185;-506996;0;16;Amap·;669;96;America/Sao_Paulo
-5211404;ItauÁu;-162029;-496109;0;52;Goi·s;9423;62;America/Sao_Paulo
-2205102;Itaueira;-759989;-430249;0;22;PiauÌ;1101;89;America/Sao_Paulo
-3133808;Ita˙na;-200818;-445801;0;31;Minas Gerais;4675;37;America/Sao_Paulo
-4111308;Ita˙na do Sul;-227289;-528874;0;41;Paran·;7619;44;America/Sao_Paulo
+3523503;Itatinga;-231047;-486157;0;35;S√£o Paulo;6571;14;America/Sao_Paulo
+2306603;Itatira;-452608;-396202;0;23;Cear√°;1433;88;America/Sao_Paulo
+2507200;Itatuba;-738115;-35638;0;25;Para√≠ba;2045;83;America/Sao_Paulo
+2404903;Ita√∫;-58363;-379912;0;24;Rio Grande do Norte;1695;84;America/Sao_Paulo
+3133758;Ita√∫ de Minas;-207375;-467525;0;31;Minas Gerais;5731;35;America/Sao_Paulo
+5104559;Ita√∫ba;-110614;-552766;0;51;Mato Grosso;9901;66;America/Porto_Velho
+1600253;Itaubal;602185;-506996;0;16;Amap√°;669;96;America/Sao_Paulo
+5211404;Itau√ßu;-162029;-496109;0;52;Goi√°s;9423;62;America/Sao_Paulo
+2205102;Itaueira;-759989;-430249;0;22;Piau√≠;1101;89;America/Sao_Paulo
+3133808;Ita√∫na;-200818;-445801;0;31;Minas Gerais;4675;37;America/Sao_Paulo
+4111308;Ita√∫na do Sul;-227289;-528874;0;41;Paran√°;7619;44;America/Sao_Paulo
 3133907;Itaverava;-206769;-436141;0;31;Minas Gerais;4677;31;America/Sao_Paulo
 3134004;Itinga;-1661;-417672;0;31;Minas Gerais;4679;33;America/Sao_Paulo
-2105427;Itinga do Maranh„o;-445293;-475235;0;21;Maranh„o;174;99;America/Sao_Paulo
+2105427;Itinga do Maranh√£o;-445293;-475235;0;21;Maranh√£o;174;99;America/Sao_Paulo
 5104609;Itiquira;-172147;-541422;0;51;Mato Grosso;9091;65;America/Porto_Velho
-3523602;Itirapina;-222562;-478166;0;35;S„o Paulo;6573;19;America/Sao_Paulo
-3523701;Itirapu„;-206416;-472194;0;35;S„o Paulo;6575;16;America/Sao_Paulo
-2916906;ItiruÁu;-13529;-401472;0;29;Bahia;3639;73;America/Sao_Paulo
-2917003;Iti˙ba;-106948;-398446;0;29;Bahia;3641;74;America/Sao_Paulo
-3523800;Itobi;-217309;-469743;0;35;S„o Paulo;6577;19;America/Sao_Paulo
-2917102;ItororÛ;-1511;-400684;0;29;Bahia;3643;73;America/Sao_Paulo
-3523909;Itu;-232544;-472927;0;35;S„o Paulo;6579;11;America/Sao_Paulo
-2917201;ItuaÁu;-138107;-413003;0;29;Bahia;3645;77;America/Sao_Paulo
-2917300;Ituber·;-137249;-391481;0;29;Bahia;3647;73;America/Sao_Paulo
+3523602;Itirapina;-222562;-478166;0;35;S√£o Paulo;6573;19;America/Sao_Paulo
+3523701;Itirapu√£;-206416;-472194;0;35;S√£o Paulo;6575;16;America/Sao_Paulo
+2916906;Itiru√ßu;-13529;-401472;0;29;Bahia;3639;73;America/Sao_Paulo
+2917003;Iti√∫ba;-106948;-398446;0;29;Bahia;3641;74;America/Sao_Paulo
+3523800;Itobi;-217309;-469743;0;35;S√£o Paulo;6577;19;America/Sao_Paulo
+2917102;Itoror√≥;-1511;-400684;0;29;Bahia;3643;73;America/Sao_Paulo
+3523909;Itu;-232544;-472927;0;35;S√£o Paulo;6579;11;America/Sao_Paulo
+2917201;Itua√ßu;-138107;-413003;0;29;Bahia;3645;77;America/Sao_Paulo
+2917300;Ituber√°;-137249;-391481;0;29;Bahia;3647;73;America/Sao_Paulo
 3134103;Itueta;-193999;-411746;0;31;Minas Gerais;4681;33;America/Sao_Paulo
 3134202;Ituiutaba;-189772;-494639;0;31;Minas Gerais;4683;34;America/Sao_Paulo
-5211503;Itumbiara;-184093;-492158;0;52;Goi·s;9425;64;America/Sao_Paulo
+5211503;Itumbiara;-184093;-492158;0;52;Goi√°s;9425;64;America/Sao_Paulo
 3134301;Itumirim;-213171;-448724;0;31;Minas Gerais;4685;35;America/Sao_Paulo
-3524006;Itupeva;-231526;-470593;0;35;S„o Paulo;6581;11;America/Sao_Paulo
-1503705;Itupiranga;-513272;-493358;0;15;Par·;473;94;America/Sao_Paulo
+3524006;Itupeva;-231526;-470593;0;35;S√£o Paulo;6581;11;America/Sao_Paulo
+1503705;Itupiranga;-513272;-493358;0;15;Par√°;473;94;America/Sao_Paulo
 4208500;Ituporanga;-274101;-495963;0;42;Santa Catarina;8167;47;America/Sao_Paulo
 3134400;Iturama;-197276;-501966;0;31;Minas Gerais;4687;34;America/Sao_Paulo
 3134509;Itutinga;-213;-446567;0;31;Minas Gerais;4689;35;America/Sao_Paulo
-3524105;Ituverava;-203355;-477902;0;35;S„o Paulo;6583;16;America/Sao_Paulo
-2917334;Iui˙;-144054;-435595;0;29;Bahia;3285;77;America/Sao_Paulo
-3203007;I˙na;-203531;-415334;0;32;EspÌrito Santo;5659;28;America/Sao_Paulo
-4111407;IvaÌ;-250067;-50857;0;41;Paran·;7621;42;America/Sao_Paulo
-4111506;Ivaipor„;-242485;-516754;0;41;Paran·;7623;43;America/Sao_Paulo
-4111555;IvatÈ;-234072;-533687;0;41;Paran·;9955;44;America/Sao_Paulo
-4111605;Ivatuba;-236187;-522203;0;41;Paran·;7625;44;America/Sao_Paulo
+3524105;Ituverava;-203355;-477902;0;35;S√£o Paulo;6583;16;America/Sao_Paulo
+2917334;Iui√∫;-144054;-435595;0;29;Bahia;3285;77;America/Sao_Paulo
+3203007;I√∫na;-203531;-415334;0;32;Esp√≠rito Santo;5659;28;America/Sao_Paulo
+4111407;Iva√≠;-250067;-50857;0;41;Paran√°;7621;42;America/Sao_Paulo
+4111506;Ivaipor√£;-242485;-516754;0;41;Paran√°;7623;43;America/Sao_Paulo
+4111555;Ivat√©;-234072;-533687;0;41;Paran√°;9955;44;America/Sao_Paulo
+4111605;Ivatuba;-236187;-522203;0;41;Paran√°;7625;44;America/Sao_Paulo
 5004700;Ivinhema;-223046;-538184;0;50;Mato Grosso do Sul;9093;67;America/Porto_Velho
-5211602;Ivol‚ndia;-165995;-507921;0;52;Goi·s;9427;64;America/Sao_Paulo
-4310751;Ivor·;-295232;-535842;0;43;Rio Grande do Sul;7395;55;America/Sao_Paulo
+5211602;Ivol√¢ndia;-165995;-507921;0;52;Goi√°s;9427;64;America/Sao_Paulo
+4310751;Ivor√°;-295232;-535842;0;43;Rio Grande do Sul;7395;55;America/Sao_Paulo
 4310801;Ivoti;-295995;-511533;0;43;Rio Grande do Sul;8717;51;America/Sao_Paulo
-2607901;Jaboat„o dos Guararapes;-811298;-35015;0;26;Pernambuco;2457;81;America/Sao_Paulo
-4208609;Jabor·;-271782;-517279;0;42;Santa Catarina;8169;49;America/Sao_Paulo
+2607901;Jaboat√£o dos Guararapes;-811298;-35015;0;26;Pernambuco;2457;81;America/Sao_Paulo
+4208609;Jabor√°;-271782;-517279;0;42;Santa Catarina;8169;49;America/Sao_Paulo
 2917359;Jaborandi;-136071;-444255;0;29;Bahia;9859;77;America/Sao_Paulo
-3524204;Jaborandi;-206884;-484112;0;35;S„o Paulo;6585;17;America/Sao_Paulo
-4111704;Jaboti;-237435;-500729;0;41;Paran·;7627;43;America/Sao_Paulo
+3524204;Jaborandi;-206884;-484112;0;35;S√£o Paulo;6585;17;America/Sao_Paulo
+4111704;Jaboti;-237435;-500729;0;41;Paran√°;7627;43;America/Sao_Paulo
 4310850;Jaboticaba;-276347;-532762;0;43;Rio Grande do Sul;7393;55;America/Sao_Paulo
-3524303;Jaboticabal;-21252;-483252;0;35;S„o Paulo;6587;16;America/Sao_Paulo
+3524303;Jaboticabal;-21252;-483252;0;35;S√£o Paulo;6587;16;America/Sao_Paulo
 3134608;Jaboticatubas;-195119;-437373;0;31;Minas Gerais;4691;31;America/Sao_Paulo
-2405009;JaÁan„;-641856;-362031;0;24;Rio Grande do Norte;1697;84;America/Sao_Paulo
+2405009;Ja√ßan√£;-641856;-362031;0;24;Rio Grande do Norte;1697;84;America/Sao_Paulo
 2917409;Jacaraci;-148541;-424329;0;29;Bahia;3649;77;America/Sao_Paulo
-2507309;Jacara˙;-661453;-35289;0;25;ParaÌba;2047;83;America/Sao_Paulo
-2703403;JacarÈ dos Homens;-963545;-372076;0;27;Alagoas;2767;82;America/Sao_Paulo
-1503754;Jacareacanga;-621469;-577544;0;15;Par·;631;93;America/Sao_Paulo
-3524402;JacareÌ;-232983;-459658;0;35;S„o Paulo;6589;12;America/Sao_Paulo
-4111803;Jacarezinho;-231591;-499739;0;41;Paran·;7629;43;America/Sao_Paulo
-3524501;Jaci;-208805;-495797;0;35;S„o Paulo;6591;17;America/Sao_Paulo
+2507309;Jacara√∫;-661453;-35289;0;25;Para√≠ba;2047;83;America/Sao_Paulo
+2703403;Jacar√© dos Homens;-963545;-372076;0;27;Alagoas;2767;82;America/Sao_Paulo
+1503754;Jacareacanga;-621469;-577544;0;15;Par√°;631;93;America/Sao_Paulo
+3524402;Jacare√≠;-232983;-459658;0;35;S√£o Paulo;6589;12;America/Sao_Paulo
+4111803;Jacarezinho;-231591;-499739;0;41;Paran√°;7629;43;America/Sao_Paulo
+3524501;Jaci;-208805;-495797;0;35;S√£o Paulo;6591;17;America/Sao_Paulo
 5104807;Jaciara;-159548;-549733;0;51;Mato Grosso;9095;66;America/Porto_Velho
 3134707;Jacinto;-161428;-40295;0;31;Minas Gerais;4693;33;America/Sao_Paulo
 4208708;Jacinto Machado;-289961;-497623;0;42;Santa Catarina;8171;48;America/Sao_Paulo
 2917508;Jacobina;-111812;-405117;0;29;Bahia;3651;74;America/Sao_Paulo
-2205151;Jacobina do PiauÌ;-793063;-412075;0;22;PiauÌ;2273;89;America/Sao_Paulo
-3134806;JacuÌ;-210137;-467359;0;31;Minas Gerais;4695;35;America/Sao_Paulo
-2703502;JacuÌpe;-883951;-354591;0;27;Alagoas;2769;82;America/Sao_Paulo
+2205151;Jacobina do Piau√≠;-793063;-412075;0;22;Piau√≠;2273;89;America/Sao_Paulo
+3134806;Jacu√≠;-210137;-467359;0;31;Minas Gerais;4695;35;America/Sao_Paulo
+2703502;Jacu√≠pe;-883951;-354591;0;27;Alagoas;2769;82;America/Sao_Paulo
 4310876;Jacuizinho;-290401;-530657;0;43;Rio Grande do Sul;1146;55;America/Sao_Paulo
-1503804;Jacund·;-444617;-491153;0;15;Par·;475;94;America/Sao_Paulo
-3524600;Jacupiranga;-246963;-480064;0;35;S„o Paulo;6593;13;America/Sao_Paulo
+1503804;Jacund√°;-444617;-491153;0;15;Par√°;475;94;America/Sao_Paulo
+3524600;Jacupiranga;-246963;-480064;0;35;S√£o Paulo;6593;13;America/Sao_Paulo
 4310900;Jacutinga;-277291;-525372;0;43;Rio Grande do Sul;8719;54;America/Sao_Paulo
 3134905;Jacutinga;-22286;-466166;0;31;Minas Gerais;4697;35;America/Sao_Paulo
-4111902;Jaguapit„;-231104;-515342;0;41;Paran·;7631;43;America/Sao_Paulo
+4111902;Jaguapit√£;-231104;-515342;0;41;Paran√°;7631;43;America/Sao_Paulo
 2917607;Jaguaquara;-135248;-39964;0;29;Bahia;3653;73;America/Sao_Paulo
-3135001;JaguaraÁu;-19647;-427498;0;31;Minas Gerais;4699;31;America/Sao_Paulo
-4311007;Jaguar„o;-325604;-53377;0;43;Rio Grande do Sul;8721;53;America/Sao_Paulo
+3135001;Jaguara√ßu;-19647;-427498;0;31;Minas Gerais;4699;31;America/Sao_Paulo
+4311007;Jaguar√£o;-325604;-53377;0;43;Rio Grande do Sul;8721;53;America/Sao_Paulo
 2917706;Jaguarari;-102569;-401999;0;29;Bahia;3655;74;America/Sao_Paulo
-3203056;JaguarÈ;-18907;-400759;0;32;EspÌrito Santo;5713;27;America/Sao_Paulo
-2306702;Jaguaretama;-56051;-387639;0;23;Cear·;1435;88;America/Sao_Paulo
+3203056;Jaguar√©;-18907;-400759;0;32;Esp√≠rito Santo;5713;27;America/Sao_Paulo
+2306702;Jaguaretama;-56051;-387639;0;23;Cear√°;1435;88;America/Sao_Paulo
 4311106;Jaguari;-294936;-54703;0;43;Rio Grande do Sul;8723;55;America/Sao_Paulo
-4112009;JaguariaÌva;-242439;-497066;0;41;Paran·;7633;43;America/Sao_Paulo
-2306801;Jaguaribara;-567765;-385359;0;23;Cear·;1437;88;America/Sao_Paulo
-2306900;Jaguaribe;-590213;-386227;0;23;Cear·;1439;88;America/Sao_Paulo
+4112009;Jaguaria√≠va;-242439;-497066;0;41;Paran√°;7633;43;America/Sao_Paulo
+2306801;Jaguaribara;-567765;-385359;0;23;Cear√°;1437;88;America/Sao_Paulo
+2306900;Jaguaribe;-590213;-386227;0;23;Cear√°;1439;88;America/Sao_Paulo
 2917805;Jaguaripe;-131109;-388939;0;29;Bahia;3657;75;America/Sao_Paulo
-3524709;Jaguari˙na;-227037;-469851;0;35;S„o Paulo;6595;19;America/Sao_Paulo
-2307007;Jaguaruana;-483151;-37781;0;23;Cear·;1441;88;America/Sao_Paulo
+3524709;Jaguari√∫na;-227037;-469851;0;35;S√£o Paulo;6595;19;America/Sao_Paulo
+2307007;Jaguaruana;-483151;-37781;0;23;Cear√°;1441;88;America/Sao_Paulo
 4208807;Jaguaruna;-286146;-490296;0;42;Santa Catarina;8173;48;America/Sao_Paulo
-3135050;JaÌba;-153432;-436688;0;31;Minas Gerais;2893;38;America/Sao_Paulo
-2205201;JaicÛs;-736229;-411371;0;22;PiauÌ;1103;89;America/Sao_Paulo
-3524808;Jales;-202672;-505494;0;35;S„o Paulo;6597;17;America/Sao_Paulo
-3524907;Jambeiro;-232522;-456942;0;35;S„o Paulo;6599;12;America/Sao_Paulo
+3135050;Ja√≠ba;-153432;-436688;0;31;Minas Gerais;2893;38;America/Sao_Paulo
+2205201;Jaic√≥s;-736229;-411371;0;22;Piau√≠;1103;89;America/Sao_Paulo
+3524808;Jales;-202672;-505494;0;35;S√£o Paulo;6597;17;America/Sao_Paulo
+3524907;Jambeiro;-232522;-456942;0;35;S√£o Paulo;6599;12;America/Sao_Paulo
 3135076;Jampruca;-18461;-41809;0;31;Minas Gerais;2655;33;America/Sao_Paulo
-3135100;Jana˙ba;-158022;-433132;0;31;Minas Gerais;4701;38;America/Sao_Paulo
-5211701;Jandaia;-170481;-501453;0;52;Goi·s;9429;64;America/Sao_Paulo
-4112108;Jandaia do Sul;-236011;-516448;0;41;Paran·;7635;43;America/Sao_Paulo
-2405108;JandaÌra;-535211;-361278;0;24;Rio Grande do Norte;1699;84;America/Sao_Paulo
-2917904;JandaÌra;-115616;-377853;0;29;Bahia;3659;75;America/Sao_Paulo
-3525003;Jandira;-235275;-469023;0;35;S„o Paulo;6601;11;America/Sao_Paulo
-2405207;JanduÌs;-601474;-374048;0;24;Rio Grande do Norte;1701;84;America/Sao_Paulo
+3135100;Jana√∫ba;-158022;-433132;0;31;Minas Gerais;4701;38;America/Sao_Paulo
+5211701;Jandaia;-170481;-501453;0;52;Goi√°s;9429;64;America/Sao_Paulo
+4112108;Jandaia do Sul;-236011;-516448;0;41;Paran√°;7635;43;America/Sao_Paulo
+2405108;Janda√≠ra;-535211;-361278;0;24;Rio Grande do Norte;1699;84;America/Sao_Paulo
+2917904;Janda√≠ra;-115616;-377853;0;29;Bahia;3659;75;America/Sao_Paulo
+3525003;Jandira;-235275;-469023;0;35;S√£o Paulo;6601;11;America/Sao_Paulo
+2405207;Jandu√≠s;-601474;-374048;0;24;Rio Grande do Norte;1701;84;America/Sao_Paulo
 5104906;Jangada;-15235;-564917;0;51;Mato Grosso;9861;65;America/Porto_Velho
-4112207;JaniÛpolis;-241401;-527784;0;41;Paran·;7637;44;America/Sao_Paulo
-3135209;Janu·ria;-154802;-443639;0;31;Minas Gerais;4703;38;America/Sao_Paulo
-2405306;Janu·rio Cicco (Boa Sa˙de);-616566;-356219;0;24;Rio Grande do Norte;1703;84;America/Sao_Paulo
-3135308;JaparaÌba;-201442;-455015;0;31;Minas Gerais;4705;37;America/Sao_Paulo
+4112207;Jani√≥polis;-241401;-527784;0;41;Paran√°;7637;44;America/Sao_Paulo
+3135209;Janu√°ria;-154802;-443639;0;31;Minas Gerais;4703;38;America/Sao_Paulo
+2405306;Janu√°rio Cicco (Boa Sa√∫de);-616566;-356219;0;24;Rio Grande do Norte;1703;84;America/Sao_Paulo
+3135308;Japara√≠ba;-201442;-455015;0;31;Minas Gerais;4705;37;America/Sao_Paulo
 2703601;Japaratinga;-908746;-352634;0;27;Alagoas;2771;82;America/Sao_Paulo
 2803302;Japaratuba;-105849;-369418;0;28;Sergipe;3165;79;America/Sao_Paulo
 3302270;Japeri;-226435;-436602;0;33;Rio de Janeiro;2913;21;America/Sao_Paulo
 2405405;Japi;-646544;-359346;0;24;Rio Grande do Norte;1705;84;America/Sao_Paulo
-4112306;Japira;-238142;-501422;0;41;Paran·;7639;43;America/Sao_Paulo
-2803401;Japoat„;-103477;-368045;0;28;Sergipe;3167;79;America/Sao_Paulo
+4112306;Japira;-238142;-501422;0;41;Paran√°;7639;43;America/Sao_Paulo
+2803401;Japoat√£;-103477;-368045;0;28;Sergipe;3167;79;America/Sao_Paulo
 3135357;Japonvar;-159891;-442758;0;31;Minas Gerais;630;38;America/Sao_Paulo
-5004809;Japor„;-238903;-544059;0;50;Mato Grosso do Sul;161;67;America/Porto_Velho
-4112405;Japur·;-234693;-525557;0;41;Paran·;7641;44;America/Sao_Paulo
-1302108;Japur·;-188237;-669291;0;13;Amazonas;245;97;America/Porto_Velho
+5004809;Japor√£;-238903;-544059;0;50;Mato Grosso do Sul;161;67;America/Porto_Velho
+4112405;Japur√°;-234693;-525557;0;41;Paran√°;7641;44;America/Sao_Paulo
+1302108;Japur√°;-188237;-669291;0;13;Amazonas;245;97;America/Porto_Velho
 2607950;Jaqueira;-872618;-357942;0;26;Pernambuco;548;81;America/Sao_Paulo
 4311122;Jaquirana;-288811;-503637;0;43;Rio Grande do Sul;7391;54;America/Sao_Paulo
-5211800;Jaragu·;-157529;-493344;0;52;Goi·s;9431;62;America/Sao_Paulo
-4208906;Jaragu· do Sul;-264851;-490713;0;42;Santa Catarina;8175;47;America/Sao_Paulo
+5211800;Jaragu√°;-157529;-493344;0;52;Goi√°s;9431;62;America/Sao_Paulo
+4208906;Jaragu√° do Sul;-264851;-490713;0;42;Santa Catarina;8175;47;America/Sao_Paulo
 5004908;Jaraguari;-201386;-543996;0;50;Mato Grosso do Sul;9097;67;America/Porto_Velho
 2703700;Jaramataia;-966224;-370046;0;27;Alagoas;2773;82;America/Sao_Paulo
-2307106;Jardim;-757599;-392826;0;23;Cear·;1443;88;America/Sao_Paulo
+2307106;Jardim;-757599;-392826;0;23;Cear√°;1443;88;America/Sao_Paulo
 5005004;Jardim;-214799;-561489;0;50;Mato Grosso do Sul;9099;67;America/Porto_Velho
-4112504;Jardim Alegre;-241809;-516902;0;41;Paran·;7643;43;America/Sao_Paulo
+4112504;Jardim Alegre;-241809;-516902;0;41;Paran√°;7643;43;America/Sao_Paulo
 2405504;Jardim de Angicos;-564999;-359713;0;24;Rio Grande do Norte;1707;84;America/Sao_Paulo
 2405603;Jardim de Piranhas;-637665;-373496;0;24;Rio Grande do Norte;1709;84;America/Sao_Paulo
-2205250;Jardim do Mulato;-6099;-4263;0;22;PiauÌ;997;86;America/Sao_Paulo
-2405702;Jardim do SeridÛ;-658047;-367736;0;24;Rio Grande do Norte;1711;84;America/Sao_Paulo
-4112603;Jardim Olinda;-225523;-520503;0;41;Paran·;7645;44;America/Sao_Paulo
-3525102;JardinÛpolis;-210176;-477606;0;35;S„o Paulo;6603;16;America/Sao_Paulo
-4208955;JardinÛpolis;-267191;-528625;0;42;Santa Catarina;5587;49;America/Sao_Paulo
+2205250;Jardim do Mulato;-6099;-4263;0;22;Piau√≠;997;86;America/Sao_Paulo
+2405702;Jardim do Serid√≥;-658047;-367736;0;24;Rio Grande do Norte;1711;84;America/Sao_Paulo
+4112603;Jardim Olinda;-225523;-520503;0;41;Paran√°;7645;44;America/Sao_Paulo
+3525102;Jardin√≥polis;-210176;-477606;0;35;S√£o Paulo;6603;16;America/Sao_Paulo
+4208955;Jardin√≥polis;-267191;-528625;0;42;Santa Catarina;5587;49;America/Sao_Paulo
 4311130;Jari;-292922;-542237;0;43;Rio Grande do Sul;992;55;America/Sao_Paulo
-3525201;Jarinu;-231039;-46728;0;35;S„o Paulo;6605;11;America/Sao_Paulo
-1100114;Jaru;-104318;-624788;0;11;RondÙnia;15;69;America/Porto_Velho
-5211909;JataÌ;-178784;-517204;0;52;Goi·s;9433;64;America/Sao_Paulo
-4112702;Jataizinho;-232578;-509777;0;41;Paran·;7647;43;America/Sao_Paulo
-2608008;Jata˙ba;-797668;-364943;0;26;Pernambuco;2459;81;America/Sao_Paulo
-5005103;JateÌ;-224806;-543079;0;50;Mato Grosso do Sul;9101;67;America/Porto_Velho
-2307205;Jati;-76797;-390029;0;23;Cear·;1445;88;America/Sao_Paulo
-2105450;Jatob·;-582282;-442153;0;21;Maranh„o;176;99;America/Sao_Paulo
-2608057;Jatob·;-917476;-382607;0;26;Pernambuco;550;87;America/Sao_Paulo
-2205276;Jatob· do PiauÌ;-477025;-41817;0;22;PiauÌ;324;86;America/Sao_Paulo
-3525300;Ja˙;-222936;-485592;0;35;S„o Paulo;6607;14;America/Sao_Paulo
-1711506;Ja˙ do Tocantins;-126509;-48589;0;17;Tocantins;329;63;America/Sao_Paulo
-5212006;Jaupaci;-161773;-509508;0;52;Goi·s;9435;64;America/Sao_Paulo
+3525201;Jarinu;-231039;-46728;0;35;S√£o Paulo;6605;11;America/Sao_Paulo
+1100114;Jaru;-104318;-624788;0;11;Rond√¥nia;15;69;America/Porto_Velho
+5211909;Jata√≠;-178784;-517204;0;52;Goi√°s;9433;64;America/Sao_Paulo
+4112702;Jataizinho;-232578;-509777;0;41;Paran√°;7647;43;America/Sao_Paulo
+2608008;Jata√∫ba;-797668;-364943;0;26;Pernambuco;2459;81;America/Sao_Paulo
+5005103;Jate√≠;-224806;-543079;0;50;Mato Grosso do Sul;9101;67;America/Porto_Velho
+2307205;Jati;-76797;-390029;0;23;Cear√°;1445;88;America/Sao_Paulo
+2105450;Jatob√°;-582282;-442153;0;21;Maranh√£o;176;99;America/Sao_Paulo
+2608057;Jatob√°;-917476;-382607;0;26;Pernambuco;550;87;America/Sao_Paulo
+2205276;Jatob√° do Piau√≠;-477025;-41817;0;22;Piau√≠;324;86;America/Sao_Paulo
+3525300;Ja√∫;-222936;-485592;0;35;S√£o Paulo;6607;14;America/Sao_Paulo
+1711506;Ja√∫ do Tocantins;-126509;-48589;0;17;Tocantins;329;63;America/Sao_Paulo
+5212006;Jaupaci;-161773;-509508;0;52;Goi√°s;9435;64;America/Sao_Paulo
 5105002;Jauru;-153342;-588723;0;51;Mato Grosso;8991;65;America/Porto_Velho
 3135407;Jeceaba;-205339;-439894;0;31;Minas Gerais;4707;31;America/Sao_Paulo
 3135456;Jenipapo de Minas;-170831;-422589;0;31;Minas Gerais;632;33;America/Sao_Paulo
-2105476;Jenipapo dos Vieiras;-536237;-456356;0;21;Maranh„o;178;99;America/Sao_Paulo
+2105476;Jenipapo dos Vieiras;-536237;-456356;0;21;Maranh√£o;178;99;America/Sao_Paulo
 3135506;Jequeri;-204542;-426651;0;31;Minas Gerais;4709;31;America/Sao_Paulo
-2703759;Jequi· da Praia;-100133;-360142;0;27;Alagoas;562;82;America/Sao_Paulo
-2918001;JequiÈ;-138509;-400877;0;29;Bahia;3661;73;America/Sao_Paulo
-3135605;JequitaÌ;-17229;-444376;0;31;Minas Gerais;4711;38;America/Sao_Paulo
-3135704;Jequitib·;-192345;-440304;0;31;Minas Gerais;4713;31;America/Sao_Paulo
+2703759;Jequi√° da Praia;-100133;-360142;0;27;Alagoas;562;82;America/Sao_Paulo
+2918001;Jequi√©;-138509;-400877;0;29;Bahia;3661;73;America/Sao_Paulo
+3135605;Jequita√≠;-17229;-444376;0;31;Minas Gerais;4711;38;America/Sao_Paulo
+3135704;Jequitib√°;-192345;-440304;0;31;Minas Gerais;4713;31;America/Sao_Paulo
 3135803;Jequitinhonha;-164375;-410117;0;31;Minas Gerais;4715;33;America/Sao_Paulo
 2918100;Jeremoabo;-100685;-383471;0;29;Bahia;3663;75;America/Sao_Paulo
-2507408;JericÛ;-654577;-378036;0;25;ParaÌba;2049;83;America/Sao_Paulo
-3525409;Jeriquara;-203116;-475918;0;35;S„o Paulo;6609;16;America/Sao_Paulo
-3203106;JerÙnimo Monteiro;-207994;-413948;0;32;EspÌrito Santo;5661;28;America/Sao_Paulo
-2205300;Jerumenha;-709128;-435033;0;22;PiauÌ;1105;89;America/Sao_Paulo
-3135902;Jesu‚nia;-219887;-452911;0;31;Minas Gerais;4717;35;America/Sao_Paulo
-4112751;JesuÌtas;-243839;-533849;0;41;Paran·;7997;44;America/Sao_Paulo
-5212055;Jes˙polis;-159484;-493739;0;52;Goi·s;49;62;America/Sao_Paulo
-1100122;Ji-Paran·;-108777;-619322;0;11;RondÙnia;5;69;America/Porto_Velho
-2307254;Jijoca de Jericoacoara;-279331;-405127;0;23;Cear·;985;88;America/Sao_Paulo
-2918209;JiquiriÁ·;-132621;-395737;0;29;Bahia;3665;75;America/Sao_Paulo
-2918308;Jita˙na;-140131;-398969;0;29;Bahia;3667;73;America/Sao_Paulo
-4209003;JoaÁaba;-271721;-515108;0;42;Santa Catarina;8177;49;America/Sao_Paulo
-3136009;JoaÌma;-166522;-410229;0;31;Minas Gerais;4719;33;America/Sao_Paulo
-3136108;JoanÈsia;-191729;-426775;0;31;Minas Gerais;4721;33;America/Sao_Paulo
-3525508;JoanÛpolis;-22927;-462741;0;35;S„o Paulo;6611;11;America/Sao_Paulo
-2608107;Jo„o Alfredo;-786565;-355787;0;26;Pernambuco;2461;81;America/Sao_Paulo
-2405801;Jo„o C‚mara;-554094;-358122;0;24;Rio Grande do Norte;1713;84;America/Sao_Paulo
-2205359;Jo„o Costa;-850736;-424264;0;22;PiauÌ;326;89;America/Sao_Paulo
-2405900;Jo„o Dias;-627215;-377885;0;24;Rio Grande do Norte;1715;84;America/Sao_Paulo
-2918357;Jo„o Dourado;-113486;-416548;0;29;Bahia;3099;74;America/Sao_Paulo
-2105500;Jo„o Lisboa;-544363;-474064;0;21;Maranh„o;809;99;America/Sao_Paulo
-3136207;Jo„o Monlevade;-198126;-431735;0;31;Minas Gerais;4723;31;America/Sao_Paulo
-3203130;Jo„o Neiva;-197577;-40386;0;32;EspÌrito Santo;5721;27;America/Sao_Paulo
-2507507;Jo„o Pessoa;-711509;-348641;1;25;ParaÌba;2051;83;America/Sao_Paulo
-3136306;Jo„o Pinheiro;-177398;-461715;0;31;Minas Gerais;4725;38;America/Sao_Paulo
-3525607;Jo„o Ramalho;-222473;-507694;0;35;S„o Paulo;6613;18;America/Sao_Paulo
-3136405;Joaquim FelÌcio;-17758;-441643;0;31;Minas Gerais;4727;38;America/Sao_Paulo
+2507408;Jeric√≥;-654577;-378036;0;25;Para√≠ba;2049;83;America/Sao_Paulo
+3525409;Jeriquara;-203116;-475918;0;35;S√£o Paulo;6609;16;America/Sao_Paulo
+3203106;Jer√¥nimo Monteiro;-207994;-413948;0;32;Esp√≠rito Santo;5661;28;America/Sao_Paulo
+2205300;Jerumenha;-709128;-435033;0;22;Piau√≠;1105;89;America/Sao_Paulo
+3135902;Jesu√¢nia;-219887;-452911;0;31;Minas Gerais;4717;35;America/Sao_Paulo
+4112751;Jesu√≠tas;-243839;-533849;0;41;Paran√°;7997;44;America/Sao_Paulo
+5212055;Jes√∫polis;-159484;-493739;0;52;Goi√°s;49;62;America/Sao_Paulo
+1100122;Ji-Paran√°;-108777;-619322;0;11;Rond√¥nia;5;69;America/Porto_Velho
+2307254;Jijoca de Jericoacoara;-279331;-405127;0;23;Cear√°;985;88;America/Sao_Paulo
+2918209;Jiquiri√ß√°;-132621;-395737;0;29;Bahia;3665;75;America/Sao_Paulo
+2918308;Jita√∫na;-140131;-398969;0;29;Bahia;3667;73;America/Sao_Paulo
+4209003;Joa√ßaba;-271721;-515108;0;42;Santa Catarina;8177;49;America/Sao_Paulo
+3136009;Joa√≠ma;-166522;-410229;0;31;Minas Gerais;4719;33;America/Sao_Paulo
+3136108;Joan√©sia;-191729;-426775;0;31;Minas Gerais;4721;33;America/Sao_Paulo
+3525508;Joan√≥polis;-22927;-462741;0;35;S√£o Paulo;6611;11;America/Sao_Paulo
+2608107;Jo√£o Alfredo;-786565;-355787;0;26;Pernambuco;2461;81;America/Sao_Paulo
+2405801;Jo√£o C√¢mara;-554094;-358122;0;24;Rio Grande do Norte;1713;84;America/Sao_Paulo
+2205359;Jo√£o Costa;-850736;-424264;0;22;Piau√≠;326;89;America/Sao_Paulo
+2405900;Jo√£o Dias;-627215;-377885;0;24;Rio Grande do Norte;1715;84;America/Sao_Paulo
+2918357;Jo√£o Dourado;-113486;-416548;0;29;Bahia;3099;74;America/Sao_Paulo
+2105500;Jo√£o Lisboa;-544363;-474064;0;21;Maranh√£o;809;99;America/Sao_Paulo
+3136207;Jo√£o Monlevade;-198126;-431735;0;31;Minas Gerais;4723;31;America/Sao_Paulo
+3203130;Jo√£o Neiva;-197577;-40386;0;32;Esp√≠rito Santo;5721;27;America/Sao_Paulo
+2507507;Jo√£o Pessoa;-711509;-348641;1;25;Para√≠ba;2051;83;America/Sao_Paulo
+3136306;Jo√£o Pinheiro;-177398;-461715;0;31;Minas Gerais;4725;38;America/Sao_Paulo
+3525607;Jo√£o Ramalho;-222473;-507694;0;35;S√£o Paulo;6613;18;America/Sao_Paulo
+3136405;Joaquim Fel√≠cio;-17758;-441643;0;31;Minas Gerais;4727;38;America/Sao_Paulo
 2703809;Joaquim Gomes;-91328;-357474;0;27;Alagoas;2775;82;America/Sao_Paulo
 2608206;Joaquim Nabuco;-862281;-355288;0;26;Pernambuco;2463;81;America/Sao_Paulo
-2205409;Joaquim Pires;-350164;-421865;0;22;PiauÌ;1107;86;America/Sao_Paulo
-4112801;Joaquim T·vora;-234987;-49909;0;41;Paran·;7649;43;America/Sao_Paulo
-2513653;Joca Claudino;-648362;-384764;0;25;ParaÌba;514;83;America/Sao_Paulo
-2205458;Joca Marques;-34804;-424255;0;22;PiauÌ;328;86;America/Sao_Paulo
-4311155;JÛia;-286435;-541141;0;43;Rio Grande do Sul;9829;55;America/Sao_Paulo
+2205409;Joaquim Pires;-350164;-421865;0;22;Piau√≠;1107;86;America/Sao_Paulo
+4112801;Joaquim T√°vora;-234987;-49909;0;41;Paran√°;7649;43;America/Sao_Paulo
+2513653;Joca Claudino;-648362;-384764;0;25;Para√≠ba;514;83;America/Sao_Paulo
+2205458;Joca Marques;-34804;-424255;0;22;Piau√≠;328;86;America/Sao_Paulo
+4311155;J√≥ia;-286435;-541141;0;43;Rio Grande do Sul;9829;55;America/Sao_Paulo
 4209102;Joinville;-263045;-488487;0;42;Santa Catarina;8179;47;America/Sao_Paulo
-3136504;Jord‚nia;-159009;-401841;0;31;Minas Gerais;4729;33;America/Sao_Paulo
-1200328;Jord„o;-943091;-718974;0;12;Acre;653;68;America/Rio_Branco
-4209151;JosÈ Boiteux;-269566;-496286;0;42;Santa Catarina;9957;47;America/Sao_Paulo
-3525706;JosÈ Bonif·cio;-210551;-496892;0;35;S„o Paulo;6615;17;America/Sao_Paulo
-2406007;JosÈ da Penha;-631095;-382823;0;24;Rio Grande do Norte;1717;84;America/Sao_Paulo
-2205508;JosÈ de Freitas;-475146;-425746;0;22;PiauÌ;1109;86;America/Sao_Paulo
-3136520;JosÈ GonÁalves de Minas;-169053;-426014;0;31;Minas Gerais;634;33;America/Sao_Paulo
-3136553;JosÈ Raydan;-182195;-424946;0;31;Minas Gerais;636;33;America/Sao_Paulo
-2105609;Josel‚ndia;-498611;-446958;0;21;Maranh„o;811;99;America/Sao_Paulo
-3136579;JosenÛpolis;-165417;-425151;0;31;Minas Gerais;638;38;America/Sao_Paulo
-5212105;Jovi‚nia;-17802;-496197;0;52;Goi·s;9437;64;America/Sao_Paulo
+3136504;Jord√¢nia;-159009;-401841;0;31;Minas Gerais;4729;33;America/Sao_Paulo
+1200328;Jord√£o;-943091;-718974;0;12;Acre;653;68;America/Rio_Branco
+4209151;Jos√© Boiteux;-269566;-496286;0;42;Santa Catarina;9957;47;America/Sao_Paulo
+3525706;Jos√© Bonif√°cio;-210551;-496892;0;35;S√£o Paulo;6615;17;America/Sao_Paulo
+2406007;Jos√© da Penha;-631095;-382823;0;24;Rio Grande do Norte;1717;84;America/Sao_Paulo
+2205508;Jos√© de Freitas;-475146;-425746;0;22;Piau√≠;1109;86;America/Sao_Paulo
+3136520;Jos√© Gon√ßalves de Minas;-169053;-426014;0;31;Minas Gerais;634;33;America/Sao_Paulo
+3136553;Jos√© Raydan;-182195;-424946;0;31;Minas Gerais;636;33;America/Sao_Paulo
+2105609;Josel√¢ndia;-498611;-446958;0;21;Maranh√£o;811;99;America/Sao_Paulo
+3136579;Josen√≥polis;-165417;-425151;0;31;Minas Gerais;638;38;America/Sao_Paulo
+5212105;Jovi√¢nia;-17802;-496197;0;52;Goi√°s;9437;64;America/Sao_Paulo
 5105101;Juara;-112639;-575244;0;51;Mato Grosso;9819;66;America/Porto_Velho
-2507606;Juarez T·vora;-71713;-355686;0;25;ParaÌba;2053;83;America/Sao_Paulo
+2507606;Juarez T√°vora;-71713;-355686;0;25;Para√≠ba;2053;83;America/Sao_Paulo
 1711803;Juarina;-811951;-490643;0;17;Tocantins;349;63;America/Sao_Paulo
 3136652;Juatuba;-199448;-443451;0;31;Minas Gerais;2691;31;America/Sao_Paulo
-2507705;Juazeirinho;-706092;-365793;0;25;ParaÌba;2055;83;America/Sao_Paulo
+2507705;Juazeirinho;-706092;-365793;0;25;Para√≠ba;2055;83;America/Sao_Paulo
 2918407;Juazeiro;-941622;-405033;0;29;Bahia;3669;74;America/Sao_Paulo
-2307304;Juazeiro do Norte;-719621;-393076;0;23;Cear·;1447;88;America/Sao_Paulo
-2205516;Juazeiro do PiauÌ;-517459;-416976;0;22;PiauÌ;330;86;America/Sao_Paulo
-2307403;Juc·s;-651523;-395187;0;23;Cear·;1449;88;America/Sao_Paulo
+2307304;Juazeiro do Norte;-719621;-393076;0;23;Cear√°;1447;88;America/Sao_Paulo
+2205516;Juazeiro do Piau√≠;-517459;-416976;0;22;Piau√≠;330;86;America/Sao_Paulo
+2307403;Juc√°s;-651523;-395187;0;23;Cear√°;1449;88;America/Sao_Paulo
 2608255;Jucati;-870195;-364871;0;26;Pernambuco;2295;87;America/Sao_Paulo
-2918456;JucuruÁu;-168488;-401641;0;29;Bahia;3287;73;America/Sao_Paulo
+2918456;Jucuru√ßu;-168488;-401641;0;29;Bahia;3287;73;America/Sao_Paulo
 2406106;Jucurutu;-60306;-37009;0;24;Rio Grande do Norte;1719;84;America/Sao_Paulo
-5105150;JuÌna;-113728;-587483;0;51;Mato Grosso;9831;66;America/Porto_Velho
+5105150;Ju√≠na;-113728;-587483;0;51;Mato Grosso;9831;66;America/Porto_Velho
 3136702;Juiz de Fora;-217595;-433398;0;31;Minas Gerais;4733;32;America/Sao_Paulo
-2205524;J˙lio Borges;-103225;-442381;0;22;PiauÌ;332;89;America/Sao_Paulo
-4311205;J˙lio de Castilhos;-292299;-536772;0;43;Rio Grande do Sul;8725;55;America/Sao_Paulo
-3525805;J˙lio Mesquita;-220112;-497873;0;35;S„o Paulo;6617;14;America/Sao_Paulo
-3525854;Jumirim;-230884;-477868;0;35;S„o Paulo;802;15;America/Sao_Paulo
-2105658;Junco do Maranh„o;-183888;-4609;0;21;Maranh„o;180;98;America/Sao_Paulo
-2507804;Junco do SeridÛ;-699269;-367166;0;25;ParaÌba;2057;83;America/Sao_Paulo
-2406155;Jundi·;-626866;-353495;0;24;Rio Grande do Norte;1108;84;America/Sao_Paulo
-2703908;Jundi·;-893297;-355669;0;27;Alagoas;2777;82;America/Sao_Paulo
-3525904;JundiaÌ;-231852;-468974;0;35;S„o Paulo;6619;11;America/Sao_Paulo
-4112900;JundiaÌ do Sul;-234357;-502496;0;41;Paran·;7651;43;America/Sao_Paulo
+2205524;J√∫lio Borges;-103225;-442381;0;22;Piau√≠;332;89;America/Sao_Paulo
+4311205;J√∫lio de Castilhos;-292299;-536772;0;43;Rio Grande do Sul;8725;55;America/Sao_Paulo
+3525805;J√∫lio Mesquita;-220112;-497873;0;35;S√£o Paulo;6617;14;America/Sao_Paulo
+3525854;Jumirim;-230884;-477868;0;35;S√£o Paulo;802;15;America/Sao_Paulo
+2105658;Junco do Maranh√£o;-183888;-4609;0;21;Maranh√£o;180;98;America/Sao_Paulo
+2507804;Junco do Serid√≥;-699269;-367166;0;25;Para√≠ba;2057;83;America/Sao_Paulo
+2406155;Jundi√°;-626866;-353495;0;24;Rio Grande do Norte;1108;84;America/Sao_Paulo
+2703908;Jundi√°;-893297;-355669;0;27;Alagoas;2777;82;America/Sao_Paulo
+3525904;Jundia√≠;-231852;-468974;0;35;S√£o Paulo;6619;11;America/Sao_Paulo
+4112900;Jundia√≠ do Sul;-234357;-502496;0;41;Paran√°;7651;43;America/Sao_Paulo
 2704005;Junqueiro;-990696;-364803;0;27;Alagoas;2779;82;America/Sao_Paulo
-3526001;JunqueirÛpolis;-215103;-514342;0;35;S„o Paulo;6621;18;America/Sao_Paulo
+3526001;Junqueir√≥polis;-215103;-514342;0;35;S√£o Paulo;6621;18;America/Sao_Paulo
 2608305;Jupi;-870904;-364126;0;26;Pernambuco;2465;87;America/Sao_Paulo
-4209177;Jupi·;-26395;-527298;0;42;Santa Catarina;924;49;America/Sao_Paulo
-3526100;Juqui·;-243101;-476426;0;35;S„o Paulo;6623;13;America/Sao_Paulo
-3526209;Juquitiba;-239244;-470653;0;35;S„o Paulo;6625;11;America/Sao_Paulo
+4209177;Jupi√°;-26395;-527298;0;42;Santa Catarina;924;49;America/Sao_Paulo
+3526100;Juqui√°;-243101;-476426;0;35;S√£o Paulo;6623;13;America/Sao_Paulo
+3526209;Juquitiba;-239244;-470653;0;35;S√£o Paulo;6625;11;America/Sao_Paulo
 3136801;Juramento;-168473;-435865;0;31;Minas Gerais;4735;38;America/Sao_Paulo
-4112959;Juranda;-244209;-528413;0;41;Paran·;8463;44;America/Sao_Paulo
+4112959;Juranda;-244209;-528413;0;41;Paran√°;8463;44;America/Sao_Paulo
 2608404;Jurema;-870714;-361347;0;26;Pernambuco;2467;87;America/Sao_Paulo
-2205532;Jurema;-921992;-431337;0;22;PiauÌ;334;89;America/Sao_Paulo
-2507903;Juripiranga;-736176;-352321;0;25;ParaÌba;2059;83;America/Sao_Paulo
-2508000;Juru;-752983;-37815;0;25;ParaÌba;2061;83;America/Sao_Paulo
-1302207;Juru·;-348438;-660718;0;13;Amazonas;247;97;America/Porto_Velho
+2205532;Jurema;-921992;-431337;0;22;Piau√≠;334;89;America/Sao_Paulo
+2507903;Juripiranga;-736176;-352321;0;25;Para√≠ba;2059;83;America/Sao_Paulo
+2508000;Juru;-752983;-37815;0;25;Para√≠ba;2061;83;America/Sao_Paulo
+1302207;Juru√°;-348438;-660718;0;13;Amazonas;247;97;America/Porto_Velho
 3136900;Juruaia;-212493;-465735;0;31;Minas Gerais;4737;35;America/Sao_Paulo
 5105176;Juruena;-103178;-583592;0;51;Mato Grosso;9921;66;America/Porto_Velho
-1503903;Juruti;-216347;-560889;0;15;Par·;477;93;America/Sao_Paulo
+1503903;Juruti;-216347;-560889;0;15;Par√°;477;93;America/Sao_Paulo
 5105200;Juscimeira;-160633;-548859;0;51;Mato Grosso;9189;66;America/Porto_Velho
 2918506;Jussara;-110431;-419702;0;29;Bahia;3671;74;America/Sao_Paulo
-5212204;Jussara;-158659;-508668;0;52;Goi·s;9439;62;America/Sao_Paulo
-4113007;Jussara;-236219;-524693;0;41;Paran·;7653;44;America/Sao_Paulo
+5212204;Jussara;-158659;-508668;0;52;Goi√°s;9439;62;America/Sao_Paulo
+4113007;Jussara;-236219;-524693;0;41;Paran√°;7653;44;America/Sao_Paulo
 2918555;Jussari;-15192;-39491;0;29;Bahia;3069;73;America/Sao_Paulo
 2918605;Jussiape;-135155;-415882;0;29;Bahia;3673;77;America/Sao_Paulo
-1302306;JutaÌ;-275814;-667595;0;13;Amazonas;249;97;America/Rio_Branco
+1302306;Juta√≠;-275814;-667595;0;13;Amazonas;249;97;America/Rio_Branco
 5005152;Juti;-228596;-546061;0;50;Mato Grosso do Sul;9923;67;America/Porto_Velho
-3136959;JuvenÌlia;-142662;-441597;0;31;Minas Gerais;640;38;America/Sao_Paulo
-4113106;KalorÈ;-238188;-516687;0;41;Paran·;7655;43;America/Sao_Paulo
-1302405;L·brea;-726413;-647948;0;13;Amazonas;251;97;America/Rio_Branco
-4209201;LacerdÛpolis;-272579;-515577;0;42;Santa Catarina;8181;49;America/Sao_Paulo
+3136959;Juven√≠lia;-142662;-441597;0;31;Minas Gerais;640;38;America/Sao_Paulo
+4113106;Kalor√©;-238188;-516687;0;41;Paran√°;7655;43;America/Sao_Paulo
+1302405;L√°brea;-726413;-647948;0;13;Amazonas;251;97;America/Rio_Branco
+4209201;Lacerd√≥polis;-272579;-515577;0;42;Santa Catarina;8181;49;America/Sao_Paulo
 3137007;Ladainha;-176279;-417488;0;31;Minas Gerais;4739;33;America/Sao_Paulo
-5005202;Lad·rio;-190089;-575973;0;50;Mato Grosso do Sul;9103;67;America/Porto_Velho
+5005202;Lad√°rio;-190089;-575973;0;50;Mato Grosso do Sul;9103;67;America/Porto_Velho
 2918704;Lafaiete Coutinho;-136541;-402119;0;29;Bahia;3675;73;America/Sao_Paulo
 3137106;Lagamar;-181759;-468063;0;31;Minas Gerais;4741;34;America/Sao_Paulo
 2803500;Lagarto;-109136;-376689;0;28;Sergipe;3169;79;America/Sao_Paulo
 4209300;Lages;-27815;-503259;0;42;Santa Catarina;8183;49;America/Sao_Paulo
-2105708;Lago da Pedra;-456974;-451319;0;21;Maranh„o;813;99;America/Sao_Paulo
-2105807;Lago do Junco;-4609;-45049;0;21;Maranh„o;815;99;America/Sao_Paulo
-2105948;Lago dos Rodrigues;-461173;-449798;0;21;Maranh„o;184;99;America/Sao_Paulo
-2105906;Lago Verde;-394661;-44826;0;21;Maranh„o;817;99;America/Sao_Paulo
-2508109;Lagoa;-658572;-379127;0;25;ParaÌba;2063;83;America/Sao_Paulo
-2205557;Lagoa Alegre;-451539;-426309;0;22;PiauÌ;999;86;America/Sao_Paulo
+2105708;Lago da Pedra;-456974;-451319;0;21;Maranh√£o;813;99;America/Sao_Paulo
+2105807;Lago do Junco;-4609;-45049;0;21;Maranh√£o;815;99;America/Sao_Paulo
+2105948;Lago dos Rodrigues;-461173;-449798;0;21;Maranh√£o;184;99;America/Sao_Paulo
+2105906;Lago Verde;-394661;-44826;0;21;Maranh√£o;817;99;America/Sao_Paulo
+2508109;Lagoa;-658572;-379127;0;25;Para√≠ba;2063;83;America/Sao_Paulo
+2205557;Lagoa Alegre;-451539;-426309;0;22;Piau√≠;999;86;America/Sao_Paulo
 4311239;Lagoa Bonita do Sul;-294939;-53017;0;43;Rio Grande do Sul;1148;51;America/Sao_Paulo
 2406205;Lagoa d'Anta;-639493;-355949;0;24;Rio Grande do Norte;1723;84;America/Sao_Paulo
 2704104;Lagoa da Canoa;-983291;-367413;0;27;Alagoas;2781;82;America/Sao_Paulo
-1711902;Lagoa da Confus„o;-107906;-496199;0;17;Tocantins;367;63;America/Sao_Paulo
+1711902;Lagoa da Confus√£o;-107906;-496199;0;17;Tocantins;367;63;America/Sao_Paulo
 3137205;Lagoa da Prata;-200237;-455401;0;31;Minas Gerais;4743;37;America/Sao_Paulo
-2508208;Lagoa de Dentro;-667213;-353706;0;25;ParaÌba;2065;83;America/Sao_Paulo
+2508208;Lagoa de Dentro;-667213;-353706;0;25;Para√≠ba;2065;83;America/Sao_Paulo
 2608503;Lagoa de Itaenga;-793005;-352874;0;26;Pernambuco;2469;81;America/Sao_Paulo
 2406304;Lagoa de Pedras;-615082;-354299;0;24;Rio Grande do Norte;1725;84;America/Sao_Paulo
-2205573;Lagoa de S„o Francisco;-438505;-415969;0;22;PiauÌ;338;86;America/Sao_Paulo
+2205573;Lagoa de S√£o Francisco;-438505;-415969;0;22;Piau√≠;338;86;America/Sao_Paulo
 2406403;Lagoa de Velhos;-60119;-358729;0;24;Rio Grande do Norte;1727;84;America/Sao_Paulo
-2205565;Lagoa do Barro do PiauÌ;-847673;-415342;0;22;PiauÌ;2259;89;America/Sao_Paulo
+2205565;Lagoa do Barro do Piau√≠;-847673;-415342;0;22;Piau√≠;2259;89;America/Sao_Paulo
 2608453;Lagoa do Carro;-784383;-353108;0;26;Pernambuco;2289;81;America/Sao_Paulo
-2105922;Lagoa do Mato;-605023;-435333;0;21;Maranh„o;182;99;America/Sao_Paulo
+2105922;Lagoa do Mato;-605023;-435333;0;21;Maranh√£o;182;99;America/Sao_Paulo
 2608602;Lagoa do Ouro;-912567;-364584;0;26;Pernambuco;2471;87;America/Sao_Paulo
-2205581;Lagoa do PiauÌ;-541864;-426437;0;22;PiauÌ;340;86;America/Sao_Paulo
-2205599;Lagoa do SÌtio;-650766;-415653;0;22;PiauÌ;342;89;America/Sao_Paulo
+2205581;Lagoa do Piau√≠;-541864;-426437;0;22;Piau√≠;340;86;America/Sao_Paulo
+2205599;Lagoa do S√≠tio;-650766;-415653;0;22;Piau√≠;342;89;America/Sao_Paulo
 1711951;Lagoa do Tocantins;-10368;-47538;0;17;Tocantins;353;63;America/Sao_Paulo
 2608701;Lagoa dos Gatos;-86602;-35904;0;26;Pernambuco;2473;81;America/Sao_Paulo
 3137304;Lagoa dos Patos;-16978;-445754;0;31;Minas Gerais;4745;38;America/Sao_Paulo
-4311270;Lagoa dos TrÍs Cantos;-285676;-528618;0;43;Rio Grande do Sul;5951;54;America/Sao_Paulo
+4311270;Lagoa dos Tr√™s Cantos;-285676;-528618;0;43;Rio Grande do Sul;5951;54;America/Sao_Paulo
 3137403;Lagoa Dourada;-209139;-440797;0;31;Minas Gerais;4747;32;America/Sao_Paulo
 3137502;Lagoa Formosa;-187715;-464012;0;31;Minas Gerais;4749;34;America/Sao_Paulo
 3137536;Lagoa Grande;-178323;-465165;0;31;Minas Gerais;2905;34;America/Sao_Paulo
 2608750;Lagoa Grande;-899452;-402767;0;26;Pernambuco;552;87;America/Sao_Paulo
-2105963;Lagoa Grande do Maranh„o;-498893;-453816;0;21;Maranh„o;186;99;America/Sao_Paulo
+2105963;Lagoa Grande do Maranh√£o;-498893;-453816;0;21;Maranh√£o;186;99;America/Sao_Paulo
 2406502;Lagoa Nova;-609339;-364703;0;24;Rio Grande do Norte;1729;84;America/Sao_Paulo
 2918753;Lagoa Real;-140334;-421328;0;29;Bahia;3289;77;America/Sao_Paulo
 2406601;Lagoa Salgada;-612295;-354724;0;24;Rio Grande do Norte;1731;84;America/Sao_Paulo
-5212253;Lagoa Santa;-191832;-513998;0;52;Goi·s;1076;64;America/Sao_Paulo
+5212253;Lagoa Santa;-191832;-513998;0;52;Goi√°s;1076;64;America/Sao_Paulo
 3137601;Lagoa Santa;-196397;-438932;0;31;Minas Gerais;4751;31;America/Sao_Paulo
-2508307;Lagoa Seca;-715535;-358491;0;25;ParaÌba;2067;83;America/Sao_Paulo
+2508307;Lagoa Seca;-715535;-358491;0;25;Para√≠ba;2067;83;America/Sao_Paulo
 4311304;Lagoa Vermelha;-282093;-515248;0;43;Rio Grande do Sul;8727;54;America/Sao_Paulo
-4311254;Lago„o;-292348;-527997;0;43;Rio Grande do Sul;7389;51;America/Sao_Paulo
-3526308;Lagoinha;-230846;-451944;0;35;S„o Paulo;6627;12;America/Sao_Paulo
-2205540;Lagoinha do PiauÌ;-583074;-426223;0;22;PiauÌ;336;86;America/Sao_Paulo
+4311254;Lago√£o;-292348;-527997;0;43;Rio Grande do Sul;7389;51;America/Sao_Paulo
+3526308;Lagoinha;-230846;-451944;0;35;S√£o Paulo;6627;12;America/Sao_Paulo
+2205540;Lagoinha do Piau√≠;-583074;-426223;0;22;Piau√≠;336;86;America/Sao_Paulo
 4209409;Laguna;-284843;-487772;0;42;Santa Catarina;8185;48;America/Sao_Paulo
-5005251;Laguna Carap„;-225448;-551502;0;50;Mato Grosso do Sul;163;67;America/Porto_Velho
+5005251;Laguna Carap√£;-225448;-551502;0;50;Mato Grosso do Sul;163;67;America/Porto_Velho
 2918803;Laje;-131673;-394213;0;29;Bahia;3677;75;America/Sao_Paulo
-3302304;Laje do MuriaÈ;-212091;-421271;0;33;Rio de Janeiro;5845;22;America/Sao_Paulo
+3302304;Laje do Muria√©;-212091;-421271;0;33;Rio de Janeiro;5845;22;America/Sao_Paulo
 1712009;Lajeado;-974996;-483565;0;17;Tocantins;351;63;America/Sao_Paulo
 4311403;Lajeado;-294591;-519644;0;43;Rio Grande do Sul;8729;51;America/Sao_Paulo
 4311429;Lajeado do Bugre;-276913;-531818;0;43;Rio Grande do Sul;5983;55;America/Sao_Paulo
 4209458;Lajeado Grande;-268576;-525648;0;42;Santa Catarina;5739;49;America/Sao_Paulo
-2105989;Lajeado Novo;-618539;-470293;0;21;Maranh„o;188;99;America/Sao_Paulo
-2918902;Lajed„o;-176056;-403383;0;29;Bahia;3679;73;America/Sao_Paulo
+2105989;Lajeado Novo;-618539;-470293;0;21;Maranh√£o;188;99;America/Sao_Paulo
+2918902;Lajed√£o;-176056;-403383;0;29;Bahia;3679;73;America/Sao_Paulo
 2919009;Lajedinho;-123529;-409048;0;29;Bahia;3681;75;America/Sao_Paulo
 2608800;Lajedo;-865791;-363293;0;26;Pernambuco;2475;87;America/Sao_Paulo
 2919058;Lajedo do Tabocal;-134663;-402204;0;29;Bahia;3291;73;America/Sao_Paulo
 2406700;Lajes;-569322;-36247;0;24;Rio Grande do Norte;1733;84;America/Sao_Paulo
 2406809;Lajes Pintadas;-614943;-361171;0;24;Rio Grande do Norte;1735;84;America/Sao_Paulo
 3137700;Lajinha;-201539;-416228;0;31;Minas Gerais;4753;33;America/Sao_Paulo
-2919108;Lamar„o;-11773;-38887;0;29;Bahia;3683;75;America/Sao_Paulo
+2919108;Lamar√£o;-11773;-38887;0;29;Bahia;3683;75;America/Sao_Paulo
 3137809;Lambari;-219671;-453498;0;31;Minas Gerais;4755;35;America/Sao_Paulo
 5105234;Lambari D'Oeste;-153188;-580046;0;51;Mato Grosso;137;65;America/Porto_Velho
 3137908;Lamim;-2079;-434706;0;31;Minas Gerais;4757;31;America/Sao_Paulo
-2205607;Landri Sales;-725922;-439364;0;22;PiauÌ;1111;89;America/Sao_Paulo
-4113205;Lapa;-257671;-497168;0;41;Paran·;7657;41;America/Sao_Paulo
-2919157;Lap„o;-113851;-418286;0;29;Bahia;3973;74;America/Sao_Paulo
-3203163;Laranja da Terra;-198994;-410621;0;32;EspÌrito Santo;5723;27;America/Sao_Paulo
+2205607;Landri Sales;-725922;-439364;0;22;Piau√≠;1111;89;America/Sao_Paulo
+4113205;Lapa;-257671;-497168;0;41;Paran√°;7657;41;America/Sao_Paulo
+2919157;Lap√£o;-113851;-418286;0;29;Bahia;3973;74;America/Sao_Paulo
+3203163;Laranja da Terra;-198994;-410621;0;32;Esp√≠rito Santo;5723;27;America/Sao_Paulo
 3138005;Laranjal;-213715;-424732;0;31;Minas Gerais;4759;32;America/Sao_Paulo
-4113254;Laranjal;-248862;-5247;0;41;Paran·;5501;42;America/Sao_Paulo
-1600279;Laranjal do Jari;-804911;-52453;0;16;Amap·;613;96;America/Sao_Paulo
-3526407;Laranjal Paulista;-230506;-478375;0;35;S„o Paulo;6629;15;America/Sao_Paulo
+4113254;Laranjal;-248862;-5247;0;41;Paran√°;5501;42;America/Sao_Paulo
+1600279;Laranjal do Jari;-804911;-52453;0;16;Amap√°;613;96;America/Sao_Paulo
+3526407;Laranjal Paulista;-230506;-478375;0;35;S√£o Paulo;6629;15;America/Sao_Paulo
 2803609;Laranjeiras;-107981;-371731;0;28;Sergipe;3171;79;America/Sao_Paulo
-4113304;Laranjeiras do Sul;-254077;-524109;0;41;Paran·;7659;42;America/Sao_Paulo
+4113304;Laranjeiras do Sul;-254077;-524109;0;41;Paran√°;7659;42;America/Sao_Paulo
 3138104;Lassance;-17887;-445735;0;31;Minas Gerais;4761;38;America/Sao_Paulo
-2508406;Lastro;-650603;-381742;0;25;ParaÌba;2069;83;America/Sao_Paulo
+2508406;Lastro;-650603;-381742;0;25;Para√≠ba;2069;83;America/Sao_Paulo
 4209508;Laurentino;-272173;-497331;0;42;Santa Catarina;8187;47;America/Sao_Paulo
 2919207;Lauro de Freitas;-128978;-38321;0;29;Bahia;3685;71;America/Sao_Paulo
 4209607;Lauro Muller;-283859;-494035;0;42;Santa Catarina;8189;48;America/Sao_Paulo
 1712157;Lavandeira;-127847;-465099;0;17;Tocantins;86;63;America/Sao_Paulo
-3526506;LavÌnia;-211639;-510412;0;35;S„o Paulo;6631;18;America/Sao_Paulo
+3526506;Lav√≠nia;-211639;-510412;0;35;S√£o Paulo;6631;18;America/Sao_Paulo
 3138203;Lavras;-21248;-450009;0;31;Minas Gerais;4763;35;America/Sao_Paulo
-2307502;Lavras da Mangabeira;-67448;-389706;0;23;Cear·;1451;88;America/Sao_Paulo
+2307502;Lavras da Mangabeira;-67448;-389706;0;23;Cear√°;1451;88;America/Sao_Paulo
 4311502;Lavras do Sul;-308071;-538931;0;43;Rio Grande do Sul;8731;55;America/Sao_Paulo
-3526605;Lavrinhas;-2257;-449024;0;35;S„o Paulo;6633;12;America/Sao_Paulo
+3526605;Lavrinhas;-2257;-449024;0;35;S√£o Paulo;6633;12;America/Sao_Paulo
 3138302;Leandro Ferreira;-197193;-450279;0;31;Minas Gerais;4765;37;America/Sao_Paulo
-4209706;Lebon RÈgis;-26928;-506921;0;42;Santa Catarina;8191;49;America/Sao_Paulo
-3526704;Leme;-221809;-473841;0;35;S„o Paulo;6635;19;America/Sao_Paulo
+4209706;Lebon R√©gis;-26928;-506921;0;42;Santa Catarina;8191;49;America/Sao_Paulo
+3526704;Leme;-221809;-473841;0;35;S√£o Paulo;6635;19;America/Sao_Paulo
 3138351;Leme do Prado;-170793;-426936;0;31;Minas Gerais;642;33;America/Sao_Paulo
-2919306;LenÁÛis;-125616;-413928;0;29;Bahia;3687;75;America/Sao_Paulo
-3526803;LenÁÛis Paulista;-226027;-488037;0;35;S„o Paulo;6637;14;America/Sao_Paulo
+2919306;Len√ß√≥is;-125616;-413928;0;29;Bahia;3687;75;America/Sao_Paulo
+3526803;Len√ß√≥is Paulista;-226027;-488037;0;35;S√£o Paulo;6637;14;America/Sao_Paulo
 4209805;Leoberto Leal;-275081;-492789;0;42;Santa Catarina;8193;48;America/Sao_Paulo
 3138401;Leopoldina;-215296;-426421;0;31;Minas Gerais;4767;32;America/Sao_Paulo
-5212303;Leopoldo de Bulhıes;-16619;-487428;0;52;Goi·s;9443;62;America/Sao_Paulo
-4113403;LeÛpolis;-230818;-507511;0;41;Paran·;7661;43;America/Sao_Paulo
+5212303;Leopoldo de Bulh√µes;-16619;-487428;0;52;Goi√°s;9443;62;America/Sao_Paulo
+4113403;Le√≥polis;-230818;-507511;0;41;Paran√°;7661;43;America/Sao_Paulo
 4311601;Liberato Salzano;-27601;-530753;0;43;Rio Grande do Sul;8733;55;America/Sao_Paulo
 3138500;Liberdade;-220275;-443208;0;31;Minas Gerais;4769;32;America/Sao_Paulo
-2919405;LicÌnio de Almeida;-146842;-425095;0;29;Bahia;3689;77;America/Sao_Paulo
-4113429;LidianÛpolis;-2411;-516506;0;41;Paran·;5507;43;America/Sao_Paulo
-2106003;Lima Campos;-451837;-444646;0;21;Maranh„o;819;99;America/Sao_Paulo
+2919405;Lic√≠nio de Almeida;-146842;-425095;0;29;Bahia;3689;77;America/Sao_Paulo
+4113429;Lidian√≥polis;-2411;-516506;0;41;Paran√°;5507;43;America/Sao_Paulo
+2106003;Lima Campos;-451837;-444646;0;21;Maranh√£o;819;99;America/Sao_Paulo
 3138609;Lima Duarte;-218386;-437934;0;31;Minas Gerais;4771;32;America/Sao_Paulo
-3526902;Limeira;-22566;-47397;0;35;S„o Paulo;6639;19;America/Sao_Paulo
+3526902;Limeira;-22566;-47397;0;35;S√£o Paulo;6639;19;America/Sao_Paulo
 3138625;Limeira do Oeste;-195512;-505815;0;31;Minas Gerais;2687;34;America/Sao_Paulo
 2608909;Limoeiro;-78726;-354402;0;26;Pernambuco;2477;81;America/Sao_Paulo
 2704203;Limoeiro de Anadia;-974098;-365121;0;27;Alagoas;2783;82;America/Sao_Paulo
-1504000;Limoeiro do Ajuru;-18985;-493903;0;15;Par·;479;91;America/Sao_Paulo
-2307601;Limoeiro do Norte;-514392;-380847;0;23;Cear·;1453;88;America/Sao_Paulo
-4113452;Lindoeste;-252596;-535733;0;41;Paran·;9959;45;America/Sao_Paulo
-3527009;LindÛia;-225226;-4665;0;35;S„o Paulo;6641;19;America/Sao_Paulo
-4209854;LindÛia do Sul;-270545;-52069;0;42;Santa Catarina;9961;49;America/Sao_Paulo
+1504000;Limoeiro do Ajuru;-18985;-493903;0;15;Par√°;479;91;America/Sao_Paulo
+2307601;Limoeiro do Norte;-514392;-380847;0;23;Cear√°;1453;88;America/Sao_Paulo
+4113452;Lindoeste;-252596;-535733;0;41;Paran√°;9959;45;America/Sao_Paulo
+3527009;Lind√≥ia;-225226;-4665;0;35;S√£o Paulo;6641;19;America/Sao_Paulo
+4209854;Lind√≥ia do Sul;-270545;-52069;0;42;Santa Catarina;9961;49;America/Sao_Paulo
 4311627;Lindolfo Collor;-295859;-512141;0;43;Rio Grande do Sul;6017;51;America/Sao_Paulo
 4311643;Linha Nova;-294679;-512003;0;43;Rio Grande do Sul;6047;51;America/Sao_Paulo
-3203205;Linhares;-193946;-400643;0;32;EspÌrito Santo;5663;27;America/Sao_Paulo
-3527108;Lins;-216718;-497526;0;35;S„o Paulo;6643;14;America/Sao_Paulo
-2508505;Livramento;-737113;-369491;0;25;ParaÌba;2071;83;America/Sao_Paulo
+3203205;Linhares;-193946;-400643;0;32;Esp√≠rito Santo;5663;27;America/Sao_Paulo
+3527108;Lins;-216718;-497526;0;35;S√£o Paulo;6643;14;America/Sao_Paulo
+2508505;Livramento;-737113;-369491;0;25;Para√≠ba;2071;83;America/Sao_Paulo
 2919504;Livramento de Nossa Senhora;-136369;-418432;0;29;Bahia;3691;77;America/Sao_Paulo
 1712405;Lizarda;-959002;-466738;0;17;Tocantins;9569;63;America/Sao_Paulo
-4113502;Loanda;-229232;-531362;0;41;Paran·;7663;44;America/Sao_Paulo
-4113601;Lobato;-230058;-519524;0;41;Paran·;7665;44;America/Sao_Paulo
-2508554;Logradouro;-661191;-354384;0;25;ParaÌba;482;83;America/Sao_Paulo
-4113700;Londrina;-23304;-511691;0;41;Paran·;7667;43;America/Sao_Paulo
+4113502;Loanda;-229232;-531362;0;41;Paran√°;7663;44;America/Sao_Paulo
+4113601;Lobato;-230058;-519524;0;41;Paran√°;7665;44;America/Sao_Paulo
+2508554;Logradouro;-661191;-354384;0;25;Para√≠ba;482;83;America/Sao_Paulo
+4113700;Londrina;-23304;-511691;0;41;Paran√°;7667;43;America/Sao_Paulo
 3138658;Lontra;-159013;-44306;0;31;Minas Gerais;2695;38;America/Sao_Paulo
 4209904;Lontras;-271684;-49535;0;42;Santa Catarina;8195;47;America/Sao_Paulo
-3527207;Lorena;-227334;-451197;0;35;S„o Paulo;6645;12;America/Sao_Paulo
-2106102;Loreto;-708111;-451451;0;21;Maranh„o;821;99;America/Sao_Paulo
-3527256;Lourdes;-20966;-502263;0;35;S„o Paulo;2937;18;America/Sao_Paulo
-3527306;Louveira;-230856;-469484;0;35;S„o Paulo;6647;19;America/Sao_Paulo
+3527207;Lorena;-227334;-451197;0;35;S√£o Paulo;6645;12;America/Sao_Paulo
+2106102;Loreto;-708111;-451451;0;21;Maranh√£o;821;99;America/Sao_Paulo
+3527256;Lourdes;-20966;-502263;0;35;S√£o Paulo;2937;18;America/Sao_Paulo
+3527306;Louveira;-230856;-469484;0;35;S√£o Paulo;6647;19;America/Sao_Paulo
 5105259;Lucas do Rio Verde;-130588;-559042;0;51;Mato Grosso;9925;65;America/Porto_Velho
-3527405;LucÈlia;-217182;-510215;0;35;S„o Paulo;6649;18;America/Sao_Paulo
-2508604;Lucena;-690258;-348748;0;25;ParaÌba;2073;83;America/Sao_Paulo
-3527504;LucianÛpolis;-224294;-49522;0;35;S„o Paulo;6651;14;America/Sao_Paulo
+3527405;Luc√©lia;-217182;-510215;0;35;S√£o Paulo;6649;18;America/Sao_Paulo
+2508604;Lucena;-690258;-348748;0;25;Para√≠ba;2073;83;America/Sao_Paulo
+3527504;Lucian√≥polis;-224294;-49522;0;35;S√£o Paulo;6651;14;America/Sao_Paulo
 5105309;Luciara;-112219;-506676;0;51;Mato Grosso;9105;66;America/Porto_Velho
-2406908;LucrÈcia;-610525;-378134;0;24;Rio Grande do Norte;1737;84;America/Sao_Paulo
-3527603;LuÌs AntÙnio;-2155;-477801;0;35;S„o Paulo;6653;16;America/Sao_Paulo
-2205706;LuÌs Correia;-288438;-416641;0;22;PiauÌ;1113;86;America/Sao_Paulo
-2106201;LuÌs Domingues;-127492;-45867;0;21;Maranh„o;823;98;America/Sao_Paulo
-2919553;LuÌs Eduardo Magalh„es;-120956;-457866;0;29;Bahia;1112;77;America/Sao_Paulo
-2407005;LuÌs Gomes;-640588;-383899;0;24;Rio Grande do Norte;1739;84;America/Sao_Paulo
+2406908;Lucr√©cia;-610525;-378134;0;24;Rio Grande do Norte;1737;84;America/Sao_Paulo
+3527603;Lu√≠s Ant√¥nio;-2155;-477801;0;35;S√£o Paulo;6653;16;America/Sao_Paulo
+2205706;Lu√≠s Correia;-288438;-416641;0;22;Piau√≠;1113;86;America/Sao_Paulo
+2106201;Lu√≠s Domingues;-127492;-45867;0;21;Maranh√£o;823;98;America/Sao_Paulo
+2919553;Lu√≠s Eduardo Magalh√£es;-120956;-457866;0;29;Bahia;1112;77;America/Sao_Paulo
+2407005;Lu√≠s Gomes;-640588;-383899;0;24;Rio Grande do Norte;1739;84;America/Sao_Paulo
 3138674;Luisburgo;-204468;-420976;0;31;Minas Gerais;644;33;America/Sao_Paulo
-3138682;Luisl‚ndia;-161095;-445886;0;31;Minas Gerais;646;38;America/Sao_Paulo
+3138682;Luisl√¢ndia;-161095;-445886;0;31;Minas Gerais;646;38;America/Sao_Paulo
 4210001;Luiz Alves;-267151;-489322;0;42;Santa Catarina;8197;47;America/Sao_Paulo
-4113734;Luiziana;-242853;-52269;0;41;Paran·;8481;44;America/Sao_Paulo
-3527702;Luizi‚nia;-216737;-503294;0;35;S„o Paulo;6655;18;America/Sao_Paulo
-3138708;Lumin·rias;-215145;-449034;0;31;Minas Gerais;4773;35;America/Sao_Paulo
-4113759;Lunardelli;-240821;-517368;0;41;Paran·;8459;43;America/Sao_Paulo
-3527801;LupÈrcio;-224146;-49818;0;35;S„o Paulo;6657;14;America/Sao_Paulo
-4113809;LupionÛpolis;-22755;-516601;0;41;Paran·;7669;43;America/Sao_Paulo
-3527900;LutÈcia;-223384;-50394;0;35;S„o Paulo;6659;18;America/Sao_Paulo
+4113734;Luiziana;-242853;-52269;0;41;Paran√°;8481;44;America/Sao_Paulo
+3527702;Luizi√¢nia;-216737;-503294;0;35;S√£o Paulo;6655;18;America/Sao_Paulo
+3138708;Lumin√°rias;-215145;-449034;0;31;Minas Gerais;4773;35;America/Sao_Paulo
+4113759;Lunardelli;-240821;-517368;0;41;Paran√°;8459;43;America/Sao_Paulo
+3527801;Lup√©rcio;-224146;-49818;0;35;S√£o Paulo;6657;14;America/Sao_Paulo
+4113809;Lupion√≥polis;-22755;-516601;0;41;Paran√°;7669;43;America/Sao_Paulo
+3527900;Lut√©cia;-223384;-50394;0;35;S√£o Paulo;6659;18;America/Sao_Paulo
 3138807;Luz;-197911;-456794;0;31;Minas Gerais;4775;37;America/Sao_Paulo
 4210035;Luzerna;-271304;-514682;0;42;Santa Catarina;926;49;America/Sao_Paulo
-5212501;Luzi‚nia;-16253;-4795;0;52;Goi·s;9445;61;America/Sao_Paulo
-2205805;Luzil‚ndia;-34683;-423718;0;22;PiauÌ;1115;86;America/Sao_Paulo
-1712454;LuzinÛpolis;-617794;-478582;0;17;Tocantins;88;63;America/Sao_Paulo
-3302403;MacaÈ;-223768;-417848;0;33;Rio de Janeiro;5847;22;America/Sao_Paulo
-2407104;MacaÌba;-585229;-353552;0;24;Rio Grande do Norte;1741;84;America/Sao_Paulo
+5212501;Luzi√¢nia;-16253;-4795;0;52;Goi√°s;9445;61;America/Sao_Paulo
+2205805;Luzil√¢ndia;-34683;-423718;0;22;Piau√≠;1115;86;America/Sao_Paulo
+1712454;Luzin√≥polis;-617794;-478582;0;17;Tocantins;88;63;America/Sao_Paulo
+3302403;Maca√©;-223768;-417848;0;33;Rio de Janeiro;5847;22;America/Sao_Paulo
+2407104;Maca√≠ba;-585229;-353552;0;24;Rio Grande do Norte;1741;84;America/Sao_Paulo
 2919603;Macajuba;-121326;-403571;0;29;Bahia;3693;74;America/Sao_Paulo
-4311718;MaÁambar·;-291445;-560674;0;43;Rio Grande do Sul;994;55;America/Sao_Paulo
+4311718;Ma√ßambar√°;-291445;-560674;0;43;Rio Grande do Sul;994;55;America/Sao_Paulo
 2803708;Macambira;-106619;-375413;0;28;Sergipe;3173;79;America/Sao_Paulo
-1600303;Macap·;34934;-510694;1;16;Amap·;605;96;America/Sao_Paulo
+1600303;Macap√°;34934;-510694;1;16;Amap√°;605;96;America/Sao_Paulo
 2609006;Macaparana;-755564;-354425;0;26;Pernambuco;2479;81;America/Sao_Paulo
 2919702;Macarani;-155646;-404209;0;29;Bahia;3695;77;America/Sao_Paulo
-3528007;Macatuba;-225002;-487102;0;35;S„o Paulo;6661;14;America/Sao_Paulo
+3528007;Macatuba;-225002;-487102;0;35;S√£o Paulo;6661;14;America/Sao_Paulo
 2407203;Macau;-510795;-366318;0;24;Rio Grande do Norte;1743;84;America/Sao_Paulo
-3528106;Macaubal;-208022;-499687;0;35;S„o Paulo;6663;17;America/Sao_Paulo
-2919801;Maca˙bas;-130186;-426945;0;29;Bahia;3697;77;America/Sao_Paulo
-3528205;MacedÙnia;-201444;-501973;0;35;S„o Paulo;6665;17;America/Sao_Paulo
-2704302;MaceiÛ;-966599;-35735;1;27;Alagoas;2785;82;America/Sao_Paulo
+3528106;Macaubal;-208022;-499687;0;35;S√£o Paulo;6663;17;America/Sao_Paulo
+2919801;Maca√∫bas;-130186;-426945;0;29;Bahia;3697;77;America/Sao_Paulo
+3528205;Maced√¥nia;-201444;-501973;0;35;S√£o Paulo;6665;17;America/Sao_Paulo
+2704302;Macei√≥;-966599;-35735;1;27;Alagoas;2785;82;America/Sao_Paulo
 3138906;Machacalis;-170723;-407245;0;31;Minas Gerais;4777;33;America/Sao_Paulo
 4311700;Machadinho;-275667;-516668;0;43;Rio Grande do Sul;8735;54;America/Sao_Paulo
-1100130;Machadinho D'Oeste;-944363;-619818;0;11;RondÙnia;39;69;America/Porto_Velho
+1100130;Machadinho D'Oeste;-944363;-619818;0;11;Rond√¥nia;39;69;America/Porto_Velho
 3139003;Machado;-216778;-459219;0;31;Minas Gerais;4779;35;America/Sao_Paulo
 2609105;Machados;-768827;-355114;0;26;Pernambuco;2481;81;America/Sao_Paulo
 4210050;Macieira;-268552;-513705;0;42;Santa Catarina;5575;49;America/Sao_Paulo
 3302452;Macuco;-219813;-422533;0;33;Rio de Janeiro;776;22;America/Sao_Paulo
-2919900;MacururÈ;-916226;-390518;0;29;Bahia;3699;75;America/Sao_Paulo
-2307635;Madalena;-484601;-395725;0;23;Cear·;1261;88;America/Sao_Paulo
-2205854;Madeiro;-348624;-424981;0;22;PiauÌ;344;86;America/Sao_Paulo
+2919900;Macurur√©;-916226;-390518;0;29;Bahia;3699;75;America/Sao_Paulo
+2307635;Madalena;-484601;-395725;0;23;Cear√°;1261;88;America/Sao_Paulo
+2205854;Madeiro;-348624;-424981;0;22;Piau√≠;344;86;America/Sao_Paulo
 2919926;Madre de Deus;-127446;-386153;0;29;Bahia;3293;71;America/Sao_Paulo
 3139102;Madre de Deus de Minas;-21483;-443287;0;31;Minas Gerais;4781;32;America/Sao_Paulo
-2508703;M„e d'¡gua;-725201;-374322;0;25;ParaÌba;2075;83;America/Sao_Paulo
-1504059;M„e do Rio;-205683;-475601;0;15;Par·;587;91;America/Sao_Paulo
+2508703;M√£e d'√Ågua;-725201;-374322;0;25;Para√≠ba;2075;83;America/Sao_Paulo
+1504059;M√£e do Rio;-205683;-475601;0;15;Par√°;587;91;America/Sao_Paulo
 2919959;Maetinga;-146623;-414915;0;29;Bahia;3975;77;America/Sao_Paulo
 4210100;Mafra;-261159;-498086;0;42;Santa Catarina;8199;47;America/Sao_Paulo
-1504109;Magalh„es Barata;-803391;-476014;0;15;Par·;481;91;America/Sao_Paulo
-2106300;Magalh„es de Almeida;-339232;-422117;0;21;Maranh„o;825;98;America/Sao_Paulo
-3528304;Magda;-206445;-502305;0;35;S„o Paulo;6667;17;America/Sao_Paulo
-3302502;MagÈ;-226632;-430315;0;33;Rio de Janeiro;5849;21;America/Sao_Paulo
+1504109;Magalh√£es Barata;-803391;-476014;0;15;Par√°;481;91;America/Sao_Paulo
+2106300;Magalh√£es de Almeida;-339232;-422117;0;21;Maranh√£o;825;98;America/Sao_Paulo
+3528304;Magda;-206445;-502305;0;35;S√£o Paulo;6667;17;America/Sao_Paulo
+3302502;Mag√©;-226632;-430315;0;33;Rio de Janeiro;5849;21;America/Sao_Paulo
 2920007;Maiquinique;-15624;-402587;0;29;Bahia;3701;77;America/Sao_Paulo
 2920106;Mairi;-117107;-401437;0;29;Bahia;3703;74;America/Sao_Paulo
-3528403;Mairinque;-235398;-47185;0;35;S„o Paulo;6669;11;America/Sao_Paulo
-3528502;Mairipor„;-233171;-465897;0;35;S„o Paulo;6671;11;America/Sao_Paulo
-5212600;Mairipotaba;-172975;-494898;0;52;Goi·s;9447;64;America/Sao_Paulo
+3528403;Mairinque;-235398;-47185;0;35;S√£o Paulo;6669;11;America/Sao_Paulo
+3528502;Mairipor√£;-233171;-465897;0;35;S√£o Paulo;6671;11;America/Sao_Paulo
+5212600;Mairipotaba;-172975;-494898;0;52;Goi√°s;9447;64;America/Sao_Paulo
 4210209;Major Gercino;-274192;-489488;0;42;Santa Catarina;8201;48;America/Sao_Paulo
 2704401;Major Isidoro;-953009;-36992;0;27;Alagoas;2787;82;America/Sao_Paulo
 2407252;Major Sales;-639949;-38324;0;24;Rio Grande do Norte;420;84;America/Sao_Paulo
@@ -2873,768 +2873,768 @@ codigo_ibge;municipio;latitude;longitude;capital;codigo_uf;estado;siafi_id;ddd;f
 2920304;Malhada de Pedras;-143847;-418842;0;29;Bahia;3707;77;America/Sao_Paulo
 2803807;Malhada dos Bois;-103418;-369252;0;28;Sergipe;3175;79;America/Sao_Paulo
 2803906;Malhador;-106649;-373004;0;28;Sergipe;3177;79;America/Sao_Paulo
-4113908;Mallet;-258806;-508173;0;41;Paran·;7671;42;America/Sao_Paulo
-2508802;Malta;-689719;-375221;0;25;ParaÌba;2077;83;America/Sao_Paulo
-2508901;Mamanguape;-68337;-351213;0;25;ParaÌba;2079;83;America/Sao_Paulo
-5212709;MambaÌ;-144823;-461165;0;52;Goi·s;9449;62;America/Sao_Paulo
-4114005;MamborÍ;-24317;-525271;0;41;Paran·;7673;44;America/Sao_Paulo
+4113908;Mallet;-258806;-508173;0;41;Paran√°;7671;42;America/Sao_Paulo
+2508802;Malta;-689719;-375221;0;25;Para√≠ba;2077;83;America/Sao_Paulo
+2508901;Mamanguape;-68337;-351213;0;25;Para√≠ba;2079;83;America/Sao_Paulo
+5212709;Mamba√≠;-144823;-461165;0;52;Goi√°s;9449;62;America/Sao_Paulo
+4114005;Mambor√™;-24317;-525271;0;41;Paran√°;7673;44;America/Sao_Paulo
 3139250;Mamonas;-150479;-429469;0;31;Minas Gerais;2895;38;America/Sao_Paulo
 4311734;Mampituba;-292136;-499311;0;43;Rio Grande do Sul;996;51;America/Sao_Paulo
 1302504;Manacapuru;-329066;-606216;0;13;Amazonas;253;92;America/Porto_Velho
-2509008;ManaÌra;-770331;-381523;0;25;ParaÌba;2081;83;America/Sao_Paulo
+2509008;Mana√≠ra;-770331;-381523;0;25;Para√≠ba;2081;83;America/Sao_Paulo
 1302553;Manaquiri;-344078;-604612;0;13;Amazonas;9839;92;America/Porto_Velho
 2609154;Manari;-89649;-376313;0;26;Pernambuco;554;87;America/Sao_Paulo
 1302603;Manaus;-311866;-600212;1;13;Amazonas;255;92;America/Porto_Velho
-1200336;M‚ncio Lima;-761657;-728997;0;12;Acre;109;68;America/Rio_Branco
-4114104;MandaguaÁu;-233458;-520944;0;41;Paran·;7675;44;America/Sao_Paulo
-4114203;Mandaguari;-235446;-51671;0;41;Paran·;7677;44;America/Sao_Paulo
-4114302;Mandirituba;-25777;-493282;0;41;Paran·;7679;41;America/Sao_Paulo
-3528601;Manduri;-230056;-493202;0;35;S„o Paulo;6673;14;America/Sao_Paulo
-4114351;ManfrinÛpolis;-261441;-533113;0;41;Paran·;864;46;America/Sao_Paulo
+1200336;M√¢ncio Lima;-761657;-728997;0;12;Acre;109;68;America/Rio_Branco
+4114104;Mandagua√ßu;-233458;-520944;0;41;Paran√°;7675;44;America/Sao_Paulo
+4114203;Mandaguari;-235446;-51671;0;41;Paran√°;7677;44;America/Sao_Paulo
+4114302;Mandirituba;-25777;-493282;0;41;Paran√°;7679;41;America/Sao_Paulo
+3528601;Manduri;-230056;-493202;0;35;S√£o Paulo;6673;14;America/Sao_Paulo
+4114351;Manfrin√≥polis;-261441;-533113;0;41;Paran√°;864;46;America/Sao_Paulo
 3139300;Manga;-147529;-439391;0;31;Minas Gerais;4785;38;America/Sao_Paulo
 3302601;Mangaratiba;-229594;-440409;0;33;Rio de Janeiro;5851;21;America/Sao_Paulo
-4114401;Mangueirinha;-259421;-521743;0;41;Paran·;7511;46;America/Sao_Paulo
-3139409;ManhuaÁu;-202572;-42028;0;31;Minas Gerais;4787;33;America/Sao_Paulo
+4114401;Mangueirinha;-259421;-521743;0;41;Paran√°;7511;46;America/Sao_Paulo
+3139409;Manhua√ßu;-202572;-42028;0;31;Minas Gerais;4787;33;America/Sao_Paulo
 3139508;Manhumirim;-203591;-419589;0;31;Minas Gerais;4789;33;America/Sao_Paulo
-1302702;ManicorÈ;-580462;-612895;0;13;Amazonas;257;97;America/Porto_Velho
-2205904;Manoel EmÌdio;-801234;-438755;0;22;PiauÌ;1117;89;America/Sao_Paulo
-4114500;Manoel Ribas;-245144;-516658;0;41;Paran·;7681;43;America/Sao_Paulo
+1302702;Manicor√©;-580462;-612895;0;13;Amazonas;257;97;America/Porto_Velho
+2205904;Manoel Em√≠dio;-801234;-438755;0;22;Piau√≠;1117;89;America/Sao_Paulo
+4114500;Manoel Ribas;-245144;-516658;0;41;Paran√°;7681;43;America/Sao_Paulo
 1200344;Manoel Urbano;-883291;-692679;0;12;Acre;155;68;America/Rio_Branco
 4311759;Manoel Viana;-295859;-554841;0;43;Rio Grande do Sul;6079;55;America/Sao_Paulo
 2920403;Manoel Vitorino;-141476;-402399;0;29;Bahia;3709;73;America/Sao_Paulo
-2920452;Mansid„o;-107227;-440428;0;29;Bahia;3977;77;America/Sao_Paulo
+2920452;Mansid√£o;-107227;-440428;0;29;Bahia;3977;77;America/Sao_Paulo
 3139607;Mantena;-187761;-409874;0;31;Minas Gerais;4791;33;America/Sao_Paulo
-3203304;MantenÛpolis;-188594;-41124;0;32;EspÌrito Santo;5665;27;America/Sao_Paulo
-4311775;MaquinÈ;-296798;-502079;0;43;Rio Grande do Sul;5783;51;America/Sao_Paulo
+3203304;Manten√≥polis;-188594;-41124;0;32;Esp√≠rito Santo;5665;27;America/Sao_Paulo
+4311775;Maquin√©;-296798;-502079;0;43;Rio Grande do Sul;5783;51;America/Sao_Paulo
 3139805;Mar de Espanha;-218707;-430062;0;31;Minas Gerais;4795;32;America/Sao_Paulo
 2704906;Mar Vermelho;-944739;-363881;0;27;Alagoas;2797;82;America/Sao_Paulo
-5212808;Mara Rosa;-140148;-491777;0;52;Goi·s;9451;62;America/Sao_Paulo
-1302801;Mara„;-185313;-65573;0;13;Amazonas;259;97;America/Porto_Velho
-1504208;Marab·;-538075;-491327;0;15;Par·;483;94;America/Sao_Paulo
-3528700;Marab· Paulista;-221068;-519617;0;35;S„o Paulo;6675;18;America/Sao_Paulo
-2106326;MaracaÁumÈ;-204918;-459587;0;21;Maranh„o;190;98;America/Sao_Paulo
-3528809;MaracaÌ;-226149;-506713;0;35;S„o Paulo;6677;18;America/Sao_Paulo
-4210407;Maracaj·;-288463;-494605;0;42;Santa Catarina;8391;48;America/Sao_Paulo
+5212808;Mara Rosa;-140148;-491777;0;52;Goi√°s;9451;62;America/Sao_Paulo
+1302801;Mara√£;-185313;-65573;0;13;Amazonas;259;97;America/Porto_Velho
+1504208;Marab√°;-538075;-491327;0;15;Par√°;483;94;America/Sao_Paulo
+3528700;Marab√° Paulista;-221068;-519617;0;35;S√£o Paulo;6675;18;America/Sao_Paulo
+2106326;Maraca√ßum√©;-204918;-459587;0;21;Maranh√£o;190;98;America/Sao_Paulo
+3528809;Maraca√≠;-226149;-506713;0;35;S√£o Paulo;6677;18;America/Sao_Paulo
+4210407;Maracaj√°;-288463;-494605;0;42;Santa Catarina;8391;48;America/Sao_Paulo
 5005400;Maracaju;-216105;-551678;0;50;Mato Grosso do Sul;9107;67;America/Porto_Velho
-1504307;Maracan„;-778899;-47452;0;15;Par·;485;91;America/Sao_Paulo
-2307650;Maracana˙;-386699;-386259;0;23;Cear·;1585;85;America/Sao_Paulo
-2920502;Marac·s;-134355;-404323;0;29;Bahia;3711;73;America/Sao_Paulo
+1504307;Maracan√£;-778899;-47452;0;15;Par√°;485;91;America/Sao_Paulo
+2307650;Maracana√∫;-386699;-386259;0;23;Cear√°;1585;85;America/Sao_Paulo
+2920502;Marac√°s;-134355;-404323;0;29;Bahia;3711;73;America/Sao_Paulo
 2704500;Maragogi;-900744;-352267;0;27;Alagoas;2789;82;America/Sao_Paulo
 2920601;Maragogipe;-12776;-389175;0;29;Bahia;3713;75;America/Sao_Paulo
 2609204;Maraial;-879062;-358266;0;26;Pernambuco;2483;81;America/Sao_Paulo
-2106359;Maraj· do Sena;-462806;-454531;0;21;Maranh„o;192;98;America/Sao_Paulo
-2307700;Maranguape;-389143;-386829;0;23;Cear·;1455;85;America/Sao_Paulo
-2106375;Maranh„ozinho;-224078;-458507;0;21;Maranh„o;194;98;America/Sao_Paulo
-1504406;Marapanim;-714702;-477034;0;15;Par·;487;91;America/Sao_Paulo
-3528858;Marapoama;-212587;-4913;0;35;S„o Paulo;2977;17;America/Sao_Paulo
-4311791;Marat·;-295457;-515573;0;43;Rio Grande do Sul;6039;51;America/Sao_Paulo
-3203320;MarataÌzes;-210398;-408384;0;32;EspÌrito Santo;760;28;America/Sao_Paulo
+2106359;Maraj√° do Sena;-462806;-454531;0;21;Maranh√£o;192;98;America/Sao_Paulo
+2307700;Maranguape;-389143;-386829;0;23;Cear√°;1455;85;America/Sao_Paulo
+2106375;Maranh√£ozinho;-224078;-458507;0;21;Maranh√£o;194;98;America/Sao_Paulo
+1504406;Marapanim;-714702;-477034;0;15;Par√°;487;91;America/Sao_Paulo
+3528858;Marapoama;-212587;-4913;0;35;S√£o Paulo;2977;17;America/Sao_Paulo
+4311791;Marat√°;-295457;-515573;0;43;Rio Grande do Sul;6039;51;America/Sao_Paulo
+3203320;Marata√≠zes;-210398;-408384;0;32;Esp√≠rito Santo;760;28;America/Sao_Paulo
 4311809;Marau;-284498;-521986;0;43;Rio Grande do Sul;8737;54;America/Sao_Paulo
-2920700;Mara˙;-141035;-390137;0;29;Bahia;3715;73;America/Sao_Paulo
+2920700;Mara√∫;-141035;-390137;0;29;Bahia;3715;73;America/Sao_Paulo
 2704609;Maravilha;-923045;-373524;0;27;Alagoas;2791;82;America/Sao_Paulo
 4210506;Maravilha;-267665;-531737;0;42;Santa Catarina;8205;49;America/Sao_Paulo
 3139706;Maravilhas;-195076;-446779;0;31;Minas Gerais;4793;37;America/Sao_Paulo
-2509057;MarcaÁ„o;-676535;-350087;0;25;ParaÌba;484;83;America/Sao_Paulo
-5105580;Marcel‚ndia;-110463;-544377;0;51;Mato Grosso;9899;66;America/Porto_Velho
+2509057;Marca√ß√£o;-676535;-350087;0;25;Para√≠ba;484;83;America/Sao_Paulo
+5105580;Marcel√¢ndia;-110463;-544377;0;51;Mato Grosso;9899;66;America/Porto_Velho
 4311908;Marcelino Ramos;-274676;-519095;0;43;Rio Grande do Sul;8739;54;America/Sao_Paulo
 2407302;Marcelino Vieira;-62846;-381642;0;24;Rio Grande do Norte;1745;84;America/Sao_Paulo
-2920809;MarcionÌlio Souza;-130064;-405295;0;29;Bahia;3717;75;America/Sao_Paulo
-2307809;Marco;-31285;-401582;0;23;Cear·;1457;88;America/Sao_Paulo
-2205953;Marcol‚ndia;-744169;-406602;0;22;PiauÌ;2275;89;America/Sao_Paulo
-2206001;Marcos Parente;-711565;-438926;0;22;PiauÌ;1119;89;America/Sao_Paulo
-4114609;Marechal C‚ndido Rondon;-24557;-540571;0;41;Paran·;7683;45;America/Sao_Paulo
+2920809;Marcion√≠lio Souza;-130064;-405295;0;29;Bahia;3717;75;America/Sao_Paulo
+2307809;Marco;-31285;-401582;0;23;Cear√°;1457;88;America/Sao_Paulo
+2205953;Marcol√¢ndia;-744169;-406602;0;22;Piau√≠;2275;89;America/Sao_Paulo
+2206001;Marcos Parente;-711565;-438926;0;22;Piau√≠;1119;89;America/Sao_Paulo
+4114609;Marechal C√¢ndido Rondon;-24557;-540571;0;41;Paran√°;7683;45;America/Sao_Paulo
 2704708;Marechal Deodoro;-970971;-358967;0;27;Alagoas;2793;82;America/Sao_Paulo
-3203346;Marechal Floriano;-204159;-4067;0;32;EspÌrito Santo;2929;27;America/Sao_Paulo
+3203346;Marechal Floriano;-204159;-4067;0;32;Esp√≠rito Santo;2929;27;America/Sao_Paulo
 1200351;Marechal Thaumaturgo;-893898;-727997;0;12;Acre;655;68;America/Rio_Branco
 4210555;Marema;-268024;-526264;0;42;Santa Catarina;9963;49;America/Sao_Paulo
-2509107;Mari;-705942;-35318;0;25;ParaÌba;2083;83;America/Sao_Paulo
-3139904;Maria da FÈ;-223044;-453773;0;31;Minas Gerais;4797;35;America/Sao_Paulo
-4114708;Maria Helena;-236158;-532053;0;41;Paran·;7685;44;America/Sao_Paulo
-4114807;Marialva;-234843;-517928;0;41;Paran·;7687;44;America/Sao_Paulo
+2509107;Mari;-705942;-35318;0;25;Para√≠ba;2083;83;America/Sao_Paulo
+3139904;Maria da F√©;-223044;-453773;0;31;Minas Gerais;4797;35;America/Sao_Paulo
+4114708;Maria Helena;-236158;-532053;0;41;Paran√°;7685;44;America/Sao_Paulo
+4114807;Marialva;-234843;-517928;0;41;Paran√°;7687;44;America/Sao_Paulo
 3140001;Mariana;-203765;-43414;0;31;Minas Gerais;4799;31;America/Sao_Paulo
 4311981;Mariana Pimentel;-30353;-515803;0;43;Rio Grande do Sul;5759;51;America/Sao_Paulo
 4312005;Mariano Moro;-273568;-521467;0;43;Rio Grande do Sul;8741;54;America/Sao_Paulo
-1712504;MarianÛpolis do Tocantins;-979377;-496553;0;17;Tocantins;9711;63;America/Sao_Paulo
-3528908;Mari·polis;-217959;-511824;0;35;S„o Paulo;6679;18;America/Sao_Paulo
+1712504;Marian√≥polis do Tocantins;-979377;-496553;0;17;Tocantins;9711;63;America/Sao_Paulo
+3528908;Mari√°polis;-217959;-511824;0;35;S√£o Paulo;6679;18;America/Sao_Paulo
 2704807;Maribondo;-958353;-363045;0;27;Alagoas;2795;82;America/Sao_Paulo
-3302700;Maric·;-229354;-428246;0;33;Rio de Janeiro;5853;21;America/Sao_Paulo
+3302700;Maric√°;-229354;-428246;0;33;Rio de Janeiro;5853;21;America/Sao_Paulo
 3140100;Marilac;-185079;-420822;0;31;Minas Gerais;4801;33;America/Sao_Paulo
-3203353;Maril‚ndia;-194114;-405456;0;32;EspÌrito Santo;5707;27;America/Sao_Paulo
-4114906;Maril‚ndia do Sul;-237425;-513137;0;41;Paran·;7433;43;America/Sao_Paulo
-4115002;Marilena;-227336;-530402;0;41;Paran·;7975;44;America/Sao_Paulo
-3529005;MarÌlia;-222171;-499501;0;35;S„o Paulo;6681;14;America/Sao_Paulo
-4115101;Mariluz;-240089;-531432;0;41;Paran·;7689;44;America/Sao_Paulo
-4115200;Maring·;-234205;-519333;0;41;Paran·;7691;44;America/Sao_Paulo
-3529104;MarinÛpolis;-204389;-508254;0;35;S„o Paulo;6683;17;America/Sao_Paulo
-3140159;M·rio Campos;-200582;-441883;0;31;Minas Gerais;648;31;America/Sao_Paulo
-4115309;MariÛpolis;-26355;-525532;0;41;Paran·;7693;46;America/Sao_Paulo
-4115358;Marip·;-2442;-538286;0;41;Paran·;5487;44;America/Sao_Paulo
-3140209;Marip· de Minas;-216979;-429546;0;31;Minas Gerais;4803;32;America/Sao_Paulo
-1504422;Marituba;-136002;-483421;0;15;Par·;54;91;America/Sao_Paulo
-2509156;MarizÛpolis;-682748;-383528;0;25;ParaÌba;486;83;America/Sao_Paulo
-3140308;MarliÈria;-197096;-427327;0;31;Minas Gerais;4805;31;America/Sao_Paulo
-4115408;Marmeleiro;-261472;-530267;0;41;Paran·;7695;46;America/Sao_Paulo
-3140407;MarmelÛpolis;-22447;-451645;0;31;Minas Gerais;4807;35;America/Sao_Paulo
+3203353;Maril√¢ndia;-194114;-405456;0;32;Esp√≠rito Santo;5707;27;America/Sao_Paulo
+4114906;Maril√¢ndia do Sul;-237425;-513137;0;41;Paran√°;7433;43;America/Sao_Paulo
+4115002;Marilena;-227336;-530402;0;41;Paran√°;7975;44;America/Sao_Paulo
+3529005;Mar√≠lia;-222171;-499501;0;35;S√£o Paulo;6681;14;America/Sao_Paulo
+4115101;Mariluz;-240089;-531432;0;41;Paran√°;7689;44;America/Sao_Paulo
+4115200;Maring√°;-234205;-519333;0;41;Paran√°;7691;44;America/Sao_Paulo
+3529104;Marin√≥polis;-204389;-508254;0;35;S√£o Paulo;6683;17;America/Sao_Paulo
+3140159;M√°rio Campos;-200582;-441883;0;31;Minas Gerais;648;31;America/Sao_Paulo
+4115309;Mari√≥polis;-26355;-525532;0;41;Paran√°;7693;46;America/Sao_Paulo
+4115358;Marip√°;-2442;-538286;0;41;Paran√°;5487;44;America/Sao_Paulo
+3140209;Marip√° de Minas;-216979;-429546;0;31;Minas Gerais;4803;32;America/Sao_Paulo
+1504422;Marituba;-136002;-483421;0;15;Par√°;54;91;America/Sao_Paulo
+2509156;Mariz√≥polis;-682748;-383528;0;25;Para√≠ba;486;83;America/Sao_Paulo
+3140308;Marli√©ria;-197096;-427327;0;31;Minas Gerais;4805;31;America/Sao_Paulo
+4115408;Marmeleiro;-261472;-530267;0;41;Paran√°;7695;46;America/Sao_Paulo
+3140407;Marmel√≥polis;-22447;-451645;0;31;Minas Gerais;4807;35;America/Sao_Paulo
 4312054;Marques de Souza;-293311;-520973;0;43;Rio Grande do Sul;998;51;America/Sao_Paulo
-4115457;Marquinho;-25112;-522497;0;41;Paran·;866;42;America/Sao_Paulo
+4115457;Marquinho;-25112;-522497;0;41;Paran√°;866;42;America/Sao_Paulo
 3140506;Martinho Campos;-193306;-452434;0;31;Minas Gerais;4809;37;America/Sao_Paulo
-2307908;MartinÛpole;-32252;-406896;0;23;Cear·;1459;88;America/Sao_Paulo
-3529203;MartinÛpolis;-221462;-511709;0;35;S„o Paulo;6685;18;America/Sao_Paulo
+2307908;Martin√≥pole;-32252;-406896;0;23;Cear√°;1459;88;America/Sao_Paulo
+3529203;Martin√≥polis;-221462;-511709;0;35;S√£o Paulo;6685;18;America/Sao_Paulo
 2407401;Martins;-608279;-37908;0;24;Rio Grande do Norte;1747;84;America/Sao_Paulo
 3140530;Martins Soares;-202546;-418786;0;31;Minas Gerais;650;33;America/Sao_Paulo
 2804003;Maruim;-107308;-370856;0;28;Sergipe;3179;79;America/Sao_Paulo
-4115507;Marumbi;-237058;-516404;0;41;Paran·;7697;43;America/Sao_Paulo
-5212907;Marzag„o;-17983;-486415;0;52;Goi·s;9453;64;America/Sao_Paulo
+4115507;Marumbi;-237058;-516404;0;41;Paran√°;7697;43;America/Sao_Paulo
+5212907;Marzag√£o;-17983;-486415;0;52;Goi√°s;9453;64;America/Sao_Paulo
 2920908;Mascote;-155542;-393016;0;29;Bahia;3719;73;America/Sao_Paulo
-2308005;MassapÍ;-352364;-403423;0;23;Cear·;1461;88;America/Sao_Paulo
-2206050;MassapÍ do PiauÌ;-747469;-411103;0;22;PiauÌ;346;89;America/Sao_Paulo
-2509206;Massaranduba;-718995;-357848;0;25;ParaÌba;2085;83;America/Sao_Paulo
+2308005;Massap√™;-352364;-403423;0;23;Cear√°;1461;88;America/Sao_Paulo
+2206050;Massap√™ do Piau√≠;-747469;-411103;0;22;Piau√≠;346;89;America/Sao_Paulo
+2509206;Massaranduba;-718995;-357848;0;25;Para√≠ba;2085;83;America/Sao_Paulo
 4210605;Massaranduba;-266109;-490054;0;42;Santa Catarina;8207;47;America/Sao_Paulo
 4312104;Mata;-295649;-544641;0;43;Rio Grande do Sul;8743;55;America/Sao_Paulo
-2921005;Mata de S„o Jo„o;-125307;-383009;0;29;Bahia;3721;71;America/Sao_Paulo
+2921005;Mata de S√£o Jo√£o;-125307;-383009;0;29;Bahia;3721;71;America/Sao_Paulo
 2705002;Mata Grande;-911824;-377323;0;27;Alagoas;2799;82;America/Sao_Paulo
-2106409;Mata Roma;-362035;-431112;0;21;Maranh„o;827;98;America/Sao_Paulo
+2106409;Mata Roma;-362035;-431112;0;21;Maranh√£o;827;98;America/Sao_Paulo
 3140555;Mata Verde;-156869;-407366;0;31;Minas Gerais;2659;33;America/Sao_Paulo
-3529302;Mat„o;-216025;-48364;0;35;S„o Paulo;6687;16;America/Sao_Paulo
-2509305;Mataraca;-659673;-350531;0;25;ParaÌba;2087;83;America/Sao_Paulo
+3529302;Mat√£o;-216025;-48364;0;35;S√£o Paulo;6687;16;America/Sao_Paulo
+2509305;Mataraca;-659673;-350531;0;25;Para√≠ba;2087;83;America/Sao_Paulo
 1712702;Mateiros;-105464;-464168;0;17;Tocantins;317;63;America/Sao_Paulo
-4115606;Matel‚ndia;-252496;-539935;0;41;Paran·;7699;45;America/Sao_Paulo
-3140605;Materl‚ndia;-184699;-430579;0;31;Minas Gerais;4811;33;America/Sao_Paulo
+4115606;Matel√¢ndia;-252496;-539935;0;41;Paran√°;7699;45;America/Sao_Paulo
+3140605;Materl√¢ndia;-184699;-430579;0;31;Minas Gerais;4811;33;America/Sao_Paulo
 3140704;Mateus Leme;-199794;-444318;0;31;Minas Gerais;4813;31;America/Sao_Paulo
 3171501;Mathias Lobato;-1859;-419166;0;31;Minas Gerais;5431;33;America/Sao_Paulo
 3140803;Matias Barbosa;-21869;-433135;0;31;Minas Gerais;4815;32;America/Sao_Paulo
 3140852;Matias Cardoso;-148563;-439146;0;31;Minas Gerais;2897;38;America/Sao_Paulo
-2206100;Matias OlÌmpio;-371492;-425507;0;22;PiauÌ;1121;86;America/Sao_Paulo
+2206100;Matias Ol√≠mpio;-371492;-425507;0;22;Piau√≠;1121;86;America/Sao_Paulo
 2921054;Matina;-139109;-428439;0;29;Bahia;3295;77;America/Sao_Paulo
-2106508;Matinha;-309849;-45035;0;21;Maranh„o;829;98;America/Sao_Paulo
-2509339;Matinhas;-712486;-357669;0;25;ParaÌba;488;83;America/Sao_Paulo
-4115705;Matinhos;-258237;-48549;0;41;Paran·;7963;41;America/Sao_Paulo
-3140902;MatipÛ;-202873;-423401;0;31;Minas Gerais;4817;31;America/Sao_Paulo
+2106508;Matinha;-309849;-45035;0;21;Maranh√£o;829;98;America/Sao_Paulo
+2509339;Matinhas;-712486;-357669;0;25;Para√≠ba;488;83;America/Sao_Paulo
+4115705;Matinhos;-258237;-48549;0;41;Paran√°;7963;41;America/Sao_Paulo
+3140902;Matip√≥;-202873;-423401;0;31;Minas Gerais;4817;31;America/Sao_Paulo
 4312138;Mato Castelhano;-2828;-521932;0;43;Rio Grande do Sul;5931;54;America/Sao_Paulo
-2509370;Mato Grosso;-654018;-377279;0;25;ParaÌba;490;83;America/Sao_Paulo
-4312153;Mato Leit„o;-295285;-521278;0;43;Rio Grande do Sul;6031;51;America/Sao_Paulo
+2509370;Mato Grosso;-654018;-377279;0;25;Para√≠ba;490;83;America/Sao_Paulo
+4312153;Mato Leit√£o;-295285;-521278;0;43;Rio Grande do Sul;6031;51;America/Sao_Paulo
 4312179;Mato Queimado;-28252;-546159;0;43;Rio Grande do Sul;1150;55;America/Sao_Paulo
-4115739;Mato Rico;-246995;-521454;0;41;Paran·;5503;42;America/Sao_Paulo
+4115739;Mato Rico;-246995;-521454;0;41;Paran√°;5503;42;America/Sao_Paulo
 3141009;Mato Verde;-153944;-4286;0;31;Minas Gerais;4819;38;America/Sao_Paulo
-2106607;Matıes;-551359;-432018;0;21;Maranh„o;831;99;America/Sao_Paulo
-2106631;Matıes do Norte;-36244;-445468;0;21;Maranh„o;196;98;America/Sao_Paulo
+2106607;Mat√µes;-551359;-432018;0;21;Maranh√£o;831;99;America/Sao_Paulo
+2106631;Mat√µes do Norte;-36244;-445468;0;21;Maranh√£o;196;98;America/Sao_Paulo
 4210704;Matos Costa;-264709;-511501;0;42;Santa Catarina;8209;49;America/Sao_Paulo
 3141108;Matozinhos;-195543;-440868;0;31;Minas Gerais;4821;31;America/Sao_Paulo
-5212956;Matrinch„;-154342;-507456;0;52;Goi·s;9927;62;America/Sao_Paulo
+5212956;Matrinch√£;-154342;-507456;0;52;Goi√°s;9927;62;America/Sao_Paulo
 2705101;Matriz de Camaragibe;-915437;-355243;0;27;Alagoas;2801;82;America/Sao_Paulo
-5105606;Matup·;-101821;-549467;0;51;Mato Grosso;9929;66;America/Porto_Velho
-2509396;MaturÈia;-726188;-37351;0;25;ParaÌba;492;83;America/Sao_Paulo
+5105606;Matup√°;-101821;-549467;0;51;Mato Grosso;9929;66;America/Porto_Velho
+2509396;Matur√©ia;-726188;-37351;0;25;Para√≠ba;492;83;America/Sao_Paulo
 3141207;Matutina;-192179;-459664;0;31;Minas Gerais;4823;34;America/Sao_Paulo
-3529401;Mau·;-236677;-464613;0;35;S„o Paulo;6689;11;America/Sao_Paulo
-4115754;Mau· da Serra;-238988;-512277;0;41;Paran·;5459;43;America/Sao_Paulo
-1302900;MauÈs;-339289;-577067;0;13;Amazonas;261;92;America/Porto_Velho
-5213004;Mauril‚ndia;-179719;-503388;0;52;Goi·s;9457;64;America/Sao_Paulo
-1712801;Mauril‚ndia do Tocantins;-595169;-475125;0;17;Tocantins;183;63;America/Sao_Paulo
-2308104;Mauriti;-738597;-387708;0;23;Cear·;1463;88;America/Sao_Paulo
+3529401;Mau√°;-236677;-464613;0;35;S√£o Paulo;6689;11;America/Sao_Paulo
+4115754;Mau√° da Serra;-238988;-512277;0;41;Paran√°;5459;43;America/Sao_Paulo
+1302900;Mau√©s;-339289;-577067;0;13;Amazonas;261;92;America/Porto_Velho
+5213004;Mauril√¢ndia;-179719;-503388;0;52;Goi√°s;9457;64;America/Sao_Paulo
+1712801;Mauril√¢ndia do Tocantins;-595169;-475125;0;17;Tocantins;183;63;America/Sao_Paulo
+2308104;Mauriti;-738597;-387708;0;23;Cear√°;1463;88;America/Sao_Paulo
 2407500;Maxaranguape;-552181;-352631;0;24;Rio Grande do Norte;1749;84;America/Sao_Paulo
 4312203;Maximiliano de Almeida;-276325;-51802;0;43;Rio Grande do Sul;8745;54;America/Sao_Paulo
-1600402;Mazag„o;-11336;-512891;0;16;Amap·;607;96;America/Sao_Paulo
+1600402;Mazag√£o;-11336;-512891;0;16;Amap√°;607;96;America/Sao_Paulo
 3141306;Medeiros;-199865;-462181;0;31;Minas Gerais;4825;37;America/Sao_Paulo
 2921104;Medeiros Neto;-173707;-402238;0;29;Bahia;3723;73;America/Sao_Paulo
-4115804;Medianeira;-252977;-540943;0;41;Paran·;7701;45;America/Sao_Paulo
-1504455;Medicil‚ndia;-344637;-528875;0;15;Par·;589;93;America/Sao_Paulo
+4115804;Medianeira;-252977;-540943;0;41;Paran√°;7701;45;America/Sao_Paulo
+1504455;Medicil√¢ndia;-344637;-528875;0;15;Par√°;589;93;America/Sao_Paulo
 3141405;Medina;-162245;-414728;0;31;Minas Gerais;4827;33;America/Sao_Paulo
 4210803;Meleiro;-288244;-496378;0;42;Santa Catarina;8211;48;America/Sao_Paulo
-1504505;MelgaÁo;-18032;-507149;0;15;Par·;489;91;America/Sao_Paulo
+1504505;Melga√ßo;-18032;-507149;0;15;Par√°;489;91;America/Sao_Paulo
 3302809;Mendes;-225245;-437312;0;33;Rio de Janeiro;5855;24;America/Sao_Paulo
 3141504;Mendes Pimentel;-186631;-414052;0;31;Minas Gerais;4829;33;America/Sao_Paulo
-3529500;MendonÁa;-211757;-495791;0;35;S„o Paulo;6691;17;America/Sao_Paulo
-4115853;Mercedes;-244538;-541618;0;41;Paran·;5531;45;America/Sao_Paulo
-3141603;MercÍs;-211976;-433337;0;31;Minas Gerais;4831;32;America/Sao_Paulo
-3529609;Meridiano;-203579;-501811;0;35;S„o Paulo;6693;17;America/Sao_Paulo
-2308203;Meruoca;-353974;-404531;0;23;Cear·;1465;88;America/Sao_Paulo
-3529658;MesÛpolis;-199684;-506326;0;35;S„o Paulo;2983;17;America/Sao_Paulo
+3529500;Mendon√ßa;-211757;-495791;0;35;S√£o Paulo;6691;17;America/Sao_Paulo
+4115853;Mercedes;-244538;-541618;0;41;Paran√°;5531;45;America/Sao_Paulo
+3141603;Merc√™s;-211976;-433337;0;31;Minas Gerais;4831;32;America/Sao_Paulo
+3529609;Meridiano;-203579;-501811;0;35;S√£o Paulo;6693;17;America/Sao_Paulo
+2308203;Meruoca;-353974;-404531;0;23;Cear√°;1465;88;America/Sao_Paulo
+3529658;Mes√≥polis;-199684;-506326;0;35;S√£o Paulo;2983;17;America/Sao_Paulo
 3302858;Mesquita;-228028;-434601;0;33;Rio de Janeiro;1116;21;America/Sao_Paulo
 3141702;Mesquita;-19224;-426079;0;31;Minas Gerais;4833;33;America/Sao_Paulo
 2705200;Messias;-939384;-358392;0;27;Alagoas;2803;82;America/Sao_Paulo
 2407609;Messias Targino;-607194;-375158;0;24;Rio Grande do Norte;1721;84;America/Sao_Paulo
-2206209;Miguel Alves;-416857;-428963;0;22;PiauÌ;1123;86;America/Sao_Paulo
+2206209;Miguel Alves;-416857;-428963;0;22;Piau√≠;1123;86;America/Sao_Paulo
 2921203;Miguel Calmon;-114299;-406031;0;29;Bahia;3725;74;America/Sao_Paulo
-2206308;Miguel Le„o;-568077;-427436;0;22;PiauÌ;1125;86;America/Sao_Paulo
+2206308;Miguel Le√£o;-568077;-427436;0;22;Piau√≠;1125;86;America/Sao_Paulo
 3302908;Miguel Pereira;-224572;-434803;0;33;Rio de Janeiro;5857;24;America/Sao_Paulo
-3529708;MiguelÛpolis;-201796;-48031;0;35;S„o Paulo;6695;16;America/Sao_Paulo
-2308302;Milagres;-729749;-389378;0;23;Cear·;1467;88;America/Sao_Paulo
+3529708;Miguel√≥polis;-201796;-48031;0;35;S√£o Paulo;6695;16;America/Sao_Paulo
+2308302;Milagres;-729749;-389378;0;23;Cear√°;1467;88;America/Sao_Paulo
 2921302;Milagres;-128646;-398611;0;29;Bahia;3727;75;America/Sao_Paulo
-2106672;Milagres do Maranh„o;-357443;-426131;0;21;Maranh„o;198;98;America/Sao_Paulo
-2308351;Milh„;-567252;-391875;0;23;Cear·;1597;88;America/Sao_Paulo
-2206357;Milton Brand„o;-468295;-414173;0;22;PiauÌ;348;86;America/Sao_Paulo
-5213053;Mimoso de Goi·s;-150515;-481611;0;52;Goi·s;9931;62;America/Sao_Paulo
-3203403;Mimoso do Sul;-210628;-413615;0;32;EspÌrito Santo;5667;28;America/Sao_Paulo
-5213087;MinaÁu;-135304;-482206;0;52;Goi·s;9647;62;America/Sao_Paulo
-2705309;Minador do Negr„o;-931236;-368696;0;27;Alagoas;2805;82;America/Sao_Paulo
-4312252;Minas do Le„o;-301346;-520423;0;43;Rio Grande do Sul;5773;51;America/Sao_Paulo
+2106672;Milagres do Maranh√£o;-357443;-426131;0;21;Maranh√£o;198;98;America/Sao_Paulo
+2308351;Milh√£;-567252;-391875;0;23;Cear√°;1597;88;America/Sao_Paulo
+2206357;Milton Brand√£o;-468295;-414173;0;22;Piau√≠;348;86;America/Sao_Paulo
+5213053;Mimoso de Goi√°s;-150515;-481611;0;52;Goi√°s;9931;62;America/Sao_Paulo
+3203403;Mimoso do Sul;-210628;-413615;0;32;Esp√≠rito Santo;5667;28;America/Sao_Paulo
+5213087;Mina√ßu;-135304;-482206;0;52;Goi√°s;9647;62;America/Sao_Paulo
+2705309;Minador do Negr√£o;-931236;-368696;0;27;Alagoas;2805;82;America/Sao_Paulo
+4312252;Minas do Le√£o;-301346;-520423;0;43;Rio Grande do Sul;5773;51;America/Sao_Paulo
 3141801;Minas Novas;-172156;-425884;0;31;Minas Gerais;4835;33;America/Sao_Paulo
 3141900;Minduri;-216797;-446051;0;31;Minas Gerais;4837;35;America/Sao_Paulo
-5213103;Mineiros;-175654;-525537;0;52;Goi·s;9459;64;America/Sao_Paulo
-3529807;Mineiros do TietÍ;-22412;-48451;0;35;S„o Paulo;6697;14;America/Sao_Paulo
-1101203;Ministro Andreazza;-11196;-615174;0;11;RondÙnia;695;69;America/Porto_Velho
-3530003;Mira Estrela;-199789;-50139;0;35;S„o Paulo;6701;17;America/Sao_Paulo
+5213103;Mineiros;-175654;-525537;0;52;Goi√°s;9459;64;America/Sao_Paulo
+3529807;Mineiros do Tiet√™;-22412;-48451;0;35;S√£o Paulo;6697;14;America/Sao_Paulo
+1101203;Ministro Andreazza;-11196;-615174;0;11;Rond√¥nia;695;69;America/Porto_Velho
+3530003;Mira Estrela;-199789;-50139;0;35;S√£o Paulo;6701;17;America/Sao_Paulo
 3142007;Mirabela;-16256;-441602;0;31;Minas Gerais;4839;38;America/Sao_Paulo
-3529906;Miracatu;-242766;-474625;0;35;S„o Paulo;6699;13;America/Sao_Paulo
+3529906;Miracatu;-242766;-474625;0;35;S√£o Paulo;6699;13;America/Sao_Paulo
 3303005;Miracema;-214148;-421938;0;33;Rio de Janeiro;5859;22;America/Sao_Paulo
 1713205;Miracema do Tocantins;-956556;-48393;0;17;Tocantins;9461;63;America/Sao_Paulo
-2106706;Mirador;-637454;-443683;0;21;Maranh„o;833;99;America/Sao_Paulo
-4115903;Mirador;-23255;-527761;0;41;Paran·;7703;44;America/Sao_Paulo
+2106706;Mirador;-637454;-443683;0;21;Maranh√£o;833;99;America/Sao_Paulo
+4115903;Mirador;-23255;-527761;0;41;Paran√°;7703;44;America/Sao_Paulo
 3142106;Miradouro;-208899;-423458;0;31;Minas Gerais;4841;32;America/Sao_Paulo
-4312302;MiraguaÌ;-27497;-536891;0;43;Rio Grande do Sul;8747;55;America/Sao_Paulo
-3142205;MiraÌ;-212021;-426122;0;31;Minas Gerais;4843;32;America/Sao_Paulo
-2308377;MiraÌma;-356867;-399663;0;23;Cear·;1263;88;America/Sao_Paulo
+4312302;Miragua√≠;-27497;-536891;0;43;Rio Grande do Sul;8747;55;America/Sao_Paulo
+3142205;Mira√≠;-212021;-426122;0;31;Minas Gerais;4843;32;America/Sao_Paulo
+2308377;Mira√≠ma;-356867;-399663;0;23;Cear√°;1263;88;America/Sao_Paulo
 5005608;Miranda;-202355;-563746;0;50;Mato Grosso do Sul;9111;67;America/Porto_Velho
-2106755;Miranda do Norte;-356313;-445814;0;21;Maranh„o;1283;98;America/Sao_Paulo
+2106755;Miranda do Norte;-356313;-445814;0;21;Maranh√£o;1283;98;America/Sao_Paulo
 2609303;Mirandiba;-812113;-387388;0;26;Pernambuco;2485;87;America/Sao_Paulo
-3530102;MirandÛpolis;-211313;-511035;0;35;S„o Paulo;6703;18;America/Sao_Paulo
+3530102;Mirand√≥polis;-211313;-511035;0;35;S√£o Paulo;6703;18;America/Sao_Paulo
 2921401;Mirangaba;-10961;-40574;0;29;Bahia;3729;74;America/Sao_Paulo
 1713304;Miranorte;-952907;-485922;0;17;Tocantins;9463;63;America/Sao_Paulo
 2921450;Mirante;-142385;-407718;0;29;Bahia;3297;77;America/Sao_Paulo
-1101302;Mirante da Serra;-11029;-626696;0;11;RondÙnia;697;69;America/Porto_Velho
-3530201;Mirante do Paranapanema;-222904;-519084;0;35;S„o Paulo;6705;18;America/Sao_Paulo
-4116000;Miraselva;-229657;-514846;0;41;Paran·;7705;43;America/Sao_Paulo
-3530300;Mirassol;-208169;-495206;0;35;S„o Paulo;6707;17;America/Sao_Paulo
+1101302;Mirante da Serra;-11029;-626696;0;11;Rond√¥nia;697;69;America/Porto_Velho
+3530201;Mirante do Paranapanema;-222904;-519084;0;35;S√£o Paulo;6705;18;America/Sao_Paulo
+4116000;Miraselva;-229657;-514846;0;41;Paran√°;7705;43;America/Sao_Paulo
+3530300;Mirassol;-208169;-495206;0;35;S√£o Paulo;6707;17;America/Sao_Paulo
 5105622;Mirassol d'Oeste;-156759;-580951;0;51;Mato Grosso;9177;65;America/Porto_Velho
-3530409;Mirassol‚ndia;-206179;-494617;0;35;S„o Paulo;6709;17;America/Sao_Paulo
-3142254;Mirav‚nia;-147348;-444092;0;31;Minas Gerais;652;38;America/Sao_Paulo
+3530409;Mirassol√¢ndia;-206179;-494617;0;35;S√£o Paulo;6709;17;America/Sao_Paulo
+3142254;Mirav√¢nia;-147348;-444092;0;31;Minas Gerais;652;38;America/Sao_Paulo
 4210852;Mirim Doce;-27197;-500786;0;42;Santa Catarina;5559;47;America/Sao_Paulo
-2106805;Mirinzal;-207094;-447787;0;21;Maranh„o;835;98;America/Sao_Paulo
-4116059;Missal;-250919;-542477;0;41;Paran·;8469;45;America/Sao_Paulo
-2308401;Miss„o Velha;-723522;-39143;0;23;Cear·;1469;88;America/Sao_Paulo
-1504604;Mocajuba;-25831;-495042;0;15;Par·;491;91;America/Sao_Paulo
-3530508;Mococa;-214647;-470024;0;35;S„o Paulo;6711;19;America/Sao_Paulo
+2106805;Mirinzal;-207094;-447787;0;21;Maranh√£o;835;98;America/Sao_Paulo
+4116059;Missal;-250919;-542477;0;41;Paran√°;8469;45;America/Sao_Paulo
+2308401;Miss√£o Velha;-723522;-39143;0;23;Cear√°;1469;88;America/Sao_Paulo
+1504604;Mocajuba;-25831;-495042;0;15;Par√°;491;91;America/Sao_Paulo
+3530508;Mococa;-214647;-470024;0;35;S√£o Paulo;6711;19;America/Sao_Paulo
 4210902;Modelo;-267729;-5304;0;42;Santa Catarina;8213;49;America/Sao_Paulo
 3142304;Moeda;-203399;-440509;0;31;Minas Gerais;4845;31;America/Sao_Paulo
 3142403;Moema;-198387;-454127;0;31;Minas Gerais;4847;37;America/Sao_Paulo
-2509404;Mogeiro;-728517;-354832;0;25;ParaÌba;2089;83;America/Sao_Paulo
-3530607;Mogi das Cruzes;-235208;-461854;0;35;S„o Paulo;6713;11;America/Sao_Paulo
-3530706;Mogi GuaÁu;-223675;-469428;0;35;S„o Paulo;6715;19;America/Sao_Paulo
-3530805;Mogi Mirim;-224332;-469532;0;35;S„o Paulo;6717;19;America/Sao_Paulo
-5213400;Moipor·;-165434;-50739;0;52;Goi·s;9465;64;America/Sao_Paulo
+2509404;Mogeiro;-728517;-354832;0;25;Para√≠ba;2089;83;America/Sao_Paulo
+3530607;Mogi das Cruzes;-235208;-461854;0;35;S√£o Paulo;6713;11;America/Sao_Paulo
+3530706;Mogi Gua√ßu;-223675;-469428;0;35;S√£o Paulo;6715;19;America/Sao_Paulo
+3530805;Mogi Mirim;-224332;-469532;0;35;S√£o Paulo;6717;19;America/Sao_Paulo
+5213400;Moipor√°;-165434;-50739;0;52;Goi√°s;9465;64;America/Sao_Paulo
 2804102;Moita Bonita;-105769;-373512;0;28;Sergipe;3181;79;America/Sao_Paulo
-1504703;Moju;-188993;-487668;0;15;Par·;493;91;America/Sao_Paulo
-1504752;MojuÌ dos Campos;-26822;-546425;0;15;Par·;1190;93;America/Sao_Paulo
-2308500;MombaÁa;-573844;-3963;0;23;Cear·;1471;88;America/Sao_Paulo
-3530904;Mombuca;-229285;-47559;0;35;S„o Paulo;6719;19;America/Sao_Paulo
-2106904;MonÁ„o;-348125;-452496;0;21;Maranh„o;837;98;America/Sao_Paulo
-3531001;MonÁıes;-208509;-500975;0;35;S„o Paulo;6721;17;America/Sao_Paulo
-4211009;MondaÌ;-271008;-534032;0;42;Santa Catarina;8215;49;America/Sao_Paulo
-3531100;Mongagu·;-240809;-466265;0;35;S„o Paulo;6723;13;America/Sao_Paulo
+1504703;Moju;-188993;-487668;0;15;Par√°;493;91;America/Sao_Paulo
+1504752;Moju√≠ dos Campos;-26822;-546425;0;15;Par√°;1190;93;America/Sao_Paulo
+2308500;Momba√ßa;-573844;-3963;0;23;Cear√°;1471;88;America/Sao_Paulo
+3530904;Mombuca;-229285;-47559;0;35;S√£o Paulo;6719;19;America/Sao_Paulo
+2106904;Mon√ß√£o;-348125;-452496;0;21;Maranh√£o;837;98;America/Sao_Paulo
+3531001;Mon√ß√µes;-208509;-500975;0;35;S√£o Paulo;6721;17;America/Sao_Paulo
+4211009;Monda√≠;-271008;-534032;0;42;Santa Catarina;8215;49;America/Sao_Paulo
+3531100;Mongagu√°;-240809;-466265;0;35;S√£o Paulo;6723;13;America/Sao_Paulo
 3142502;Monjolos;-183245;-44118;0;31;Minas Gerais;4849;38;America/Sao_Paulo
-2206407;Monsenhor Gil;-5562;-426075;0;22;PiauÌ;1127;86;America/Sao_Paulo
-2206506;Monsenhor HipÛlito;-699275;-41026;0;22;PiauÌ;1129;89;America/Sao_Paulo
+2206407;Monsenhor Gil;-5562;-426075;0;22;Piau√≠;1127;86;America/Sao_Paulo
+2206506;Monsenhor Hip√≥lito;-699275;-41026;0;22;Piau√≠;1129;89;America/Sao_Paulo
 3142601;Monsenhor Paulo;-217579;-455391;0;31;Minas Gerais;4851;35;America/Sao_Paulo
-2308609;Monsenhor Tabosa;-479102;-400646;0;23;Cear·;1473;88;America/Sao_Paulo
-2509503;Montadas;-708848;-359592;0;25;ParaÌba;2091;83;America/Sao_Paulo
-3142700;Montalv‚nia;-144197;-443719;0;31;Minas Gerais;4853;38;America/Sao_Paulo
-3203502;Montanha;-181303;-403668;0;32;EspÌrito Santo;5669;27;America/Sao_Paulo
+2308609;Monsenhor Tabosa;-479102;-400646;0;23;Cear√°;1473;88;America/Sao_Paulo
+2509503;Montadas;-708848;-359592;0;25;Para√≠ba;2091;83;America/Sao_Paulo
+3142700;Montalv√¢nia;-144197;-443719;0;31;Minas Gerais;4853;38;America/Sao_Paulo
+3203502;Montanha;-181303;-403668;0;32;Esp√≠rito Santo;5669;27;America/Sao_Paulo
 2407708;Montanhas;-648522;-352842;0;24;Rio Grande do Norte;1753;84;America/Sao_Paulo
 4312351;Montauri;-286462;-520767;0;43;Rio Grande do Sul;7387;54;America/Sao_Paulo
-1504802;Monte Alegre;-199768;-540724;0;15;Par·;495;93;America/Sao_Paulo
+1504802;Monte Alegre;-199768;-540724;0;15;Par√°;495;93;America/Sao_Paulo
 2407807;Monte Alegre;-607063;-353253;0;24;Rio Grande do Norte;1755;84;America/Sao_Paulo
-5213509;Monte Alegre de Goi·s;-132552;-468928;0;52;Goi·s;9467;62;America/Sao_Paulo
+5213509;Monte Alegre de Goi√°s;-132552;-468928;0;52;Goi√°s;9467;62;America/Sao_Paulo
 3142809;Monte Alegre de Minas;-18869;-48881;0;31;Minas Gerais;4855;34;America/Sao_Paulo
 2804201;Monte Alegre de Sergipe;-100256;-375616;0;28;Sergipe;3183;79;America/Sao_Paulo
-2206605;Monte Alegre do PiauÌ;-975364;-453037;0;22;PiauÌ;1131;89;America/Sao_Paulo
-3531209;Monte Alegre do Sul;-226817;-46681;0;35;S„o Paulo;6725;19;America/Sao_Paulo
+2206605;Monte Alegre do Piau√≠;-975364;-453037;0;22;Piau√≠;1131;89;America/Sao_Paulo
+3531209;Monte Alegre do Sul;-226817;-46681;0;35;S√£o Paulo;6725;19;America/Sao_Paulo
 4312377;Monte Alegre dos Campos;-286805;-507834;0;43;Rio Grande do Sul;1000;54;America/Sao_Paulo
-3531308;Monte Alto;-212655;-484971;0;35;S„o Paulo;6727;16;America/Sao_Paulo
-3531407;Monte AprazÌvel;-20768;-497184;0;35;S„o Paulo;6729;17;America/Sao_Paulo
+3531308;Monte Alto;-212655;-484971;0;35;S√£o Paulo;6727;16;America/Sao_Paulo
+3531407;Monte Apraz√≠vel;-20768;-497184;0;35;S√£o Paulo;6729;17;America/Sao_Paulo
 3142908;Monte Azul;-151514;-428718;0;31;Minas Gerais;4857;38;America/Sao_Paulo
-3531506;Monte Azul Paulista;-209065;-486387;0;35;S„o Paulo;6731;17;America/Sao_Paulo
+3531506;Monte Azul Paulista;-209065;-486387;0;35;S√£o Paulo;6731;17;America/Sao_Paulo
 3143005;Monte Belo;-213271;-463635;0;31;Minas Gerais;4859;35;America/Sao_Paulo
 4312385;Monte Belo do Sul;-291607;-516333;0;43;Rio Grande do Sul;5993;54;America/Sao_Paulo
 4211058;Monte Carlo;-272239;-509808;0;42;Santa Catarina;5561;49;America/Sao_Paulo
 3143104;Monte Carmelo;-187302;-474912;0;31;Minas Gerais;4861;34;America/Sao_Paulo
 4211108;Monte Castelo;-26461;-502327;0;42;Santa Catarina;8217;47;America/Sao_Paulo
-3531605;Monte Castelo;-212981;-515679;0;35;S„o Paulo;6733;18;America/Sao_Paulo
+3531605;Monte Castelo;-212981;-515679;0;35;S√£o Paulo;6733;18;America/Sao_Paulo
 2407906;Monte das Gameleiras;-643698;-357831;0;24;Rio Grande do Norte;1757;84;America/Sao_Paulo
 1713601;Monte do Carmo;-107611;-481114;0;17;Tocantins;9469;63;America/Sao_Paulo
 3143153;Monte Formoso;-168691;-412473;0;31;Minas Gerais;654;33;America/Sao_Paulo
-2509602;Monte Horebe;-720402;-385838;0;25;ParaÌba;2093;83;America/Sao_Paulo
-3531803;Monte Mor;-22945;-473122;0;35;S„o Paulo;6737;19;America/Sao_Paulo
-1101401;Monte Negro;-102458;-6329;0;11;RondÙnia;685;69;America/Porto_Velho
+2509602;Monte Horebe;-720402;-385838;0;25;Para√≠ba;2093;83;America/Sao_Paulo
+3531803;Monte Mor;-22945;-473122;0;35;S√£o Paulo;6737;19;America/Sao_Paulo
+1101401;Monte Negro;-102458;-6329;0;11;Rond√¥nia;685;69;America/Porto_Velho
 2921500;Monte Santo;-104374;-393321;0;29;Bahia;3731;75;America/Sao_Paulo
 3143203;Monte Santo de Minas;-211873;-469753;0;31;Minas Gerais;4863;35;America/Sao_Paulo
 1713700;Monte Santo do Tocantins;-100075;-489941;0;17;Tocantins;90;63;America/Sao_Paulo
-3143401;Monte Si„o;-224335;-46573;0;31;Minas Gerais;4867;35;America/Sao_Paulo
-2509701;Monteiro;-788363;-371184;0;25;ParaÌba;2095;83;America/Sao_Paulo
-3531704;Monteiro Lobato;-229544;-458407;0;35;S„o Paulo;6735;12;America/Sao_Paulo
-2705408;MonteirÛpolis;-960357;-372505;0;27;Alagoas;2807;82;America/Sao_Paulo
+3143401;Monte Si√£o;-224335;-46573;0;31;Minas Gerais;4867;35;America/Sao_Paulo
+2509701;Monteiro;-788363;-371184;0;25;Para√≠ba;2095;83;America/Sao_Paulo
+3531704;Monteiro Lobato;-229544;-458407;0;35;S√£o Paulo;6735;12;America/Sao_Paulo
+2705408;Monteir√≥polis;-960357;-372505;0;27;Alagoas;2807;82;America/Sao_Paulo
 4312401;Montenegro;-296824;-514679;0;43;Rio Grande do Sul;8749;51;America/Sao_Paulo
-2107001;Montes Altos;-583067;-470673;0;21;Maranh„o;839;99;America/Sao_Paulo
+2107001;Montes Altos;-583067;-470673;0;21;Maranh√£o;839;99;America/Sao_Paulo
 3143302;Montes Claros;-167282;-438578;0;31;Minas Gerais;4865;38;America/Sao_Paulo
-5213707;Montes Claros de Goi·s;-160059;-513979;0;52;Goi·s;9471;62;America/Sao_Paulo
+5213707;Montes Claros de Goi√°s;-160059;-513979;0;52;Goi√°s;9471;62;America/Sao_Paulo
 3143450;Montezuma;-151702;-424941;0;31;Minas Gerais;2697;38;America/Sao_Paulo
-5213756;Montividiu;-174439;-511728;0;52;Goi·s;9933;64;America/Sao_Paulo
-5213772;Montividiu do Norte;-133485;-486853;0;52;Goi·s;79;62;America/Sao_Paulo
-2308708;Morada Nova;-509736;-383702;0;23;Cear·;1475;88;America/Sao_Paulo
+5213756;Montividiu;-174439;-511728;0;52;Goi√°s;9933;64;America/Sao_Paulo
+5213772;Montividiu do Norte;-133485;-486853;0;52;Goi√°s;79;62;America/Sao_Paulo
+2308708;Morada Nova;-509736;-383702;0;23;Cear√°;1475;88;America/Sao_Paulo
 3143500;Morada Nova de Minas;-185998;-453584;0;31;Minas Gerais;4869;37;America/Sao_Paulo
-2308807;Mora˙jo;-346311;-406776;0;23;Cear·;1477;88;America/Sao_Paulo
-2614303;Moreil‚ndia;-761931;-39546;0;26;Pernambuco;2585;87;America/Sao_Paulo
-4116109;Moreira Sales;-240509;-530102;0;41;Paran·;7707;44;America/Sao_Paulo
+2308807;Mora√∫jo;-346311;-406776;0;23;Cear√°;1477;88;America/Sao_Paulo
+2614303;Moreil√¢ndia;-761931;-39546;0;26;Pernambuco;2585;87;America/Sao_Paulo
+4116109;Moreira Sales;-240509;-530102;0;41;Paran√°;7707;44;America/Sao_Paulo
 2609402;Moreno;-810871;-350835;0;26;Pernambuco;2487;81;America/Sao_Paulo
-4312427;MormaÁo;-286968;-526999;0;43;Rio Grande do Sul;5933;54;America/Sao_Paulo
-2921609;Morpar·;-115569;-432766;0;29;Bahia;3733;77;America/Sao_Paulo
-4116208;Morretes;-254744;-488345;0;41;Paran·;7709;41;America/Sao_Paulo
-5213806;Morrinhos;-177334;-491059;0;52;Goi·s;9473;64;America/Sao_Paulo
-2308906;Morrinhos;-323426;-401233;0;23;Cear·;1479;88;America/Sao_Paulo
+4312427;Morma√ßo;-286968;-526999;0;43;Rio Grande do Sul;5933;54;America/Sao_Paulo
+2921609;Morpar√°;-115569;-432766;0;29;Bahia;3733;77;America/Sao_Paulo
+4116208;Morretes;-254744;-488345;0;41;Paran√°;7709;41;America/Sao_Paulo
+5213806;Morrinhos;-177334;-491059;0;52;Goi√°s;9473;64;America/Sao_Paulo
+2308906;Morrinhos;-323426;-401233;0;23;Cear√°;1479;88;America/Sao_Paulo
 4312443;Morrinhos do Sul;-293578;-499328;0;43;Rio Grande do Sul;5775;51;America/Sao_Paulo
-3531902;Morro Agudo;-207288;-480581;0;35;S„o Paulo;6739;16;America/Sao_Paulo
-5213855;Morro Agudo de Goi·s;-153184;-500553;0;52;Goi·s;9935;62;America/Sao_Paulo
-2206654;Morro CabeÁa no Tempo;-971891;-439072;0;22;PiauÌ;350;89;America/Sao_Paulo
-4211207;Morro da FumaÁa;-286511;-492169;0;42;Santa Catarina;8219;48;America/Sao_Paulo
-3143609;Morro da GarÁa;-185356;-44601;0;31;Minas Gerais;4871;38;America/Sao_Paulo
-2921708;Morro do ChapÈu;-115488;-411565;0;29;Bahia;3735;74;America/Sao_Paulo
-2206670;Morro do ChapÈu do PiauÌ;-373337;-423024;0;22;PiauÌ;352;86;America/Sao_Paulo
+3531902;Morro Agudo;-207288;-480581;0;35;S√£o Paulo;6739;16;America/Sao_Paulo
+5213855;Morro Agudo de Goi√°s;-153184;-500553;0;52;Goi√°s;9935;62;America/Sao_Paulo
+2206654;Morro Cabe√ßa no Tempo;-971891;-439072;0;22;Piau√≠;350;89;America/Sao_Paulo
+4211207;Morro da Fuma√ßa;-286511;-492169;0;42;Santa Catarina;8219;48;America/Sao_Paulo
+3143609;Morro da Gar√ßa;-185356;-44601;0;31;Minas Gerais;4871;38;America/Sao_Paulo
+2921708;Morro do Chap√©u;-115488;-411565;0;29;Bahia;3735;74;America/Sao_Paulo
+2206670;Morro do Chap√©u do Piau√≠;-373337;-423024;0;22;Piau√≠;352;86;America/Sao_Paulo
 3143708;Morro do Pilar;-192236;-433795;0;31;Minas Gerais;4873;31;America/Sao_Paulo
 4211256;Morro Grande;-288006;-497214;0;42;Santa Catarina;5539;48;America/Sao_Paulo
 4312450;Morro Redondo;-315887;-526261;0;43;Rio Grande do Sul;7385;53;America/Sao_Paulo
 4312476;Morro Reuter;-295379;-510811;0;43;Rio Grande do Sul;6019;51;America/Sao_Paulo
-2107100;Morros;-285379;-440357;0;21;Maranh„o;841;98;America/Sao_Paulo
+2107100;Morros;-285379;-440357;0;21;Maranh√£o;841;98;America/Sao_Paulo
 2921807;Mortugaba;-150225;-423727;0;29;Bahia;3737;77;America/Sao_Paulo
-3532009;Morungaba;-228811;-467896;0;35;S„o Paulo;6741;11;America/Sao_Paulo
-5213905;Moss‚medes;-16124;-502136;0;52;Goi·s;9475;64;America/Sao_Paulo
-2408003;MossorÛ;-518374;-373474;0;24;Rio Grande do Norte;1759;84;America/Sao_Paulo
+3532009;Morungaba;-228811;-467896;0;35;S√£o Paulo;6741;11;America/Sao_Paulo
+5213905;Moss√¢medes;-16124;-502136;0;52;Goi√°s;9475;64;America/Sao_Paulo
+2408003;Mossor√≥;-518374;-373474;0;24;Rio Grande do Norte;1759;84;America/Sao_Paulo
 4312500;Mostardas;-311054;-509167;0;43;Rio Grande do Sul;8751;51;America/Sao_Paulo
-3532058;Motuca;-215103;-481538;0;35;S„o Paulo;7263;16;America/Sao_Paulo
-5214002;Mozarl‚ndia;-147457;-505713;0;52;Goi·s;9477;62;America/Sao_Paulo
-1504901;Muan·;-153936;-492224;0;15;Par·;497;91;America/Sao_Paulo
-1400308;MucajaÌ;243998;-609096;0;14;Roraima;309;95;America/Porto_Velho
-2309003;Mucambo;-390271;-407452;0;23;Cear·;1481;88;America/Sao_Paulo
-2921906;MucugÍ;-130053;-413703;0;29;Bahia;3739;75;America/Sao_Paulo
-4312609;MuÁum;-29163;-518714;0;43;Rio Grande do Sul;8753;51;America/Sao_Paulo
+3532058;Motuca;-215103;-481538;0;35;S√£o Paulo;7263;16;America/Sao_Paulo
+5214002;Mozarl√¢ndia;-147457;-505713;0;52;Goi√°s;9477;62;America/Sao_Paulo
+1504901;Muan√°;-153936;-492224;0;15;Par√°;497;91;America/Sao_Paulo
+1400308;Mucaja√≠;243998;-609096;0;14;Roraima;309;95;America/Porto_Velho
+2309003;Mucambo;-390271;-407452;0;23;Cear√°;1481;88;America/Sao_Paulo
+2921906;Mucug√™;-130053;-413703;0;29;Bahia;3739;75;America/Sao_Paulo
+4312609;Mu√ßum;-29163;-518714;0;43;Rio Grande do Sul;8753;51;America/Sao_Paulo
 2922003;Mucuri;-180754;-395565;0;29;Bahia;3741;73;America/Sao_Paulo
-3203601;Mucurici;-180965;-4052;0;32;EspÌrito Santo;5671;27;America/Sao_Paulo
-4312617;Muitos Capıes;-283132;-511836;0;43;Rio Grande do Sul;1002;54;America/Sao_Paulo
+3203601;Mucurici;-180965;-4052;0;32;Esp√≠rito Santo;5671;27;America/Sao_Paulo
+4312617;Muitos Cap√µes;-283132;-511836;0;43;Rio Grande do Sul;1002;54;America/Sao_Paulo
 4312625;Muliterno;-283253;-517697;0;43;Rio Grande do Sul;5935;54;America/Sao_Paulo
-2509800;Mulungu;-702525;-3546;0;25;ParaÌba;2097;83;America/Sao_Paulo
-2309102;Mulungu;-430294;-389951;0;23;Cear·;1483;85;America/Sao_Paulo
+2509800;Mulungu;-702525;-3546;0;25;Para√≠ba;2097;83;America/Sao_Paulo
+2309102;Mulungu;-430294;-389951;0;23;Cear√°;1483;85;America/Sao_Paulo
 2922052;Mulungu do Morro;-119648;-416374;0;29;Bahia;3299;74;America/Sao_Paulo
 2922102;Mundo Novo;-118541;-404714;0;29;Bahia;3743;74;America/Sao_Paulo
 5005681;Mundo Novo;-239355;-54281;0;50;Mato Grosso do Sul;9179;67;America/Porto_Velho
-5214051;Mundo Novo;-137729;-502814;0;52;Goi·s;9651;62;America/Sao_Paulo
+5214051;Mundo Novo;-137729;-502814;0;52;Goi√°s;9651;62;America/Sao_Paulo
 3143807;Munhoz;-226092;-46362;0;31;Minas Gerais;4875;35;America/Sao_Paulo
-4116307;Munhoz de Melo;-231487;-517737;0;41;Paran·;7711;44;America/Sao_Paulo
+4116307;Munhoz de Melo;-231487;-517737;0;41;Paran√°;7711;44;America/Sao_Paulo
 2922201;Muniz Ferreira;-130092;-391092;0;29;Bahia;3745;75;America/Sao_Paulo
-3203700;Muniz Freire;-204652;-414156;0;32;EspÌrito Santo;5673;28;America/Sao_Paulo
-2922250;MuquÈm de S„o Francisco;-12065;-435497;0;29;Bahia;3005;77;America/Sao_Paulo
-3203809;Muqui;-209509;-41346;0;32;EspÌrito Santo;5675;28;America/Sao_Paulo
-3143906;MuriaÈ;-2113;-423693;0;31;Minas Gerais;4877;32;America/Sao_Paulo
+3203700;Muniz Freire;-204652;-414156;0;32;Esp√≠rito Santo;5673;28;America/Sao_Paulo
+2922250;Muqu√©m de S√£o Francisco;-12065;-435497;0;29;Bahia;3005;77;America/Sao_Paulo
+3203809;Muqui;-209509;-41346;0;32;Esp√≠rito Santo;5675;28;America/Sao_Paulo
+3143906;Muria√©;-2113;-423693;0;31;Minas Gerais;4877;32;America/Sao_Paulo
 2804300;Muribeca;-104271;-369588;0;28;Sergipe;3185;79;America/Sao_Paulo
 2705507;Murici;-930682;-359428;0;27;Alagoas;2809;82;America/Sao_Paulo
-2206696;Murici dos Portelas;-3319;-42094;0;22;PiauÌ;354;86;America/Sao_Paulo
-1713957;Muricil‚ndia;-714669;-486091;0;17;Tocantins;187;63;America/Sao_Paulo
+2206696;Murici dos Portelas;-3319;-42094;0;22;Piau√≠;354;86;America/Sao_Paulo
+1713957;Muricil√¢ndia;-714669;-486091;0;17;Tocantins;187;63;America/Sao_Paulo
 2922300;Muritiba;-126329;-389921;0;29;Bahia;3747;75;America/Sao_Paulo
-3532108;Murutinga do Sul;-209908;-512774;0;35;S„o Paulo;6743;18;America/Sao_Paulo
-2922409;MutuÌpe;-132284;-395044;0;29;Bahia;3749;75;America/Sao_Paulo
+3532108;Murutinga do Sul;-209908;-512774;0;35;S√£o Paulo;6743;18;America/Sao_Paulo
+2922409;Mutu√≠pe;-132284;-395044;0;29;Bahia;3749;75;America/Sao_Paulo
 3144003;Mutum;-198121;-414407;0;31;Minas Gerais;4879;33;America/Sao_Paulo
-5214101;MutunÛpolis;-137303;-492745;0;52;Goi·s;9479;62;America/Sao_Paulo
+5214101;Mutun√≥polis;-137303;-492745;0;52;Goi√°s;9479;62;America/Sao_Paulo
 3144102;Muzambinho;-213692;-465213;0;31;Minas Gerais;4881;35;America/Sao_Paulo
 3144201;Nacip Raydan;-184544;-422481;0;31;Minas Gerais;4883;33;America/Sao_Paulo
-3532157;Nantes;-226156;-5124;0;35;S„o Paulo;804;18;America/Sao_Paulo
+3532157;Nantes;-226156;-5124;0;35;S√£o Paulo;804;18;America/Sao_Paulo
 3144300;Nanuque;-178481;-403533;0;31;Minas Gerais;4885;33;America/Sao_Paulo
-4312658;N„o-Me-Toque;-284548;-528182;0;43;Rio Grande do Sul;8755;54;America/Sao_Paulo
+4312658;N√£o-Me-Toque;-284548;-528182;0;43;Rio Grande do Sul;8755;54;America/Sao_Paulo
 3144359;Naque;-192291;-423312;0;31;Minas Gerais;656;33;America/Sao_Paulo
-3532207;Narandiba;-224057;-515274;0;35;S„o Paulo;6745;18;America/Sao_Paulo
+3532207;Narandiba;-224057;-515274;0;35;S√£o Paulo;6745;18;America/Sao_Paulo
 2408102;Natal;-579357;-351986;1;24;Rio Grande do Norte;1761;84;America/Sao_Paulo
-3144375;Natal‚ndia;-165021;-464874;0;31;Minas Gerais;658;38;America/Sao_Paulo
-3144409;NatÈrcia;-221158;-455123;0;31;Minas Gerais;4887;35;America/Sao_Paulo
+3144375;Natal√¢ndia;-165021;-464874;0;31;Minas Gerais;658;38;America/Sao_Paulo
+3144409;Nat√©rcia;-221158;-455123;0;31;Minas Gerais;4887;35;America/Sao_Paulo
 1714203;Natividade;-117034;-477223;0;17;Tocantins;9481;63;America/Sao_Paulo
 3303104;Natividade;-21039;-419697;0;33;Rio de Janeiro;5861;22;America/Sao_Paulo
-3532306;Natividade da Serra;-233707;-454468;0;35;S„o Paulo;6747;12;America/Sao_Paulo
-2509909;Natuba;-763514;-355586;0;25;ParaÌba;2099;83;America/Sao_Paulo
+3532306;Natividade da Serra;-233707;-454468;0;35;S√£o Paulo;6747;12;America/Sao_Paulo
+2509909;Natuba;-763514;-355586;0;25;Para√≠ba;2099;83;America/Sao_Paulo
 4211306;Navegantes;-268943;-486546;0;42;Santa Catarina;8221;47;America/Sao_Paulo
-5005707;NaviraÌ;-230618;-541995;0;50;Mato Grosso do Sul;9113;67;America/Porto_Velho
-2922508;NazarÈ;-130235;-390108;0;29;Bahia;3751;75;America/Sao_Paulo
-1714302;NazarÈ;-637496;-476643;0;17;Tocantins;9483;63;America/Sao_Paulo
-2609501;NazarÈ da Mata;-774149;-352193;0;26;Pernambuco;2489;81;America/Sao_Paulo
-2206704;NazarÈ do PiauÌ;-697023;-426773;0;22;PiauÌ;1133;89;America/Sao_Paulo
-3532405;NazarÈ Paulista;-231747;-463983;0;35;S„o Paulo;6749;11;America/Sao_Paulo
+5005707;Navira√≠;-230618;-541995;0;50;Mato Grosso do Sul;9113;67;America/Porto_Velho
+2922508;Nazar√©;-130235;-390108;0;29;Bahia;3751;75;America/Sao_Paulo
+1714302;Nazar√©;-637496;-476643;0;17;Tocantins;9483;63;America/Sao_Paulo
+2609501;Nazar√© da Mata;-774149;-352193;0;26;Pernambuco;2489;81;America/Sao_Paulo
+2206704;Nazar√© do Piau√≠;-697023;-426773;0;22;Piau√≠;1133;89;America/Sao_Paulo
+3532405;Nazar√© Paulista;-231747;-463983;0;35;S√£o Paulo;6749;11;America/Sao_Paulo
 3144508;Nazareno;-212168;-446138;0;31;Minas Gerais;4889;35;America/Sao_Paulo
-2510006;Nazarezinho;-69114;-38322;0;25;ParaÌba;2101;83;America/Sao_Paulo
-2206720;Naz·ria;-535128;-428153;0;22;PiauÌ;1180;86;America/Sao_Paulo
-5214408;Naz·rio;-165808;-498817;0;52;Goi·s;9485;64;America/Sao_Paulo
-2804409;NeÛpolis;-103215;-36585;0;28;Sergipe;3187;79;America/Sao_Paulo
+2510006;Nazarezinho;-69114;-38322;0;25;Para√≠ba;2101;83;America/Sao_Paulo
+2206720;Naz√°ria;-535128;-428153;0;22;Piau√≠;1180;86;America/Sao_Paulo
+5214408;Naz√°rio;-165808;-498817;0;52;Goi√°s;9485;64;America/Sao_Paulo
+2804409;Ne√≥polis;-103215;-36585;0;28;Sergipe;3187;79;America/Sao_Paulo
 3144607;Nepomuceno;-212324;-45235;0;31;Minas Gerais;4891;35;America/Sao_Paulo
-5214507;NerÛpolis;-164047;-492227;0;52;Goi·s;9487;62;America/Sao_Paulo
-3532504;Neves Paulista;-20843;-496358;0;35;S„o Paulo;6751;17;America/Sao_Paulo
-1303007;Nhamund·;-220793;-567112;0;13;Amazonas;263;92;America/Porto_Velho
-3532603;Nhandeara;-206945;-500436;0;35;S„o Paulo;6753;17;America/Sao_Paulo
+5214507;Ner√≥polis;-164047;-492227;0;52;Goi√°s;9487;62;America/Sao_Paulo
+3532504;Neves Paulista;-20843;-496358;0;35;S√£o Paulo;6751;17;America/Sao_Paulo
+1303007;Nhamund√°;-220793;-567112;0;13;Amazonas;263;92;America/Porto_Velho
+3532603;Nhandeara;-206945;-500436;0;35;S√£o Paulo;6753;17;America/Sao_Paulo
 4312674;Nicolau Vergueiro;-285298;-524676;0;43;Rio Grande do Sul;5937;54;America/Sao_Paulo
-2922607;Nilo PeÁanha;-13604;-391091;0;29;Bahia;3753;73;America/Sao_Paulo
-3303203;NilÛpolis;-228057;-434233;0;33;Rio de Janeiro;5863;21;America/Sao_Paulo
-2107209;Nina Rodrigues;-346788;-439134;0;21;Maranh„o;843;98;America/Sao_Paulo
+2922607;Nilo Pe√ßanha;-13604;-391091;0;29;Bahia;3753;73;America/Sao_Paulo
+3303203;Nil√≥polis;-228057;-434233;0;33;Rio de Janeiro;5863;21;America/Sao_Paulo
+2107209;Nina Rodrigues;-346788;-439134;0;21;Maranh√£o;843;98;America/Sao_Paulo
 3144656;Ninheira;-153148;-417564;0;31;Minas Gerais;660;38;America/Sao_Paulo
 5005806;Nioaque;-211419;-558296;0;50;Mato Grosso do Sul;9115;67;America/Porto_Velho
-3532702;Nipo„;-209114;-497833;0;35;S„o Paulo;6755;17;America/Sao_Paulo
-5214606;Niquel‚ndia;-144662;-484599;0;52;Goi·s;9489;62;America/Sao_Paulo
-2408201;NÌsia Floresta;-609329;-351991;0;24;Rio Grande do Norte;1763;84;America/Sao_Paulo
-3303302;NiterÛi;-228832;-431034;0;33;Rio de Janeiro;5865;21;America/Sao_Paulo
+3532702;Nipo√£;-209114;-497833;0;35;S√£o Paulo;6755;17;America/Sao_Paulo
+5214606;Niquel√¢ndia;-144662;-484599;0;52;Goi√°s;9489;62;America/Sao_Paulo
+2408201;N√≠sia Floresta;-609329;-351991;0;24;Rio Grande do Norte;1763;84;America/Sao_Paulo
+3303302;Niter√≥i;-228832;-431034;0;33;Rio de Janeiro;5865;21;America/Sao_Paulo
 5105903;Nobres;-147192;-563284;0;51;Mato Grosso;9117;65;America/Porto_Velho
 4312708;Nonoai;-273689;-527756;0;43;Rio Grande do Sul;8757;54;America/Sao_Paulo
 2922656;Nordestina;-108192;-394297;0;29;Bahia;3979;75;America/Sao_Paulo
 1400407;Normandia;38853;-596204;0;14;Roraima;311;95;America/Porto_Velho
-5106000;Nortel‚ndia;-14454;-567945;0;51;Mato Grosso;9119;65;America/Porto_Velho
+5106000;Nortel√¢ndia;-14454;-567945;0;51;Mato Grosso;9119;65;America/Porto_Velho
 2804458;Nossa Senhora Aparecida;-103944;-374517;0;28;Sergipe;3135;79;America/Sao_Paulo
-2804508;Nossa Senhora da GlÛria;-102158;-374211;0;28;Sergipe;3189;79;America/Sao_Paulo
+2804508;Nossa Senhora da Gl√≥ria;-102158;-374211;0;28;Sergipe;3189;79;America/Sao_Paulo
 2804607;Nossa Senhora das Dores;-104854;-371963;0;28;Sergipe;3191;79;America/Sao_Paulo
-4116406;Nossa Senhora das GraÁas;-229129;-517978;0;41;Paran·;7713;44;America/Sao_Paulo
+4116406;Nossa Senhora das Gra√ßas;-229129;-517978;0;41;Paran√°;7713;44;America/Sao_Paulo
 2804706;Nossa Senhora de Lourdes;-100772;-370615;0;28;Sergipe;3193;79;America/Sao_Paulo
-2206753;Nossa Senhora de NazarÈ;-463019;-42173;0;22;PiauÌ;356;86;America/Sao_Paulo
+2206753;Nossa Senhora de Nazar√©;-463019;-42173;0;22;Piau√≠;356;86;America/Sao_Paulo
 5106109;Nossa Senhora do Livramento;-15772;-563432;0;51;Mato Grosso;9121;65;America/Porto_Velho
 2804805;Nossa Senhora do Socorro;-108468;-371231;0;28;Sergipe;3195;79;America/Sao_Paulo
-2206803;Nossa Senhora dos RemÈdios;-397574;-426184;0;22;PiauÌ;1135;86;America/Sao_Paulo
-3532801;Nova AlianÁa;-210156;-494986;0;35;S„o Paulo;6757;17;America/Sao_Paulo
-4116505;Nova AlianÁa do IvaÌ;-231763;-526032;0;41;Paran·;7715;44;America/Sao_Paulo
+2206803;Nossa Senhora dos Rem√©dios;-397574;-426184;0;22;Piau√≠;1135;86;America/Sao_Paulo
+3532801;Nova Alian√ßa;-210156;-494986;0;35;S√£o Paulo;6757;17;America/Sao_Paulo
+4116505;Nova Alian√ßa do Iva√≠;-231763;-526032;0;41;Paran√°;7715;44;America/Sao_Paulo
 4312757;Nova Alvorada;-286822;-521631;0;43;Rio Grande do Sul;7383;54;America/Sao_Paulo
 5006002;Nova Alvorada do Sul;-214657;-543825;0;50;Mato Grosso do Sul;143;67;America/Porto_Velho
-5214705;Nova AmÈrica;-150206;-498953;0;52;Goi·s;9491;62;America/Sao_Paulo
-4116604;Nova AmÈrica da Colina;-233308;-507168;0;41;Paran·;7717;43;America/Sao_Paulo
+5214705;Nova Am√©rica;-150206;-498953;0;52;Goi√°s;9491;62;America/Sao_Paulo
+4116604;Nova Am√©rica da Colina;-233308;-507168;0;41;Paran√°;7717;43;America/Sao_Paulo
 5006200;Nova Andradina;-22238;-533437;0;50;Mato Grosso do Sul;9123;67;America/Porto_Velho
-4312807;Nova AraÁ·;-286537;-517458;0;43;Rio Grande do Sul;8759;54;America/Sao_Paulo
-4116703;Nova Aurora;-245289;-532575;0;41;Paran·;7965;45;America/Sao_Paulo
-5214804;Nova Aurora;-180597;-482552;0;52;Goi·s;9493;64;America/Sao_Paulo
+4312807;Nova Ara√ß√°;-286537;-517458;0;43;Rio Grande do Sul;8759;54;America/Sao_Paulo
+4116703;Nova Aurora;-245289;-532575;0;41;Paran√°;7965;45;America/Sao_Paulo
+5214804;Nova Aurora;-180597;-482552;0;52;Goi√°s;9493;64;America/Sao_Paulo
 5106158;Nova Bandeirantes;-984977;-578139;0;51;Mato Grosso;117;66;America/Porto_Velho
 4312906;Nova Bassano;-287291;-517072;0;43;Rio Grande do Sul;8761;54;America/Sao_Paulo
-3144672;Nova BelÈm;-184925;-411107;0;31;Minas Gerais;662;33;America/Sao_Paulo
+3144672;Nova Bel√©m;-184925;-411107;0;31;Minas Gerais;662;33;America/Sao_Paulo
 4312955;Nova Boa Vista;-279926;-529784;0;43;Rio Grande do Sul;5953;54;America/Sao_Paulo
-5106208;Nova Brasil‚ndia;-149612;-549685;0;51;Mato Grosso;8981;66;America/Porto_Velho
-1100148;Nova Brasil‚ndia D'Oeste;-117247;-623127;0;11;RondÙnia;41;69;America/Porto_Velho
-4313003;Nova BrÈscia;-292182;-520319;0;43;Rio Grande do Sul;8763;51;America/Sao_Paulo
-3532827;Nova Campina;-241224;-489022;0;35;S„o Paulo;3061;15;America/Sao_Paulo
-2922706;Nova Cana„;-147912;-401458;0;29;Bahia;3755;73;America/Sao_Paulo
-5106216;Nova Cana„ do Norte;-10558;-55953;0;51;Mato Grosso;9889;66;America/Porto_Velho
-3532843;Nova Cana„ Paulista;-203836;-509483;0;35;S„o Paulo;2985;17;America/Sao_Paulo
-4313011;Nova Candel·ria;-276137;-541074;0;43;Rio Grande do Sul;1004;55;America/Sao_Paulo
-4116802;Nova Cantu;-246723;-525661;0;41;Paran·;7719;44;America/Sao_Paulo
-3532868;Nova Castilho;-207615;-503477;0;35;S„o Paulo;806;17;America/Sao_Paulo
-2107258;Nova Colinas;-712263;-462607;0;21;Maranh„o;200;99;America/Sao_Paulo
-5214838;Nova Crix·s;-140957;-5033;0;52;Goi·s;9653;62;America/Sao_Paulo
+5106208;Nova Brasil√¢ndia;-149612;-549685;0;51;Mato Grosso;8981;66;America/Porto_Velho
+1100148;Nova Brasil√¢ndia D'Oeste;-117247;-623127;0;11;Rond√¥nia;41;69;America/Porto_Velho
+4313003;Nova Br√©scia;-292182;-520319;0;43;Rio Grande do Sul;8763;51;America/Sao_Paulo
+3532827;Nova Campina;-241224;-489022;0;35;S√£o Paulo;3061;15;America/Sao_Paulo
+2922706;Nova Cana√£;-147912;-401458;0;29;Bahia;3755;73;America/Sao_Paulo
+5106216;Nova Cana√£ do Norte;-10558;-55953;0;51;Mato Grosso;9889;66;America/Porto_Velho
+3532843;Nova Cana√£ Paulista;-203836;-509483;0;35;S√£o Paulo;2985;17;America/Sao_Paulo
+4313011;Nova Candel√°ria;-276137;-541074;0;43;Rio Grande do Sul;1004;55;America/Sao_Paulo
+4116802;Nova Cantu;-246723;-525661;0;41;Paran√°;7719;44;America/Sao_Paulo
+3532868;Nova Castilho;-207615;-503477;0;35;S√£o Paulo;806;17;America/Sao_Paulo
+2107258;Nova Colinas;-712263;-462607;0;21;Maranh√£o;200;99;America/Sao_Paulo
+5214838;Nova Crix√°s;-140957;-5033;0;52;Goi√°s;9653;62;America/Sao_Paulo
 2408300;Nova Cruz;-647511;-354286;0;24;Rio Grande do Norte;1765;84;America/Sao_Paulo
 3144706;Nova Era;-197577;-430333;0;31;Minas Gerais;4893;31;America/Sao_Paulo
 4211405;Nova Erechim;-268982;-529066;0;42;Santa Catarina;8223;49;America/Sao_Paulo
-4116901;Nova EsperanÁa;-23182;-522031;0;41;Paran·;7721;44;America/Sao_Paulo
-1504950;Nova EsperanÁa do Piri·;-226693;-469731;0;15;Par·;391;91;America/Sao_Paulo
-4116950;Nova EsperanÁa do Sudoeste;-259004;-532618;0;41;Paran·;5477;46;America/Sao_Paulo
-4313037;Nova EsperanÁa do Sul;-294066;-548293;0;43;Rio Grande do Sul;7381;55;America/Sao_Paulo
-3532900;Nova Europa;-217765;-485705;0;35;S„o Paulo;6759;16;America/Sao_Paulo
-4117008;Nova F·tima;-234324;-505665;0;41;Paran·;7723;43;America/Sao_Paulo
-2922730;Nova F·tima;-116031;-396302;0;29;Bahia;3007;75;America/Sao_Paulo
-2510105;Nova Floresta;-645056;-362057;0;25;ParaÌba;2103;83;America/Sao_Paulo
+4116901;Nova Esperan√ßa;-23182;-522031;0;41;Paran√°;7721;44;America/Sao_Paulo
+1504950;Nova Esperan√ßa do Piri√°;-226693;-469731;0;15;Par√°;391;91;America/Sao_Paulo
+4116950;Nova Esperan√ßa do Sudoeste;-259004;-532618;0;41;Paran√°;5477;46;America/Sao_Paulo
+4313037;Nova Esperan√ßa do Sul;-294066;-548293;0;43;Rio Grande do Sul;7381;55;America/Sao_Paulo
+3532900;Nova Europa;-217765;-485705;0;35;S√£o Paulo;6759;16;America/Sao_Paulo
+4117008;Nova F√°tima;-234324;-505665;0;41;Paran√°;7723;43;America/Sao_Paulo
+2922730;Nova F√°tima;-116031;-396302;0;29;Bahia;3007;75;America/Sao_Paulo
+2510105;Nova Floresta;-645056;-362057;0;25;Para√≠ba;2103;83;America/Sao_Paulo
 3303401;Nova Friburgo;-222932;-425377;0;33;Rio de Janeiro;5867;22;America/Sao_Paulo
-5214861;Nova GlÛria;-15145;-495737;0;52;Goi·s;9655;62;America/Sao_Paulo
-3533007;Nova Granada;-205321;-493123;0;35;S„o Paulo;6761;17;America/Sao_Paulo
+5214861;Nova Gl√≥ria;-15145;-495737;0;52;Goi√°s;9655;62;America/Sao_Paulo
+3533007;Nova Granada;-205321;-493123;0;35;S√£o Paulo;6761;17;America/Sao_Paulo
 5108808;Nova Guarita;-10312;-554061;0;51;Mato Grosso;121;66;America/Porto_Velho
-3533106;Nova Guataporanga;-21332;-516447;0;35;S„o Paulo;6763;18;America/Sao_Paulo
+3533106;Nova Guataporanga;-21332;-516447;0;35;S√£o Paulo;6763;18;America/Sao_Paulo
 4313060;Nova Hartz;-295808;-509051;0;43;Rio Grande do Sul;7379;51;America/Sao_Paulo
-2922755;Nova Ibi·;-13812;-396182;0;29;Bahia;3009;73;America/Sao_Paulo
-3303500;Nova IguaÁu;-227556;-434603;0;33;Rio de Janeiro;5869;21;America/Sao_Paulo
-5214879;Nova IguaÁu de Goi·s;-142868;-493872;0;52;Goi·s;87;62;America/Sao_Paulo
-3533205;Nova IndependÍncia;-211026;-514905;0;35;S„o Paulo;6765;18;America/Sao_Paulo
-2107308;Nova Iorque;-673047;-440471;0;21;Maranh„o;845;99;America/Sao_Paulo
-1504976;Nova Ipixuna;-491622;-490822;0;15;Par·;56;94;America/Sao_Paulo
+2922755;Nova Ibi√°;-13812;-396182;0;29;Bahia;3009;73;America/Sao_Paulo
+3303500;Nova Igua√ßu;-227556;-434603;0;33;Rio de Janeiro;5869;21;America/Sao_Paulo
+5214879;Nova Igua√ßu de Goi√°s;-142868;-493872;0;52;Goi√°s;87;62;America/Sao_Paulo
+3533205;Nova Independ√™ncia;-211026;-514905;0;35;S√£o Paulo;6765;18;America/Sao_Paulo
+2107308;Nova Iorque;-673047;-440471;0;21;Maranh√£o;845;99;America/Sao_Paulo
+1504976;Nova Ipixuna;-491622;-490822;0;15;Par√°;56;94;America/Sao_Paulo
 4211454;Nova Itaberaba;-269428;-528141;0;42;Santa Catarina;5589;49;America/Sao_Paulo
 2922805;Nova Itarana;-130241;-400653;0;29;Bahia;3757;73;America/Sao_Paulo
 5106182;Nova Lacerda;-144727;-596001;0;51;Mato Grosso;1040;65;America/Porto_Velho
-4117057;Nova Laranjeiras;-253054;-525447;0;41;Paran·;5479;42;America/Sao_Paulo
+4117057;Nova Laranjeiras;-253054;-525447;0;41;Paran√°;5479;42;America/Sao_Paulo
 3144805;Nova Lima;-199758;-438509;0;31;Minas Gerais;4895;31;America/Sao_Paulo
-4117107;Nova Londrina;-227639;-529868;0;41;Paran·;7725;44;America/Sao_Paulo
-3533304;Nova Luzit‚nia;-20856;-502617;0;35;S„o Paulo;6767;17;America/Sao_Paulo
-1100338;Nova MamorÈ;-104077;-653346;0;11;RondÙnia;47;69;America/Porto_Velho
-5108857;Nova Maril‚ndia;-143568;-569696;0;51;Mato Grosso;103;65;America/Porto_Velho
-5108907;Nova Maring·;-130136;-570908;0;51;Mato Grosso;111;66;America/Porto_Velho
-3144904;Nova MÛdica;-184417;-414984;0;31;Minas Gerais;4897;33;America/Sao_Paulo
+4117107;Nova Londrina;-227639;-529868;0;41;Paran√°;7725;44;America/Sao_Paulo
+3533304;Nova Luzit√¢nia;-20856;-502617;0;35;S√£o Paulo;6767;17;America/Sao_Paulo
+1100338;Nova Mamor√©;-104077;-653346;0;11;Rond√¥nia;47;69;America/Porto_Velho
+5108857;Nova Maril√¢ndia;-143568;-569696;0;51;Mato Grosso;103;65;America/Porto_Velho
+5108907;Nova Maring√°;-130136;-570908;0;51;Mato Grosso;111;66;America/Porto_Velho
+3144904;Nova M√≥dica;-184417;-414984;0;31;Minas Gerais;4897;33;America/Sao_Paulo
 5108956;Nova Monte Verde;-999998;-575261;0;51;Mato Grosso;119;66;America/Porto_Velho
 5106224;Nova Mutum;-138374;-560743;0;51;Mato Grosso;9937;65;America/Porto_Velho
-5106174;Nova NazarÈ;-139486;-518002;0;51;Mato Grosso;1086;66;America/Porto_Velho
-3533403;Nova Odessa;-227832;-472941;0;35;S„o Paulo;6769;19;America/Sao_Paulo
-4117206;Nova OlÌmpia;-234703;-530898;0;41;Paran·;7967;44;America/Sao_Paulo
-5106232;Nova OlÌmpia;-147889;-572886;0;51;Mato Grosso;9893;65;America/Porto_Velho
+5106174;Nova Nazar√©;-139486;-518002;0;51;Mato Grosso;1086;66;America/Porto_Velho
+3533403;Nova Odessa;-227832;-472941;0;35;S√£o Paulo;6769;19;America/Sao_Paulo
+4117206;Nova Ol√≠mpia;-234703;-530898;0;41;Paran√°;7967;44;America/Sao_Paulo
+5106232;Nova Ol√≠mpia;-147889;-572886;0;51;Mato Grosso;9893;65;America/Porto_Velho
 1714880;Nova Olinda;-763171;-484252;0;17;Tocantins;9663;63;America/Sao_Paulo
-2309201;Nova Olinda;-708415;-396713;0;23;Cear·;1485;88;America/Sao_Paulo
-2510204;Nova Olinda;-747232;-380382;0;25;ParaÌba;2105;83;America/Sao_Paulo
-2107357;Nova Olinda do Maranh„o;-284227;-456953;0;21;Maranh„o;202;98;America/Sao_Paulo
+2309201;Nova Olinda;-708415;-396713;0;23;Cear√°;1485;88;America/Sao_Paulo
+2510204;Nova Olinda;-747232;-380382;0;25;Para√≠ba;2105;83;America/Sao_Paulo
+2107357;Nova Olinda do Maranh√£o;-284227;-456953;0;21;Maranh√£o;202;98;America/Sao_Paulo
 1303106;Nova Olinda do Norte;-390037;-59094;0;13;Amazonas;265;92;America/Porto_Velho
-4313086;Nova P·dua;-290275;-513098;0;43;Rio Grande do Sul;5991;54;America/Sao_Paulo
+4313086;Nova P√°dua;-290275;-513098;0;43;Rio Grande do Sul;5991;54;America/Sao_Paulo
 4313102;Nova Palma;-29471;-534689;0;43;Rio Grande do Sul;8765;55;America/Sao_Paulo
-2510303;Nova Palmeira;-667122;-36422;0;25;ParaÌba;2107;83;America/Sao_Paulo
-4313201;Nova PetrÛpolis;-293741;-511136;0;43;Rio Grande do Sul;8767;54;America/Sao_Paulo
+2510303;Nova Palmeira;-667122;-36422;0;25;Para√≠ba;2107;83;America/Sao_Paulo
+4313201;Nova Petr√≥polis;-293741;-511136;0;43;Rio Grande do Sul;8767;54;America/Sao_Paulo
 3145000;Nova Ponte;-191461;-476779;0;31;Minas Gerais;4899;34;America/Sao_Paulo
 3145059;Nova Porteirinha;-157993;-432941;0;31;Minas Gerais;664;38;America/Sao_Paulo
 4313300;Nova Prata;-287799;-516113;0;43;Rio Grande do Sul;8769;54;America/Sao_Paulo
-4117255;Nova Prata do IguaÁu;-256309;-533469;0;41;Paran·;7995;46;America/Sao_Paulo
+4117255;Nova Prata do Igua√ßu;-256309;-533469;0;41;Paran√°;7995;46;America/Sao_Paulo
 4313334;Nova Ramada;-280667;-536992;0;43;Rio Grande do Sul;1006;55;America/Sao_Paulo
-2922854;Nova RedenÁ„o;-12815;-410748;0;29;Bahia;3011;75;America/Sao_Paulo
+2922854;Nova Reden√ß√£o;-12815;-410748;0;29;Bahia;3011;75;America/Sao_Paulo
 3145109;Nova Resende;-211286;-464157;0;31;Minas Gerais;4901;35;America/Sao_Paulo
-5214903;Nova Roma;-137388;-468734;0;52;Goi·s;9495;62;America/Sao_Paulo
+5214903;Nova Roma;-137388;-468734;0;52;Goi√°s;9495;62;America/Sao_Paulo
 4313359;Nova Roma do Sul;-289882;-514095;0;43;Rio Grande do Sul;7377;54;America/Sao_Paulo
-1715002;Nova Rosal‚ndia;-105651;-489125;0;17;Tocantins;9721;63;America/Sao_Paulo
-2309300;Nova Russas;-470581;-405621;0;23;Cear·;1487;88;America/Sao_Paulo
-4117214;Nova Santa B·rbara;-235865;-507598;0;41;Paran·;5457;43;America/Sao_Paulo
+1715002;Nova Rosal√¢ndia;-105651;-489125;0;17;Tocantins;9721;63;America/Sao_Paulo
+2309300;Nova Russas;-470581;-405621;0;23;Cear√°;1487;88;America/Sao_Paulo
+4117214;Nova Santa B√°rbara;-235865;-507598;0;41;Paran√°;5457;43;America/Sao_Paulo
 5106190;Nova Santa Helena;-108651;-551872;0;51;Mato Grosso;1088;66;America/Porto_Velho
 4313375;Nova Santa Rita;-298525;-512837;0;43;Rio Grande do Sul;5757;51;America/Sao_Paulo
-2207959;Nova Santa Rita;-809707;-420471;0;22;PiauÌ;370;89;America/Sao_Paulo
-4117222;Nova Santa Rosa;-244693;-539552;0;41;Paran·;7979;45;America/Sao_Paulo
+2207959;Nova Santa Rita;-809707;-420471;0;22;Piau√≠;370;89;America/Sao_Paulo
+4117222;Nova Santa Rosa;-244693;-539552;0;41;Paran√°;7979;45;America/Sao_Paulo
 3145208;Nova Serrana;-198713;-449847;0;31;Minas Gerais;4903;37;America/Sao_Paulo
 2922904;Nova Soure;-112329;-384871;0;29;Bahia;3759;75;America/Sao_Paulo
-4117271;Nova Tebas;-24438;-519454;0;41;Paran·;9913;42;America/Sao_Paulo
-1505007;Nova Timboteua;-120874;-473921;0;15;Par·;499;91;America/Sao_Paulo
+4117271;Nova Tebas;-24438;-519454;0;41;Paran√°;9913;42;America/Sao_Paulo
+1505007;Nova Timboteua;-120874;-473921;0;15;Par√°;499;91;America/Sao_Paulo
 4211504;Nova Trento;-27278;-489298;0;42;Santa Catarina;8225;48;America/Sao_Paulo
-5106240;Nova Ubirat„;-129834;-552556;0;51;Mato Grosso;1042;66;America/Porto_Velho
-3136603;Nova Uni„o;-196876;-43583;0;31;Minas Gerais;4731;31;America/Sao_Paulo
-1101435;Nova Uni„o;-109068;-625564;0;11;RondÙnia;10;69;America/Porto_Velho
-3203908;Nova VenÈcia;-18715;-404053;0;32;EspÌrito Santo;5677;27;America/Sao_Paulo
+5106240;Nova Ubirat√£;-129834;-552556;0;51;Mato Grosso;1042;66;America/Porto_Velho
+3136603;Nova Uni√£o;-196876;-43583;0;31;Minas Gerais;4731;31;America/Sao_Paulo
+1101435;Nova Uni√£o;-109068;-625564;0;11;Rond√¥nia;10;69;America/Porto_Velho
+3203908;Nova Ven√©cia;-18715;-404053;0;32;Esp√≠rito Santo;5677;27;America/Sao_Paulo
 4211603;Nova Veneza;-286338;-495055;0;42;Santa Catarina;8227;48;America/Sao_Paulo
-5215009;Nova Veneza;-163695;-493168;0;52;Goi·s;9497;62;America/Sao_Paulo
-2923001;Nova ViÁosa;-178926;-393743;0;29;Bahia;3761;73;America/Sao_Paulo
+5215009;Nova Veneza;-163695;-493168;0;52;Goi√°s;9497;62;America/Sao_Paulo
+2923001;Nova Vi√ßosa;-178926;-393743;0;29;Bahia;3761;73;America/Sao_Paulo
 5106257;Nova Xavantina;-146771;-523502;0;51;Mato Grosso;9195;66;America/Porto_Velho
-3533254;Novais;-209893;-489141;0;35;S„o Paulo;2979;17;America/Sao_Paulo
+3533254;Novais;-209893;-489141;0;35;S√£o Paulo;2979;17;America/Sao_Paulo
 1715101;Novo Acordo;-997063;-476785;0;17;Tocantins;9499;63;America/Sao_Paulo
-1303205;Novo Air„o;-263637;-609434;0;13;Amazonas;201;92;America/Porto_Velho
+1303205;Novo Air√£o;-263637;-609434;0;13;Amazonas;201;92;America/Porto_Velho
 1715150;Novo Alegre;-129217;-465713;0;17;Tocantins;9703;63;America/Sao_Paulo
-1303304;Novo Aripuan„;-512593;-603732;0;13;Amazonas;267;97;America/Porto_Velho
+1303304;Novo Aripuan√£;-512593;-603732;0;13;Amazonas;267;97;America/Porto_Velho
 4313490;Novo Barreiro;-279077;-531103;0;43;Rio Grande do Sul;5985;55;America/Sao_Paulo
-5215207;Novo Brasil;-160313;-507113;0;52;Goi·s;9501;62;America/Sao_Paulo
+5215207;Novo Brasil;-160313;-507113;0;52;Goi√°s;9501;62;America/Sao_Paulo
 4313391;Novo Cabrais;-297338;-529489;0;43;Rio Grande do Sul;1008;51;America/Sao_Paulo
 3145307;Novo Cruzeiro;-174654;-418826;0;31;Minas Gerais;4905;33;America/Sao_Paulo
-5215231;Novo Gama;-160592;-480417;0;52;Goi·s;1058;61;America/Sao_Paulo
+5215231;Novo Gama;-160592;-480417;0;52;Goi√°s;1058;61;America/Sao_Paulo
 4313409;Novo Hamburgo;-296875;-511328;0;43;Rio Grande do Sul;8771;51;America/Sao_Paulo
 4211652;Novo Horizonte;-264442;-528281;0;42;Santa Catarina;5591;49;America/Sao_Paulo
-3533502;Novo Horizonte;-214651;-492234;0;35;S„o Paulo;6771;17;America/Sao_Paulo
+3533502;Novo Horizonte;-214651;-492234;0;35;S√£o Paulo;6771;17;America/Sao_Paulo
 2923035;Novo Horizonte;-128083;-421682;0;29;Bahia;3013;77;America/Sao_Paulo
 5106273;Novo Horizonte do Norte;-114089;-573488;0;51;Mato Grosso;9903;66;America/Porto_Velho
-1100502;Novo Horizonte do Oeste;-116961;-619951;0;11;RondÙnia;689;69;America/Porto_Velho
+1100502;Novo Horizonte do Oeste;-116961;-619951;0;11;Rond√¥nia;689;69;America/Porto_Velho
 5006259;Novo Horizonte do Sul;-226693;-538601;0;50;Mato Grosso do Sul;159;67;America/Porto_Velho
-4117297;Novo Itacolomi;-237631;-515079;0;41;Paran·;5517;43;America/Sao_Paulo
+4117297;Novo Itacolomi;-237631;-515079;0;41;Paran√°;5517;43;America/Sao_Paulo
 1715259;Novo Jardim;-11826;-466325;0;17;Tocantins;321;63;America/Sao_Paulo
 2705606;Novo Lino;-894191;-35664;0;27;Alagoas;2811;82;America/Sao_Paulo
 4313425;Novo Machado;-275765;-545036;0;43;Rio Grande do Sul;6057;55;America/Sao_Paulo
 5106265;Novo Mundo;-995616;-552029;0;51;Mato Grosso;1044;66;America/Porto_Velho
-2309409;Novo Oriente;-552552;-407713;0;23;Cear·;1489;88;America/Sao_Paulo
+2309409;Novo Oriente;-552552;-407713;0;23;Cear√°;1489;88;America/Sao_Paulo
 3145356;Novo Oriente de Minas;-174089;-412194;0;31;Minas Gerais;666;33;America/Sao_Paulo
-2206902;Novo Oriente do PiauÌ;-644901;-419261;0;22;PiauÌ;1137;89;America/Sao_Paulo
-5215256;Novo Planalto;-132424;-49506;0;52;Goi·s;9735;62;America/Sao_Paulo
-1505031;Novo Progresso;-714347;-553786;0;15;Par·;633;93;America/Sao_Paulo
-1505064;Novo Repartimento;-424749;-499499;0;15;Par·;629;94;America/Sao_Paulo
-2206951;Novo Santo AntÙnio;-528749;-419325;0;22;PiauÌ;358;86;America/Sao_Paulo
-5106315;Novo Santo AntÙnio;-122875;-509686;0;51;Mato Grosso;1090;66;America/Porto_Velho
-5106281;Novo S„o Joaquim;-149054;-530194;0;51;Mato Grosso;9867;66;America/Porto_Velho
+2206902;Novo Oriente do Piau√≠;-644901;-419261;0;22;Piau√≠;1137;89;America/Sao_Paulo
+5215256;Novo Planalto;-132424;-49506;0;52;Goi√°s;9735;62;America/Sao_Paulo
+1505031;Novo Progresso;-714347;-553786;0;15;Par√°;633;93;America/Sao_Paulo
+1505064;Novo Repartimento;-424749;-499499;0;15;Par√°;629;94;America/Sao_Paulo
+2206951;Novo Santo Ant√¥nio;-528749;-419325;0;22;Piau√≠;358;86;America/Sao_Paulo
+5106315;Novo Santo Ant√¥nio;-122875;-509686;0;51;Mato Grosso;1090;66;America/Porto_Velho
+5106281;Novo S√£o Joaquim;-149054;-530194;0;51;Mato Grosso;9867;66;America/Porto_Velho
 4313441;Novo Tiradentes;-275649;-531837;0;43;Rio Grande do Sul;5973;55;America/Sao_Paulo
 2923050;Novo Triunfo;-103182;-384014;0;29;Bahia;3015;75;America/Sao_Paulo
 4313466;Novo Xingu;-27749;-530639;0;43;Rio Grande do Sul;1152;54;America/Sao_Paulo
 3145372;Novorizonte;-160162;-424044;0;31;Minas Gerais;668;38;America/Sao_Paulo
-3533601;Nuporanga;-207296;-477429;0;35;S„o Paulo;6773;16;America/Sao_Paulo
-1505106;”bidos;-190107;-555208;0;15;Par·;501;93;America/Sao_Paulo
-2309458;Ocara;-448523;-385933;0;23;Cear·;1265;85;America/Sao_Paulo
-3533700;OcauÁu;-22438;-49922;0;35;S„o Paulo;6775;14;America/Sao_Paulo
-2207009;Oeiras;-701915;-421283;0;22;PiauÌ;1139;89;America/Sao_Paulo
-1505205;Oeiras do Par·;-200358;-498628;0;15;Par·;503;91;America/Sao_Paulo
-1600501;Oiapoque;384074;-518331;0;16;Amap·;609;96;America/Sao_Paulo
+3533601;Nuporanga;-207296;-477429;0;35;S√£o Paulo;6773;16;America/Sao_Paulo
+1505106;√ìbidos;-190107;-555208;0;15;Par√°;501;93;America/Sao_Paulo
+2309458;Ocara;-448523;-385933;0;23;Cear√°;1265;85;America/Sao_Paulo
+3533700;Ocau√ßu;-22438;-49922;0;35;S√£o Paulo;6775;14;America/Sao_Paulo
+2207009;Oeiras;-701915;-421283;0;22;Piau√≠;1139;89;America/Sao_Paulo
+1505205;Oeiras do Par√°;-200358;-498628;0;15;Par√°;503;91;America/Sao_Paulo
+1600501;Oiapoque;384074;-518331;0;16;Amap√°;609;96;America/Sao_Paulo
 3145406;Olaria;-218598;-439356;0;31;Minas Gerais;4907;32;America/Sao_Paulo
-3533809;”leo;-229435;-493419;0;35;S„o Paulo;6777;14;America/Sao_Paulo
-2510402;Olho d'¡gua;-722118;-377406;0;25;ParaÌba;2109;83;America/Sao_Paulo
-2107407;Olho d'¡gua das Cunh„s;-413417;-451163;0;21;Maranh„o;847;98;America/Sao_Paulo
-2705705;Olho d'¡gua das Flores;-953686;-372971;0;27;Alagoas;2813;82;America/Sao_Paulo
-2705804;Olho d'¡gua do Casado;-950357;-378301;0;27;Alagoas;2815;82;America/Sao_Paulo
-2207108;Olho D'¡gua do PiauÌ;-584125;-425594;0;22;PiauÌ;360;86;America/Sao_Paulo
-2705903;Olho d'¡gua Grande;-100572;-368101;0;27;Alagoas;2817;82;America/Sao_Paulo
-2408409;Olho-d'¡gua do Borges;-59486;-377047;0;24;Rio Grande do Norte;1767;84;America/Sao_Paulo
-3145455;Olhos d'¡gua;-173982;-435719;0;31;Minas Gerais;670;38;America/Sao_Paulo
-3533908;OlÌmpia;-207366;-489106;0;35;S„o Paulo;6779;17;America/Sao_Paulo
-3145505;OlÌmpio Noronha;-220685;-452657;0;31;Minas Gerais;4909;35;America/Sao_Paulo
+3533809;√ìleo;-229435;-493419;0;35;S√£o Paulo;6777;14;America/Sao_Paulo
+2510402;Olho d'√Ågua;-722118;-377406;0;25;Para√≠ba;2109;83;America/Sao_Paulo
+2107407;Olho d'√Ågua das Cunh√£s;-413417;-451163;0;21;Maranh√£o;847;98;America/Sao_Paulo
+2705705;Olho d'√Ågua das Flores;-953686;-372971;0;27;Alagoas;2813;82;America/Sao_Paulo
+2705804;Olho d'√Ågua do Casado;-950357;-378301;0;27;Alagoas;2815;82;America/Sao_Paulo
+2207108;Olho D'√Ågua do Piau√≠;-584125;-425594;0;22;Piau√≠;360;86;America/Sao_Paulo
+2705903;Olho d'√Ågua Grande;-100572;-368101;0;27;Alagoas;2817;82;America/Sao_Paulo
+2408409;Olho-d'√Ågua do Borges;-59486;-377047;0;24;Rio Grande do Norte;1767;84;America/Sao_Paulo
+3145455;Olhos d'√Ågua;-173982;-435719;0;31;Minas Gerais;670;38;America/Sao_Paulo
+3533908;Ol√≠mpia;-207366;-489106;0;35;S√£o Paulo;6779;17;America/Sao_Paulo
+3145505;Ol√≠mpio Noronha;-220685;-452657;0;31;Minas Gerais;4909;35;America/Sao_Paulo
 2609600;Olinda;-801017;-348545;0;26;Pernambuco;2491;81;America/Sao_Paulo
-2107456;Olinda Nova do Maranh„o;-299295;-449897;0;21;Maranh„o;204;98;America/Sao_Paulo
+2107456;Olinda Nova do Maranh√£o;-299295;-449897;0;21;Maranh√£o;204;98;America/Sao_Paulo
 2923100;Olindina;-113497;-383379;0;29;Bahia;3763;75;America/Sao_Paulo
-2510501;Olivedos;-698434;-36241;0;25;ParaÌba;2111;83;America/Sao_Paulo
+2510501;Olivedos;-698434;-36241;0;25;Para√≠ba;2111;83;America/Sao_Paulo
 3145604;Oliveira;-206982;-44829;0;31;Minas Gerais;4911;37;America/Sao_Paulo
-1715507;Oliveira de F·tima;-10707;-489086;0;17;Tocantins;92;63;America/Sao_Paulo
+1715507;Oliveira de F√°tima;-10707;-489086;0;17;Tocantins;92;63;America/Sao_Paulo
 2923209;Oliveira dos Brejinhos;-123132;-428969;0;29;Bahia;3765;77;America/Sao_Paulo
 3145703;Oliveira Fortes;-213401;-434499;0;31;Minas Gerais;4913;32;America/Sao_Paulo
-2706000;OlivenÁa;-951954;-371954;0;27;Alagoas;2819;82;America/Sao_Paulo
-3145802;OnÁa de Pitangui;-197276;-448058;0;31;Minas Gerais;4915;37;America/Sao_Paulo
-3534005;Onda Verde;-206042;-492929;0;35;S„o Paulo;6781;17;America/Sao_Paulo
-3145851;OratÛrios;-204298;-427977;0;31;Minas Gerais;672;31;America/Sao_Paulo
-3534104;Oriente;-221549;-500971;0;35;S„o Paulo;6783;14;America/Sao_Paulo
-3534203;Orindi˙va;-201861;-493464;0;35;S„o Paulo;6785;17;America/Sao_Paulo
-1505304;Oriximin·;-175989;-558579;0;15;Par·;505;93;America/Sao_Paulo
-3145877;Oriz‚nia;-205142;-421991;0;31;Minas Gerais;674;32;America/Sao_Paulo
-5215306;Orizona;-170334;-482964;0;52;Goi·s;9503;64;America/Sao_Paulo
-3534302;Orl‚ndia;-207169;-478852;0;35;S„o Paulo;6787;16;America/Sao_Paulo
+2706000;Oliven√ßa;-951954;-371954;0;27;Alagoas;2819;82;America/Sao_Paulo
+3145802;On√ßa de Pitangui;-197276;-448058;0;31;Minas Gerais;4915;37;America/Sao_Paulo
+3534005;Onda Verde;-206042;-492929;0;35;S√£o Paulo;6781;17;America/Sao_Paulo
+3145851;Orat√≥rios;-204298;-427977;0;31;Minas Gerais;672;31;America/Sao_Paulo
+3534104;Oriente;-221549;-500971;0;35;S√£o Paulo;6783;14;America/Sao_Paulo
+3534203;Orindi√∫va;-201861;-493464;0;35;S√£o Paulo;6785;17;America/Sao_Paulo
+1505304;Oriximin√°;-175989;-558579;0;15;Par√°;505;93;America/Sao_Paulo
+3145877;Oriz√¢nia;-205142;-421991;0;31;Minas Gerais;674;32;America/Sao_Paulo
+5215306;Orizona;-170334;-482964;0;52;Goi√°s;9503;64;America/Sao_Paulo
+3534302;Orl√¢ndia;-207169;-478852;0;35;S√£o Paulo;6787;16;America/Sao_Paulo
 4211702;Orleans;-283487;-492986;0;42;Santa Catarina;8229;48;America/Sao_Paulo
-2609709;OrobÛ;-774553;-355956;0;26;Pernambuco;2493;81;America/Sao_Paulo
-2609808;OrocÛ;-861026;-396026;0;26;Pernambuco;2495;87;America/Sao_Paulo
-2309508;OrÛs;-625182;-389053;0;23;Cear·;1491;88;America/Sao_Paulo
-4117305;Ortigueira;-242058;-509185;0;41;Paran·;7727;42;America/Sao_Paulo
-3534401;Osasco;-235324;-467916;0;35;S„o Paulo;6789;11;America/Sao_Paulo
-3534500;Oscar Bressane;-223149;-502811;0;35;S„o Paulo;6791;14;America/Sao_Paulo
-4313508;OsÛrio;-298881;-502667;0;43;Rio Grande do Sul;8773;51;America/Sao_Paulo
-3534609;Osvaldo Cruz;-217968;-508793;0;35;S„o Paulo;6793;18;America/Sao_Paulo
-4211751;OtacÌlio Costa;-274789;-501231;0;42;Santa Catarina;8397;49;America/Sao_Paulo
-1505403;OurÈm;-154168;-471126;0;15;Par·;507;91;America/Sao_Paulo
-2923308;OuriÁangas;-120175;-386166;0;29;Bahia;3767;75;America/Sao_Paulo
+2609709;Orob√≥;-774553;-355956;0;26;Pernambuco;2493;81;America/Sao_Paulo
+2609808;Oroc√≥;-861026;-396026;0;26;Pernambuco;2495;87;America/Sao_Paulo
+2309508;Or√≥s;-625182;-389053;0;23;Cear√°;1491;88;America/Sao_Paulo
+4117305;Ortigueira;-242058;-509185;0;41;Paran√°;7727;42;America/Sao_Paulo
+3534401;Osasco;-235324;-467916;0;35;S√£o Paulo;6789;11;America/Sao_Paulo
+3534500;Oscar Bressane;-223149;-502811;0;35;S√£o Paulo;6791;14;America/Sao_Paulo
+4313508;Os√≥rio;-298881;-502667;0;43;Rio Grande do Sul;8773;51;America/Sao_Paulo
+3534609;Osvaldo Cruz;-217968;-508793;0;35;S√£o Paulo;6793;18;America/Sao_Paulo
+4211751;Otac√≠lio Costa;-274789;-501231;0;42;Santa Catarina;8397;49;America/Sao_Paulo
+1505403;Our√©m;-154168;-471126;0;15;Par√°;507;91;America/Sao_Paulo
+2923308;Ouri√ßangas;-120175;-386166;0;29;Bahia;3767;75;America/Sao_Paulo
 2609907;Ouricuri;-787918;-4008;0;26;Pernambuco;2497;87;America/Sao_Paulo
-1505437;Ouril‚ndia do Norte;-67529;-510858;0;15;Par·;591;94;America/Sao_Paulo
-3534708;Ourinhos;-229797;-498697;0;35;S„o Paulo;6795;14;America/Sao_Paulo
-4117404;Ourizona;-234053;-521964;0;41;Paran·;7729;44;America/Sao_Paulo
+1505437;Ouril√¢ndia do Norte;-67529;-510858;0;15;Par√°;591;94;America/Sao_Paulo
+3534708;Ourinhos;-229797;-498697;0;35;S√£o Paulo;6795;14;America/Sao_Paulo
+4117404;Ourizona;-234053;-521964;0;41;Paran√°;7729;44;America/Sao_Paulo
 4211801;Ouro;-273379;-516194;0;42;Santa Catarina;8231;49;America/Sao_Paulo
 3145901;Ouro Branco;-205263;-436962;0;31;Minas Gerais;4917;31;America/Sao_Paulo
 2408508;Ouro Branco;-66958;-369428;0;24;Rio Grande do Norte;1769;84;America/Sao_Paulo
 2706109;Ouro Branco;-915884;-373556;0;27;Alagoas;2821;82;America/Sao_Paulo
 3146008;Ouro Fino;-222779;-463716;0;31;Minas Gerais;4919;35;America/Sao_Paulo
 3146107;Ouro Preto;-203796;-43512;0;31;Minas Gerais;4921;31;America/Sao_Paulo
-1100155;Ouro Preto do Oeste;-107167;-622565;0;11;RondÙnia;17;69;America/Porto_Velho
-2510600;Ouro Velho;-761604;-371519;0;25;ParaÌba;2113;83;America/Sao_Paulo
+1100155;Ouro Preto do Oeste;-107167;-622565;0;11;Rond√¥nia;17;69;America/Porto_Velho
+2510600;Ouro Velho;-761604;-371519;0;25;Para√≠ba;2113;83;America/Sao_Paulo
 4211850;Ouro Verde;-26692;-523108;0;42;Santa Catarina;5741;49;America/Sao_Paulo
-3534807;Ouro Verde;-214872;-517024;0;35;S„o Paulo;6797;18;America/Sao_Paulo
-5215405;Ouro Verde de Goi·s;-162181;-491942;0;52;Goi·s;9505;62;America/Sao_Paulo
+3534807;Ouro Verde;-214872;-517024;0;35;S√£o Paulo;6797;18;America/Sao_Paulo
+5215405;Ouro Verde de Goi√°s;-162181;-491942;0;52;Goi√°s;9505;62;America/Sao_Paulo
 3146206;Ouro Verde de Minas;-180719;-412734;0;31;Minas Gerais;4923;33;America/Sao_Paulo
-4117453;Ouro Verde do Oeste;-247933;-539043;0;41;Paran·;9965;45;America/Sao_Paulo
-3534757;Ouroeste;-200061;-503768;0;35;S„o Paulo;808;17;America/Sao_Paulo
-2923357;Ourol‚ndia;-109578;-410756;0;29;Bahia;3017;74;America/Sao_Paulo
-5215504;Ouvidor;-182277;-478355;0;52;Goi·s;9507;64;America/Sao_Paulo
-3534906;Pacaembu;-215627;-512654;0;35;S„o Paulo;6799;18;America/Sao_Paulo
-1505486;Pacaj·;-383542;-506399;0;15;Par·;593;91;America/Sao_Paulo
-2309607;Pacajus;-417107;-38465;0;23;Cear·;1493;85;America/Sao_Paulo
+4117453;Ouro Verde do Oeste;-247933;-539043;0;41;Paran√°;9965;45;America/Sao_Paulo
+3534757;Ouroeste;-200061;-503768;0;35;S√£o Paulo;808;17;America/Sao_Paulo
+2923357;Ourol√¢ndia;-109578;-410756;0;29;Bahia;3017;74;America/Sao_Paulo
+5215504;Ouvidor;-182277;-478355;0;52;Goi√°s;9507;64;America/Sao_Paulo
+3534906;Pacaembu;-215627;-512654;0;35;S√£o Paulo;6799;18;America/Sao_Paulo
+1505486;Pacaj√°;-383542;-506399;0;15;Par√°;593;91;America/Sao_Paulo
+2309607;Pacajus;-417107;-38465;0;23;Cear√°;1493;85;America/Sao_Paulo
 1400456;Pacaraima;44799;-611477;0;14;Roraima;34;95;America/Porto_Velho
-2309706;Pacatuba;-39784;-386183;0;23;Cear·;1495;85;America/Sao_Paulo
+2309706;Pacatuba;-39784;-386183;0;23;Cear√°;1495;85;America/Sao_Paulo
 2804904;Pacatuba;-104538;-366531;0;28;Sergipe;3197;79;America/Sao_Paulo
-2107506;PaÁo do Lumiar;-251657;-441019;0;21;Maranh„o;849;98;America/Sao_Paulo
-2309805;Pacoti;-422492;-38922;0;23;Cear·;1497;85;America/Sao_Paulo
-2309904;Pacuj·;-398327;-406989;0;23;Cear·;1499;88;America/Sao_Paulo
-5215603;Padre Bernardo;-151605;-482833;0;52;Goi·s;9509;61;America/Sao_Paulo
+2107506;Pa√ßo do Lumiar;-251657;-441019;0;21;Maranh√£o;849;98;America/Sao_Paulo
+2309805;Pacoti;-422492;-38922;0;23;Cear√°;1497;85;America/Sao_Paulo
+2309904;Pacuj√°;-398327;-406989;0;23;Cear√°;1499;88;America/Sao_Paulo
+5215603;Padre Bernardo;-151605;-482833;0;52;Goi√°s;9509;61;America/Sao_Paulo
 3146255;Padre Carvalho;-163646;-425088;0;31;Minas Gerais;676;38;America/Sao_Paulo
-2207207;Padre Marcos;-735101;-408997;0;22;PiauÌ;1143;89;America/Sao_Paulo
-3146305;Padre ParaÌso;-170758;-414821;0;31;Minas Gerais;4925;33;America/Sao_Paulo
-2207306;Paes Landim;-777375;-422474;0;22;PiauÌ;1145;89;America/Sao_Paulo
+2207207;Padre Marcos;-735101;-408997;0;22;Piau√≠;1143;89;America/Sao_Paulo
+3146305;Padre Para√≠so;-170758;-414821;0;31;Minas Gerais;4925;33;America/Sao_Paulo
+2207306;Paes Landim;-777375;-422474;0;22;Piau√≠;1145;89;America/Sao_Paulo
 3146552;Pai Pedro;-155271;-4307;0;31;Minas Gerais;678;38;America/Sao_Paulo
 4211876;Paial;-272541;-524975;0;42;Santa Catarina;928;49;America/Sao_Paulo
-4117503;PaiÁandu;-234555;-52046;0;41;Paran·;7731;44;America/Sao_Paulo
+4117503;Pai√ßandu;-234555;-52046;0;41;Paran√°;7731;44;America/Sao_Paulo
 4313607;Paim Filho;-277075;-51763;0;43;Rio Grande do Sul;8775;54;America/Sao_Paulo
 3146404;Paineiras;-188993;-455321;0;31;Minas Gerais;4927;37;America/Sao_Paulo
 4211892;Painel;-279234;-500972;0;42;Santa Catarina;930;49;America/Sao_Paulo
 3146503;Pains;-203705;-456627;0;31;Minas Gerais;4929;37;America/Sao_Paulo
 3146602;Paiva;-212913;-434088;0;31;Minas Gerais;4931;32;America/Sao_Paulo
-2207355;Paje˙ do PiauÌ;-785508;-428248;0;22;PiauÌ;362;89;America/Sao_Paulo
+2207355;Paje√∫ do Piau√≠;-785508;-428248;0;22;Piau√≠;362;89;America/Sao_Paulo
 2706208;Palestina;-967493;-37339;0;27;Alagoas;2823;82;America/Sao_Paulo
-3535002;Palestina;-2039;-494309;0;35;S„o Paulo;6801;17;America/Sao_Paulo
-5215652;Palestina de Goi·s;-167392;-515309;0;52;Goi·s;9737;64;America/Sao_Paulo
-1505494;Palestina do Par·;-574027;-483181;0;15;Par·;379;94;America/Sao_Paulo
-2310001;Palhano;-473672;-379655;0;23;Cear·;1501;88;America/Sao_Paulo
-4211900;PalhoÁa;-276455;-486697;0;42;Santa Catarina;8233;48;America/Sao_Paulo
+3535002;Palestina;-2039;-494309;0;35;S√£o Paulo;6801;17;America/Sao_Paulo
+5215652;Palestina de Goi√°s;-167392;-515309;0;52;Goi√°s;9737;64;America/Sao_Paulo
+1505494;Palestina do Par√°;-574027;-483181;0;15;Par√°;379;94;America/Sao_Paulo
+2310001;Palhano;-473672;-379655;0;23;Cear√°;1501;88;America/Sao_Paulo
+4211900;Palho√ßa;-276455;-486697;0;42;Santa Catarina;8233;48;America/Sao_Paulo
 3146701;Palma;-213748;-423123;0;31;Minas Gerais;4933;32;America/Sao_Paulo
 4212007;Palma Sola;-263471;-532771;0;42;Santa Catarina;8235;49;America/Sao_Paulo
-2310100;Palm·cia;-413831;-388446;0;23;Cear·;1503;85;America/Sao_Paulo
+2310100;Palm√°cia;-413831;-388446;0;23;Cear√°;1503;85;America/Sao_Paulo
 2610004;Palmares;-868423;-35589;0;26;Pernambuco;2499;81;America/Sao_Paulo
 4313656;Palmares do Sul;-302535;-505103;0;43;Rio Grande do Sul;8967;51;America/Sao_Paulo
-3535101;Palmares Paulista;-210854;-488037;0;35;S„o Paulo;6803;17;America/Sao_Paulo
-4117602;Palmas;-264839;-519888;0;41;Paran·;7733;46;America/Sao_Paulo
+3535101;Palmares Paulista;-210854;-488037;0;35;S√£o Paulo;6803;17;America/Sao_Paulo
+4117602;Palmas;-264839;-519888;0;41;Paran√°;7733;46;America/Sao_Paulo
 1721000;Palmas;-1024;-483558;1;17;Tocantins;9733;63;America/Sao_Paulo
 2923407;Palmas de Monte Alto;-142676;-431609;0;29;Bahia;3769;77;America/Sao_Paulo
-4117701;Palmeira;-254257;-50007;0;41;Paran·;7735;42;America/Sao_Paulo
+4117701;Palmeira;-254257;-50007;0;41;Paran√°;7735;42;America/Sao_Paulo
 4212056;Palmeira;-27583;-501577;0;42;Santa Catarina;932;49;America/Sao_Paulo
-3535200;Palmeira d'Oeste;-204148;-507632;0;35;S„o Paulo;6805;17;America/Sao_Paulo
-4313706;Palmeira das Missıes;-279007;-533134;0;43;Rio Grande do Sul;8777;55;America/Sao_Paulo
-2207405;Palmeira do PiauÌ;-873076;-442466;0;22;PiauÌ;1147;89;America/Sao_Paulo
-2706307;Palmeira dos Õndios;-940568;-366328;0;27;Alagoas;2825;82;America/Sao_Paulo
-2207504;Palmeirais;-597086;-43056;0;22;PiauÌ;1149;86;America/Sao_Paulo
-2107605;Palmeir‚ndia;-264433;-448933;0;21;Maranh„o;851;98;America/Sao_Paulo
+3535200;Palmeira d'Oeste;-204148;-507632;0;35;S√£o Paulo;6805;17;America/Sao_Paulo
+4313706;Palmeira das Miss√µes;-279007;-533134;0;43;Rio Grande do Sul;8777;55;America/Sao_Paulo
+2207405;Palmeira do Piau√≠;-873076;-442466;0;22;Piau√≠;1147;89;America/Sao_Paulo
+2706307;Palmeira dos √çndios;-940568;-366328;0;27;Alagoas;2825;82;America/Sao_Paulo
+2207504;Palmeirais;-597086;-43056;0;22;Piau√≠;1149;86;America/Sao_Paulo
+2107605;Palmeir√¢ndia;-264433;-448933;0;21;Maranh√£o;851;98;America/Sao_Paulo
 1715705;Palmeirante;-784786;-479242;0;17;Tocantins;189;63;America/Sao_Paulo
 2923506;Palmeiras;-125059;-415809;0;29;Bahia;3771;75;America/Sao_Paulo
-5215702;Palmeiras de Goi·s;-168044;-49924;0;52;Goi·s;9511;64;America/Sao_Paulo
+5215702;Palmeiras de Goi√°s;-168044;-49924;0;52;Goi√°s;9511;64;America/Sao_Paulo
 1713809;Palmeiras do Tocantins;-661658;-475464;0;17;Tocantins;185;63;America/Sao_Paulo
 2610103;Palmeirina;-90109;-363242;0;26;Pernambuco;2501;87;America/Sao_Paulo
-1715754;PalmeirÛpolis;-130447;-484026;0;17;Tocantins;9649;63;America/Sao_Paulo
-5215801;Palmelo;-173258;-48426;0;52;Goi·s;9513;64;America/Sao_Paulo
-5215900;PalminÛpolis;-167924;-501652;0;52;Goi·s;9515;64;America/Sao_Paulo
-3535309;Palmital;-227858;-50218;0;35;S„o Paulo;6807;18;America/Sao_Paulo
-4117800;Palmital;-248853;-522029;0;41;Paran·;7737;42;America/Sao_Paulo
+1715754;Palmeir√≥polis;-130447;-484026;0;17;Tocantins;9649;63;America/Sao_Paulo
+5215801;Palmelo;-173258;-48426;0;52;Goi√°s;9513;64;America/Sao_Paulo
+5215900;Palmin√≥polis;-167924;-501652;0;52;Goi√°s;9515;64;America/Sao_Paulo
+3535309;Palmital;-227858;-50218;0;35;S√£o Paulo;6807;18;America/Sao_Paulo
+4117800;Palmital;-248853;-522029;0;41;Paran√°;7737;42;America/Sao_Paulo
 4313805;Palmitinho;-273596;-53558;0;43;Rio Grande do Sul;8779;55;America/Sao_Paulo
 4212106;Palmitos;-270702;-531586;0;42;Santa Catarina;8237;49;America/Sao_Paulo
-3146750;PalmÛpolis;-167364;-404296;0;31;Minas Gerais;2661;33;America/Sao_Paulo
-4117909;Palotina;-242868;-538404;0;41;Paran·;7739;44;America/Sao_Paulo
-5216007;Panam·;-181783;-49355;0;52;Goi·s;9517;64;America/Sao_Paulo
+3146750;Palm√≥polis;-167364;-404296;0;31;Minas Gerais;2661;33;America/Sao_Paulo
+4117909;Palotina;-242868;-538404;0;41;Paran√°;7739;44;America/Sao_Paulo
+5216007;Panam√°;-181783;-49355;0;52;Goi√°s;9517;64;America/Sao_Paulo
 4313904;Panambi;-282833;-535023;0;43;Rio Grande do Sul;8781;55;America/Sao_Paulo
-3204005;Pancas;-192229;-408534;0;32;EspÌrito Santo;5679;27;America/Sao_Paulo
+3204005;Pancas;-192229;-408534;0;32;Esp√≠rito Santo;5679;27;America/Sao_Paulo
 2610202;Panelas;-866121;-360125;0;26;Pernambuco;2503;81;America/Sao_Paulo
-3535408;Panorama;-21354;-518562;0;35;S„o Paulo;6809;18;America/Sao_Paulo
+3535408;Panorama;-21354;-518562;0;35;S√£o Paulo;6809;18;America/Sao_Paulo
 4313953;Pantano Grande;-301902;-523729;0;43;Rio Grande do Sul;7375;51;America/Sao_Paulo
-2706406;P„o de AÁ˙car;-974032;-374403;0;27;Alagoas;2827;82;America/Sao_Paulo
+2706406;P√£o de A√ß√∫car;-974032;-374403;0;27;Alagoas;2827;82;America/Sao_Paulo
 3146909;Papagaios;-194419;-447468;0;31;Minas Gerais;4937;37;America/Sao_Paulo
 4212205;Papanduva;-263777;-501419;0;42;Santa Catarina;8239;47;America/Sao_Paulo
-2207553;Paquet·;-710303;-417;0;22;PiauÌ;364;89;America/Sao_Paulo
-3147105;Par· de Minas;-198534;-446114;0;31;Minas Gerais;4941;37;America/Sao_Paulo
+2207553;Paquet√°;-710303;-417;0;22;Piau√≠;364;89;America/Sao_Paulo
+3147105;Par√° de Minas;-198534;-446114;0;31;Minas Gerais;4941;37;America/Sao_Paulo
 3303609;Paracambi;-226078;-437108;0;33;Rio de Janeiro;5871;21;America/Sao_Paulo
 3147006;Paracatu;-172252;-468711;0;31;Minas Gerais;4939;38;America/Sao_Paulo
-2310209;Paracuru;-341436;-3903;0;23;Cear·;1505;85;America/Sao_Paulo
-1505502;Paragominas;-300212;-473527;0;15;Par·;509;91;America/Sao_Paulo
-3147204;ParaguaÁu;-215465;-457374;0;31;Minas Gerais;4943;35;America/Sao_Paulo
-3535507;ParaguaÁu Paulista;-224114;-505732;0;35;S„o Paulo;6811;18;America/Sao_Paulo
-4314001;ParaÌ;-285964;-517896;0;43;Rio Grande do Sul;8783;54;America/Sao_Paulo
-3303708;ParaÌba do Sul;-221585;-43304;0;33;Rio de Janeiro;5873;24;America/Sao_Paulo
-2107704;Paraibano;-64264;-439792;0;21;Maranh„o;853;99;America/Sao_Paulo
-3535606;Paraibuna;-233872;-456639;0;35;S„o Paulo;6813;12;America/Sao_Paulo
-2310258;Paraipaba;-343799;-391479;0;23;Cear·;1599;85;America/Sao_Paulo
-3535705;ParaÌso;-210159;-487761;0;35;S„o Paulo;6815;17;America/Sao_Paulo
-4212239;ParaÌso;-2662;-536716;0;42;Santa Catarina;5747;49;America/Sao_Paulo
-5006275;ParaÌso das ¡guas;-190216;-530116;0;50;Mato Grosso do Sul;1196;67;America/Porto_Velho
-4118006;ParaÌso do Norte;-232824;-526054;0;41;Paran·;7741;44;America/Sao_Paulo
-4314027;ParaÌso do Sul;-296717;-53144;0;43;Rio Grande do Sul;7373;55;America/Sao_Paulo
-1716109;ParaÌso do Tocantins;-10175;-488823;0;17;Tocantins;9519;63;America/Sao_Paulo
-3147303;ParaisÛpolis;-225539;-457803;0;31;Minas Gerais;4945;35;America/Sao_Paulo
-2310308;Parambu;-620768;-406905;0;23;Cear·;1507;88;America/Sao_Paulo
+2310209;Paracuru;-341436;-3903;0;23;Cear√°;1505;85;America/Sao_Paulo
+1505502;Paragominas;-300212;-473527;0;15;Par√°;509;91;America/Sao_Paulo
+3147204;Paragua√ßu;-215465;-457374;0;31;Minas Gerais;4943;35;America/Sao_Paulo
+3535507;Paragua√ßu Paulista;-224114;-505732;0;35;S√£o Paulo;6811;18;America/Sao_Paulo
+4314001;Para√≠;-285964;-517896;0;43;Rio Grande do Sul;8783;54;America/Sao_Paulo
+3303708;Para√≠ba do Sul;-221585;-43304;0;33;Rio de Janeiro;5873;24;America/Sao_Paulo
+2107704;Paraibano;-64264;-439792;0;21;Maranh√£o;853;99;America/Sao_Paulo
+3535606;Paraibuna;-233872;-456639;0;35;S√£o Paulo;6813;12;America/Sao_Paulo
+2310258;Paraipaba;-343799;-391479;0;23;Cear√°;1599;85;America/Sao_Paulo
+3535705;Para√≠so;-210159;-487761;0;35;S√£o Paulo;6815;17;America/Sao_Paulo
+4212239;Para√≠so;-2662;-536716;0;42;Santa Catarina;5747;49;America/Sao_Paulo
+5006275;Para√≠so das √Åguas;-190216;-530116;0;50;Mato Grosso do Sul;1196;67;America/Porto_Velho
+4118006;Para√≠so do Norte;-232824;-526054;0;41;Paran√°;7741;44;America/Sao_Paulo
+4314027;Para√≠so do Sul;-296717;-53144;0;43;Rio Grande do Sul;7373;55;America/Sao_Paulo
+1716109;Para√≠so do Tocantins;-10175;-488823;0;17;Tocantins;9519;63;America/Sao_Paulo
+3147303;Parais√≥polis;-225539;-457803;0;31;Minas Gerais;4945;35;America/Sao_Paulo
+2310308;Parambu;-620768;-406905;0;23;Cear√°;1507;88;America/Sao_Paulo
 2923605;Paramirim;-134388;-422395;0;29;Bahia;3773;77;America/Sao_Paulo
-2310407;Paramoti;-408815;-392417;0;23;Cear·;1509;85;America/Sao_Paulo
-1716208;Paran„;-126167;-478734;0;17;Tocantins;9521;63;America/Sao_Paulo
-2408607;Paran·;-647565;-383057;0;24;Rio Grande do Norte;1771;84;America/Sao_Paulo
-4118105;Paranacity;-229297;-521549;0;41;Paran·;7743;44;America/Sao_Paulo
-4118204;Paranagu·;-255161;-485225;0;41;Paran·;7745;41;America/Sao_Paulo
-5006309;ParanaÌba;-196746;-511909;0;50;Mato Grosso do Sul;9125;67;America/Porto_Velho
-5216304;Paranaiguara;-189141;-506539;0;52;Goi·s;9455;64;America/Sao_Paulo
-5106299;ParanaÌta;-965835;-564786;0;51;Mato Grosso;9885;66;America/Porto_Velho
-3535804;Paranapanema;-233862;-487214;0;35;S„o Paulo;6817;14;America/Sao_Paulo
-4118303;Paranapoema;-226412;-520905;0;41;Paran·;7747;44;America/Sao_Paulo
-3535903;Paranapu„;-201048;-505886;0;35;S„o Paulo;6819;17;America/Sao_Paulo
+2310407;Paramoti;-408815;-392417;0;23;Cear√°;1509;85;America/Sao_Paulo
+1716208;Paran√£;-126167;-478734;0;17;Tocantins;9521;63;America/Sao_Paulo
+2408607;Paran√°;-647565;-383057;0;24;Rio Grande do Norte;1771;84;America/Sao_Paulo
+4118105;Paranacity;-229297;-521549;0;41;Paran√°;7743;44;America/Sao_Paulo
+4118204;Paranagu√°;-255161;-485225;0;41;Paran√°;7745;41;America/Sao_Paulo
+5006309;Parana√≠ba;-196746;-511909;0;50;Mato Grosso do Sul;9125;67;America/Porto_Velho
+5216304;Paranaiguara;-189141;-506539;0;52;Goi√°s;9455;64;America/Sao_Paulo
+5106299;Parana√≠ta;-965835;-564786;0;51;Mato Grosso;9885;66;America/Porto_Velho
+3535804;Paranapanema;-233862;-487214;0;35;S√£o Paulo;6817;14;America/Sao_Paulo
+4118303;Paranapoema;-226412;-520905;0;41;Paran√°;7747;44;America/Sao_Paulo
+3535903;Paranapu√£;-201048;-505886;0;35;S√£o Paulo;6819;17;America/Sao_Paulo
 2610301;Paranatama;-891875;-366549;0;26;Pernambuco;2505;87;America/Sao_Paulo
 5106307;Paranatinga;-144265;-540524;0;51;Mato Grosso;8983;66;America/Porto_Velho
-4118402;ParanavaÌ;-230816;-524617;0;41;Paran·;7749;44;America/Sao_Paulo
+4118402;Paranava√≠;-230816;-524617;0;41;Paran√°;7749;44;America/Sao_Paulo
 5006358;Paranhos;-238911;-55429;0;50;Mato Grosso do Sul;9739;67;America/Porto_Velho
 3147402;Paraopeba;-192732;-444044;0;31;Minas Gerais;4947;31;America/Sao_Paulo
-3536000;Parapu„;-217792;-507949;0;35;S„o Paulo;6821;18;America/Sao_Paulo
-2510659;Parari;-730975;-366522;0;25;ParaÌba;494;83;America/Sao_Paulo
+3536000;Parapu√£;-217792;-507949;0;35;S√£o Paulo;6821;18;America/Sao_Paulo
+2510659;Parari;-730975;-366522;0;25;Para√≠ba;494;83;America/Sao_Paulo
 2923704;Paratinga;-12687;-431798;0;29;Bahia;3775;77;America/Sao_Paulo
 3303807;Paraty;-232221;-447175;0;33;Rio de Janeiro;5875;24;America/Sao_Paulo
-2408706;Para˙;-576893;-371032;0;24;Rio Grande do Norte;1773;84;America/Sao_Paulo
-1505536;Parauapebas;-606781;-499037;0;15;Par·;595;94;America/Sao_Paulo
-5216403;Para˙na;-169463;-504484;0;52;Goi·s;9523;64;America/Sao_Paulo
+2408706;Para√∫;-576893;-371032;0;24;Rio Grande do Norte;1773;84;America/Sao_Paulo
+1505536;Parauapebas;-606781;-499037;0;15;Par√°;595;94;America/Sao_Paulo
+5216403;Para√∫na;-169463;-504484;0;52;Goi√°s;9523;64;America/Sao_Paulo
 2408805;Parazinho;-522276;-358398;0;24;Rio Grande do Norte;1775;84;America/Sao_Paulo
-3536109;Pardinho;-230841;-483679;0;35;S„o Paulo;6823;14;America/Sao_Paulo
+3536109;Pardinho;-230841;-483679;0;35;S√£o Paulo;6823;14;America/Sao_Paulo
 4314035;Pareci Novo;-296365;-513974;0;43;Rio Grande do Sul;6041;51;America/Sao_Paulo
-1101450;Parecis;-121754;-616032;0;11;RondÙnia;12;69;America/Porto_Velho
+1101450;Parecis;-121754;-616032;0;11;Rond√¥nia;12;69;America/Porto_Velho
 2408904;Parelhas;-668491;-366566;0;24;Rio Grande do Norte;1777;84;America/Sao_Paulo
 2706422;Pariconha;-925634;-379988;0;27;Alagoas;2645;82;America/Sao_Paulo
 1303403;Parintins;-263741;-56729;0;13;Amazonas;269;92;America/Porto_Velho
 2923803;Paripiranga;-106859;-378626;0;29;Bahia;3777;75;America/Sao_Paulo
 2706448;Paripueira;-946313;-35552;0;27;Alagoas;2641;82;America/Sao_Paulo
-3536208;Pariquera-AÁu;-247147;-478742;0;35;S„o Paulo;6825;13;America/Sao_Paulo
-3536257;Parisi;-203034;-500163;0;35;S„o Paulo;2989;17;America/Sao_Paulo
-2207603;Parnagu·;-102166;-4463;0;22;PiauÌ;1151;89;America/Sao_Paulo
-2207702;ParnaÌba;-290585;-417754;0;22;PiauÌ;1153;86;America/Sao_Paulo
+3536208;Pariquera-A√ßu;-247147;-478742;0;35;S√£o Paulo;6825;13;America/Sao_Paulo
+3536257;Parisi;-203034;-500163;0;35;S√£o Paulo;2989;17;America/Sao_Paulo
+2207603;Parnagu√°;-102166;-4463;0;22;Piau√≠;1151;89;America/Sao_Paulo
+2207702;Parna√≠ba;-290585;-417754;0;22;Piau√≠;1153;86;America/Sao_Paulo
 2403251;Parnamirim;-591116;-35271;0;24;Rio Grande do Norte;1779;84;America/Sao_Paulo
 2610400;Parnamirim;-808729;-395795;0;26;Pernambuco;2507;87;America/Sao_Paulo
-2107803;Parnarama;-567365;-431011;0;21;Maranh„o;855;99;America/Sao_Paulo
-4314050;ParobÈ;-296243;-508312;0;43;Rio Grande do Sul;9825;51;America/Sao_Paulo
+2107803;Parnarama;-567365;-431011;0;21;Maranh√£o;855;99;America/Sao_Paulo
+4314050;Parob√©;-296243;-508312;0;43;Rio Grande do Sul;9825;51;America/Sao_Paulo
 2409100;Passa e Fica;-643018;-356442;0;24;Rio Grande do Norte;1781;84;America/Sao_Paulo
 3147600;Passa Quatro;-223871;-449709;0;31;Minas Gerais;4951;35;America/Sao_Paulo
 4314068;Passa Sete;-294577;-529599;0;43;Rio Grande do Sul;1010;51;America/Sao_Paulo
 3147709;Passa Tempo;-206539;-444926;0;31;Minas Gerais;4953;37;America/Sao_Paulo
 3147808;Passa-Vinte;-222097;-442344;0;31;Minas Gerais;4955;32;America/Sao_Paulo
-3147501;PassabÈm;-193509;-431383;0;31;Minas Gerais;4949;31;America/Sao_Paulo
+3147501;Passab√©m;-193509;-431383;0;31;Minas Gerais;4949;31;America/Sao_Paulo
 2409209;Passagem;-627268;-3537;0;24;Rio Grande do Norte;1783;84;America/Sao_Paulo
-2510709;Passagem;-713467;-370433;0;25;ParaÌba;2115;83;America/Sao_Paulo
-2107902;Passagem Franca;-617745;-437755;0;21;Maranh„o;857;99;America/Sao_Paulo
-2207751;Passagem Franca do PiauÌ;-586036;-424436;0;22;PiauÌ;1293;86;America/Sao_Paulo
+2510709;Passagem;-713467;-370433;0;25;Para√≠ba;2115;83;America/Sao_Paulo
+2107902;Passagem Franca;-617745;-437755;0;21;Maranh√£o;857;99;America/Sao_Paulo
+2207751;Passagem Franca do Piau√≠;-586036;-424436;0;22;Piau√≠;1293;86;America/Sao_Paulo
 2610509;Passira;-79971;-355813;0;26;Pernambuco;2509;81;America/Sao_Paulo
 2706505;Passo de Camaragibe;-924511;-354745;0;27;Alagoas;2829;82;America/Sao_Paulo
 4212254;Passo de Torres;-293099;-49722;0;42;Santa Catarina;5541;48;America/Sao_Paulo
@@ -3642,281 +3642,281 @@ codigo_ibge;municipio;latitude;longitude;capital;codigo_uf;estado;siafi_id;ddd;f
 4314100;Passo Fundo;-282576;-524091;0;43;Rio Grande do Sul;8785;54;America/Sao_Paulo
 3147907;Passos;-207193;-46609;0;31;Minas Gerais;4957;35;America/Sao_Paulo
 4212270;Passos Maia;-267829;-520568;0;42;Santa Catarina;5743;49;America/Sao_Paulo
-2108009;Pastos Bons;-660296;-440745;0;21;Maranh„o;859;99;America/Sao_Paulo
+2108009;Pastos Bons;-660296;-440745;0;21;Maranh√£o;859;99;America/Sao_Paulo
 3147956;Patis;-160773;-440787;0;31;Minas Gerais;680;38;America/Sao_Paulo
-4118451;Pato Bragado;-246271;-542265;0;41;Paran·;5533;45;America/Sao_Paulo
-4118501;Pato Branco;-262292;-526706;0;41;Paran·;7751;46;America/Sao_Paulo
-2510808;Patos;-701743;-372747;0;25;ParaÌba;2117;83;America/Sao_Paulo
+4118451;Pato Bragado;-246271;-542265;0;41;Paran√°;5533;45;America/Sao_Paulo
+4118501;Pato Branco;-262292;-526706;0;41;Paran√°;7751;46;America/Sao_Paulo
+2510808;Patos;-701743;-372747;0;25;Para√≠ba;2117;83;America/Sao_Paulo
 3148004;Patos de Minas;-185699;-465013;0;31;Minas Gerais;4959;34;America/Sao_Paulo
-2207777;Patos do PiauÌ;-767231;-412408;0;22;PiauÌ;2277;89;America/Sao_Paulo
-3148103;PatrocÌnio;-189379;-469934;0;31;Minas Gerais;4961;34;America/Sao_Paulo
-3148202;PatrocÌnio do MuriaÈ;-211544;-422125;0;31;Minas Gerais;4963;32;America/Sao_Paulo
-3536307;PatrocÌnio Paulista;-206384;-472801;0;35;S„o Paulo;6827;16;America/Sao_Paulo
+2207777;Patos do Piau√≠;-767231;-412408;0;22;Piau√≠;2277;89;America/Sao_Paulo
+3148103;Patroc√≠nio;-189379;-469934;0;31;Minas Gerais;4961;34;America/Sao_Paulo
+3148202;Patroc√≠nio do Muria√©;-211544;-422125;0;31;Minas Gerais;4963;32;America/Sao_Paulo
+3536307;Patroc√≠nio Paulista;-206384;-472801;0;35;S√£o Paulo;6827;16;America/Sao_Paulo
 2409308;Patu;-610656;-376356;0;24;Rio Grande do Norte;1785;84;America/Sao_Paulo
 3303856;Paty do Alferes;-224309;-434285;0;33;Rio de Janeiro;6005;24;America/Sao_Paulo
 2923902;Pau Brasil;-154572;-396458;0;29;Bahia;3779;73;America/Sao_Paulo
-1505551;Pau d'Arco;-159772;-469268;0;15;Par·;387;94;America/Sao_Paulo
+1505551;Pau d'Arco;-159772;-469268;0;15;Par√°;387;94;America/Sao_Paulo
 1716307;Pau D'Arco;-753919;-49367;0;17;Tocantins;191;63;America/Sao_Paulo
-2207793;Pau D'Arco do PiauÌ;-526072;-423908;0;22;PiauÌ;1104;86;America/Sao_Paulo
+2207793;Pau D'Arco do Piau√≠;-526072;-423908;0;22;Piau√≠;1104;86;America/Sao_Paulo
 2409407;Pau dos Ferros;-610498;-382077;0;24;Rio Grande do Norte;1787;84;America/Sao_Paulo
 2610608;Paudalho;-790287;-351716;0;26;Pernambuco;2511;81;America/Sao_Paulo
 1303502;Pauini;-771311;-66992;0;13;Amazonas;271;97;America/Rio_Branco
-3148301;Paula C‚ndido;-208754;-429752;0;31;Minas Gerais;4965;32;America/Sao_Paulo
-4118600;Paula Freitas;-262105;-50931;0;41;Paran·;7753;42;America/Sao_Paulo
-3536406;PaulicÈia;-213153;-518321;0;35;S„o Paulo;6829;18;America/Sao_Paulo
-3536505;PaulÌnia;-227542;-471488;0;35;S„o Paulo;6831;19;America/Sao_Paulo
-2108058;Paulino Neves;-272094;-425258;0;21;Maranh„o;206;98;America/Sao_Paulo
-2510907;Paulista;-659138;-376185;0;25;ParaÌba;2119;83;America/Sao_Paulo
+3148301;Paula C√¢ndido;-208754;-429752;0;31;Minas Gerais;4965;32;America/Sao_Paulo
+4118600;Paula Freitas;-262105;-50931;0;41;Paran√°;7753;42;America/Sao_Paulo
+3536406;Paulic√©ia;-213153;-518321;0;35;S√£o Paulo;6829;18;America/Sao_Paulo
+3536505;Paul√≠nia;-227542;-471488;0;35;S√£o Paulo;6831;19;America/Sao_Paulo
+2108058;Paulino Neves;-272094;-425258;0;21;Maranh√£o;206;98;America/Sao_Paulo
+2510907;Paulista;-659138;-376185;0;25;Para√≠ba;2119;83;America/Sao_Paulo
 2610707;Paulista;-793401;-348684;0;26;Pernambuco;2513;81;America/Sao_Paulo
-2207801;Paulistana;-813436;-411431;0;22;PiauÌ;1155;89;America/Sao_Paulo
-3536570;Paulist‚nia;-225768;-494008;0;35;S„o Paulo;810;14;America/Sao_Paulo
+2207801;Paulistana;-813436;-411431;0;22;Piau√≠;1155;89;America/Sao_Paulo
+3536570;Paulist√¢nia;-225768;-494008;0;35;S√£o Paulo;810;14;America/Sao_Paulo
 3148400;Paulistas;-184276;-428628;0;31;Minas Gerais;4967;33;America/Sao_Paulo
 2924009;Paulo Afonso;-93983;-382216;0;29;Bahia;3781;75;America/Sao_Paulo
 4314134;Paulo Bento;-277051;-524169;0;43;Rio Grande do Sul;1154;54;America/Sao_Paulo
-3536604;Paulo de Faria;-200296;-494;0;35;S„o Paulo;6833;17;America/Sao_Paulo
-4118709;Paulo Frontin;-260466;-508304;0;41;Paran·;7755;42;America/Sao_Paulo
+3536604;Paulo de Faria;-200296;-494;0;35;S√£o Paulo;6833;17;America/Sao_Paulo
+4118709;Paulo Frontin;-260466;-508304;0;41;Paran√°;7755;42;America/Sao_Paulo
 2706604;Paulo Jacinto;-936792;-363672;0;27;Alagoas;2831;82;America/Sao_Paulo
 4212304;Paulo Lopes;-279607;-486864;0;42;Santa Catarina;8241;48;America/Sao_Paulo
-2108108;Paulo Ramos;-444485;-452398;0;21;Maranh„o;959;98;America/Sao_Paulo
-3148509;Pav„o;-174267;-410035;0;31;Minas Gerais;4969;33;America/Sao_Paulo
+2108108;Paulo Ramos;-444485;-452398;0;21;Maranh√£o;959;98;America/Sao_Paulo
+3148509;Pav√£o;-174267;-410035;0;31;Minas Gerais;4969;33;America/Sao_Paulo
 4314159;Paverama;-295486;-517339;0;43;Rio Grande do Sul;7371;51;America/Sao_Paulo
-2207850;Pavussu;-796059;-432284;0;22;PiauÌ;366;89;America/Sao_Paulo
-2924058;PÈ de Serra;-118313;-39611;0;29;Bahia;3981;75;America/Sao_Paulo
-4118808;Peabiru;-23914;-523431;0;41;Paran·;7757;44;America/Sao_Paulo
-3148608;PeÁanha;-185441;-425583;0;31;Minas Gerais;4971;33;America/Sao_Paulo
-3536703;Pederneiras;-223511;-487781;0;35;S„o Paulo;6835;14;America/Sao_Paulo
+2207850;Pavussu;-796059;-432284;0;22;Piau√≠;366;89;America/Sao_Paulo
+2924058;P√© de Serra;-118313;-39611;0;29;Bahia;3981;75;America/Sao_Paulo
+4118808;Peabiru;-23914;-523431;0;41;Paran√°;7757;44;America/Sao_Paulo
+3148608;Pe√ßanha;-185441;-425583;0;31;Minas Gerais;4971;33;America/Sao_Paulo
+3536703;Pederneiras;-223511;-487781;0;35;S√£o Paulo;6835;14;America/Sao_Paulo
 2610806;Pedra;-849641;-3694;0;26;Pernambuco;2515;87;America/Sao_Paulo
 3148707;Pedra Azul;-160086;-412909;0;31;Minas Gerais;4973;33;America/Sao_Paulo
-3536802;Pedra Bela;-227902;-464455;0;35;S„o Paulo;6837;11;America/Sao_Paulo
+3536802;Pedra Bela;-227902;-464455;0;35;S√£o Paulo;6837;11;America/Sao_Paulo
 3148756;Pedra Bonita;-205219;-423304;0;31;Minas Gerais;682;31;America/Sao_Paulo
-2511004;Pedra Branca;-742169;-380689;0;25;ParaÌba;2121;83;America/Sao_Paulo
-2310506;Pedra Branca;-545341;-397078;0;23;Cear·;1511;88;America/Sao_Paulo
-1600154;Pedra Branca do Amapari;777424;-519503;0;16;Amap·;663;96;America/Sao_Paulo
+2511004;Pedra Branca;-742169;-380689;0;25;Para√≠ba;2121;83;America/Sao_Paulo
+2310506;Pedra Branca;-545341;-397078;0;23;Cear√°;1511;88;America/Sao_Paulo
+1600154;Pedra Branca do Amapari;777424;-519503;0;16;Amap√°;663;96;America/Sao_Paulo
 3148806;Pedra do Anta;-205968;-427123;0;31;Minas Gerais;4975;31;America/Sao_Paulo
-3148905;Pedra do Indai·;-202563;-452107;0;31;Minas Gerais;4977;37;America/Sao_Paulo
+3148905;Pedra do Indai√°;-202563;-452107;0;31;Minas Gerais;4977;37;America/Sao_Paulo
 3149002;Pedra Dourada;-208266;-421515;0;31;Minas Gerais;4979;32;America/Sao_Paulo
 2409506;Pedra Grande;-514988;-35876;0;24;Rio Grande do Norte;1789;84;America/Sao_Paulo
-2511103;Pedra Lavrada;-674997;-364758;0;25;ParaÌba;2123;83;America/Sao_Paulo
+2511103;Pedra Lavrada;-674997;-364758;0;25;Para√≠ba;2123;83;America/Sao_Paulo
 2805000;Pedra Mole;-106134;-376922;0;28;Sergipe;3199;79;America/Sao_Paulo
 2409605;Pedra Preta;-557352;-361084;0;24;Rio Grande do Norte;1791;84;America/Sao_Paulo
 5106372;Pedra Preta;-166245;-544722;0;51;Mato Grosso;9181;66;America/Porto_Velho
 3149101;Pedralva;-222386;-454654;0;31;Minas Gerais;4981;35;America/Sao_Paulo
-3536901;PedranÛpolis;-202474;-501129;0;35;S„o Paulo;6839;17;America/Sao_Paulo
-2924108;Pedr„o;-121491;-386487;0;29;Bahia;3783;75;America/Sao_Paulo
+3536901;Pedran√≥polis;-202474;-501129;0;35;S√£o Paulo;6839;17;America/Sao_Paulo
+2924108;Pedr√£o;-121491;-386487;0;29;Bahia;3783;75;America/Sao_Paulo
 4314175;Pedras Altas;-317365;-535814;0;43;Rio Grande do Sul;1156;53;America/Sao_Paulo
-2511202;Pedras de Fogo;-739107;-351065;0;25;ParaÌba;2125;83;America/Sao_Paulo
+2511202;Pedras de Fogo;-739107;-351065;0;25;Para√≠ba;2125;83;America/Sao_Paulo
 3149150;Pedras de Maria da Cruz;-156032;-44391;0;31;Minas Gerais;2899;38;America/Sao_Paulo
 4212403;Pedras Grandes;-284339;-491949;0;42;Santa Catarina;8243;48;America/Sao_Paulo
-3537008;Pedregulho;-202535;-474775;0;35;S„o Paulo;6841;16;America/Sao_Paulo
-3537107;Pedreira;-227413;-468948;0;35;S„o Paulo;6843;19;America/Sao_Paulo
-2108207;Pedreiras;-456482;-446006;0;21;Maranh„o;861;99;America/Sao_Paulo
+3537008;Pedregulho;-202535;-474775;0;35;S√£o Paulo;6841;16;America/Sao_Paulo
+3537107;Pedreira;-227413;-468948;0;35;S√£o Paulo;6843;19;America/Sao_Paulo
+2108207;Pedreiras;-456482;-446006;0;21;Maranh√£o;861;99;America/Sao_Paulo
 2805109;Pedrinhas;-111902;-376775;0;28;Sergipe;3201;79;America/Sao_Paulo
-3537156;Pedrinhas Paulista;-228174;-507933;0;35;S„o Paulo;2963;18;America/Sao_Paulo
-3149200;PedrinÛpolis;-192241;-474579;0;31;Minas Gerais;4983;34;America/Sao_Paulo
+3537156;Pedrinhas Paulista;-228174;-507933;0;35;S√£o Paulo;2963;18;America/Sao_Paulo
+3149200;Pedrin√≥polis;-192241;-474579;0;31;Minas Gerais;4983;34;America/Sao_Paulo
 1716505;Pedro Afonso;-897034;-481729;0;17;Tocantins;9525;63;America/Sao_Paulo
 2924207;Pedro Alexandre;-10012;-378932;0;29;Bahia;3785;75;America/Sao_Paulo
 2409704;Pedro Avelino;-55161;-363867;0;24;Rio Grande do Norte;1793;84;America/Sao_Paulo
-3204054;Pedro Can·rio;-183004;-399574;0;32;EspÌrito Santo;5715;27;America/Sao_Paulo
-3537206;Pedro de Toledo;-242764;-472354;0;35;S„o Paulo;6845;13;America/Sao_Paulo
-2108256;Pedro do Ros·rio;-297272;-453493;0;21;Maranh„o;208;98;America/Sao_Paulo
+3204054;Pedro Can√°rio;-183004;-399574;0;32;Esp√≠rito Santo;5715;27;America/Sao_Paulo
+3537206;Pedro de Toledo;-242764;-472354;0;35;S√£o Paulo;6845;13;America/Sao_Paulo
+2108256;Pedro do Ros√°rio;-297272;-453493;0;21;Maranh√£o;208;98;America/Sao_Paulo
 5006408;Pedro Gomes;-180996;-545507;0;50;Mato Grosso do Sul;9127;67;America/Porto_Velho
-2207900;Pedro II;-442585;-414482;0;22;PiauÌ;1157;86;America/Sao_Paulo
-2207934;Pedro Laurentino;-806807;-422847;0;22;PiauÌ;368;89;America/Sao_Paulo
+2207900;Pedro II;-442585;-414482;0;22;Piau√≠;1157;86;America/Sao_Paulo
+2207934;Pedro Laurentino;-806807;-422847;0;22;Piau√≠;368;89;America/Sao_Paulo
 3149309;Pedro Leopoldo;-196308;-440383;0;31;Minas Gerais;4985;31;America/Sao_Paulo
-4314209;Pedro OsÛrio;-318642;-528184;0;43;Rio Grande do Sul;8787;53;America/Sao_Paulo
-2512721;Pedro RÈgis;-663323;-352966;0;25;ParaÌba;500;83;America/Sao_Paulo
+4314209;Pedro Os√≥rio;-318642;-528184;0;43;Rio Grande do Sul;8787;53;America/Sao_Paulo
+2512721;Pedro R√©gis;-663323;-352966;0;25;Para√≠ba;500;83;America/Sao_Paulo
 3149408;Pedro Teixeira;-217076;-43743;0;31;Minas Gerais;4987;32;America/Sao_Paulo
 2409803;Pedro Velho;-64356;-352195;0;24;Rio Grande do Norte;1795;84;America/Sao_Paulo
 1716604;Peixe;-120254;-485395;0;17;Tocantins;9527;63;America/Sao_Paulo
-1505601;Peixe-Boi;-119382;-47324;0;15;Par·;511;91;America/Sao_Paulo
+1505601;Peixe-Boi;-119382;-47324;0;15;Par√°;511;91;America/Sao_Paulo
 5106422;Peixoto de Azevedo;-102262;-549794;0;51;Mato Grosso;9891;66;America/Porto_Velho
-4314308;PejuÁara;-284283;-536579;0;43;Rio Grande do Sul;8789;55;America/Sao_Paulo
+4314308;Peju√ßara;-284283;-536579;0;43;Rio Grande do Sul;8789;55;America/Sao_Paulo
 4314407;Pelotas;-317649;-523371;0;43;Rio Grande do Sul;8791;53;America/Sao_Paulo
-2310605;Penaforte;-782163;-390707;0;23;Cear·;1513;88;America/Sao_Paulo
-2108306;Penalva;-327674;-451768;0;21;Maranh„o;863;98;America/Sao_Paulo
-3537305;Pen·polis;-214148;-500769;0;35;S„o Paulo;6847;18;America/Sao_Paulo
-2409902;PendÍncias;-52564;-367095;0;24;Rio Grande do Norte;1797;84;America/Sao_Paulo
+2310605;Penaforte;-782163;-390707;0;23;Cear√°;1513;88;America/Sao_Paulo
+2108306;Penalva;-327674;-451768;0;21;Maranh√£o;863;98;America/Sao_Paulo
+3537305;Pen√°polis;-214148;-500769;0;35;S√£o Paulo;6847;18;America/Sao_Paulo
+2409902;Pend√™ncias;-52564;-367095;0;24;Rio Grande do Norte;1797;84;America/Sao_Paulo
 2706703;Penedo;-102874;-365819;0;27;Alagoas;2833;82;America/Sao_Paulo
 4212502;Penha;-267754;-486465;0;42;Santa Catarina;8245;47;America/Sao_Paulo
-2310704;Pentecoste;-379274;-392692;0;23;Cear·;1515;85;America/Sao_Paulo
+2310704;Pentecoste;-379274;-392692;0;23;Cear√°;1515;85;America/Sao_Paulo
 3149507;Pequeri;-218341;-431145;0;31;Minas Gerais;4989;32;America/Sao_Paulo
 3149606;Pequi;-196284;-446604;0;31;Minas Gerais;4991;37;America/Sao_Paulo
 1716653;Pequizeiro;-85932;-489327;0;17;Tocantins;9705;63;America/Sao_Paulo
-3149705;Perdig„o;-199411;-45078;0;31;Minas Gerais;4993;37;America/Sao_Paulo
+3149705;Perdig√£o;-199411;-45078;0;31;Minas Gerais;4993;37;America/Sao_Paulo
 3149804;Perdizes;-193434;-472963;0;31;Minas Gerais;4995;34;America/Sao_Paulo
-3149903;Perdıes;-210932;-450896;0;31;Minas Gerais;4997;35;America/Sao_Paulo
-3537404;Pereira Barreto;-206368;-511123;0;35;S„o Paulo;6849;18;America/Sao_Paulo
-3537503;Pereiras;-230804;-47972;0;35;S„o Paulo;6851;14;America/Sao_Paulo
-2310803;Pereiro;-603576;-384624;0;23;Cear·;1517;88;America/Sao_Paulo
-2108405;Peri Mirim;-257676;-448504;0;21;Maranh„o;865;98;America/Sao_Paulo
+3149903;Perd√µes;-210932;-450896;0;31;Minas Gerais;4997;35;America/Sao_Paulo
+3537404;Pereira Barreto;-206368;-511123;0;35;S√£o Paulo;6849;18;America/Sao_Paulo
+3537503;Pereiras;-230804;-47972;0;35;S√£o Paulo;6851;14;America/Sao_Paulo
+2310803;Pereiro;-603576;-384624;0;23;Cear√°;1517;88;America/Sao_Paulo
+2108405;Peri Mirim;-257676;-448504;0;21;Maranh√£o;865;98;America/Sao_Paulo
 3149952;Periquito;-191573;-422333;0;31;Minas Gerais;684;33;America/Sao_Paulo
 4212601;Peritiba;-273754;-519018;0;42;Santa Catarina;8247;49;America/Sao_Paulo
-2108454;PeritorÛ;-437459;-443369;0;21;Maranh„o;210;99;America/Sao_Paulo
-4118857;Perobal;-238949;-534098;0;41;Paran·;868;44;America/Sao_Paulo
-4118907;PÈrola;-238039;-536834;0;41;Paran·;7969;44;America/Sao_Paulo
-4119004;PÈrola d'Oeste;-258278;-537433;0;41;Paran·;7759;46;America/Sao_Paulo
-5216452;Perol‚ndia;-175258;-52065;0;52;Goi·s;75;64;America/Sao_Paulo
-3537602;PeruÌbe;-24312;-470012;0;35;S„o Paulo;6853;13;America/Sao_Paulo
+2108454;Peritor√≥;-437459;-443369;0;21;Maranh√£o;210;99;America/Sao_Paulo
+4118857;Perobal;-238949;-534098;0;41;Paran√°;868;44;America/Sao_Paulo
+4118907;P√©rola;-238039;-536834;0;41;Paran√°;7969;44;America/Sao_Paulo
+4119004;P√©rola d'Oeste;-258278;-537433;0;41;Paran√°;7759;46;America/Sao_Paulo
+5216452;Perol√¢ndia;-175258;-52065;0;52;Goi√°s;75;64;America/Sao_Paulo
+3537602;Peru√≠be;-24312;-470012;0;35;S√£o Paulo;6853;13;America/Sao_Paulo
 3150000;Pescador;-18357;-416006;0;31;Minas Gerais;4999;33;America/Sao_Paulo
 4212650;Pescaria Brava;-283966;-488864;0;42;Santa Catarina;1194;48;America/Sao_Paulo
 2610905;Pesqueira;-835797;-366978;0;26;Pernambuco;2517;87;America/Sao_Paulo
-2611002;Petrol‚ndia;-906863;-383027;0;26;Pernambuco;2519;87;America/Sao_Paulo
-4212700;Petrol‚ndia;-275346;-496937;0;42;Santa Catarina;8249;47;America/Sao_Paulo
+2611002;Petrol√¢ndia;-906863;-383027;0;26;Pernambuco;2519;87;America/Sao_Paulo
+4212700;Petrol√¢ndia;-275346;-496937;0;42;Santa Catarina;8249;47;America/Sao_Paulo
 2611101;Petrolina;-938866;-405027;0;26;Pernambuco;2521;87;America/Sao_Paulo
-5216809;Petrolina de Goi·s;-160968;-493364;0;52;Goi·s;9531;62;America/Sao_Paulo
-3303906;PetrÛpolis;-2252;-431926;0;33;Rio de Janeiro;5877;24;America/Sao_Paulo
-2706802;PiaÁabuÁu;-10406;-36434;0;27;Alagoas;2835;82;America/Sao_Paulo
-3537701;Piacatu;-215921;-506003;0;35;S„o Paulo;6855;18;America/Sao_Paulo
-2511301;PiancÛ;-719282;-379289;0;25;ParaÌba;2127;83;America/Sao_Paulo
-2924306;Piat„;-131465;-417702;0;29;Bahia;3787;77;America/Sao_Paulo
+5216809;Petrolina de Goi√°s;-160968;-493364;0;52;Goi√°s;9531;62;America/Sao_Paulo
+3303906;Petr√≥polis;-2252;-431926;0;33;Rio de Janeiro;5877;24;America/Sao_Paulo
+2706802;Pia√ßabu√ßu;-10406;-36434;0;27;Alagoas;2835;82;America/Sao_Paulo
+3537701;Piacatu;-215921;-506003;0;35;S√£o Paulo;6855;18;America/Sao_Paulo
+2511301;Pianc√≥;-719282;-379289;0;25;Para√≠ba;2127;83;America/Sao_Paulo
+2924306;Piat√£;-131465;-417702;0;29;Bahia;3787;77;America/Sao_Paulo
 3150109;Piau;-215096;-43313;0;31;Minas Gerais;5001;32;America/Sao_Paulo
-4314423;Picada CafÈ;-294464;-511367;0;43;Rio Grande do Sul;6021;54;America/Sao_Paulo
-1505635;PiÁarra;-643778;-488716;0;15;Par·;58;94;America/Sao_Paulo
-2208007;Picos;-707721;-41467;0;22;PiauÌ;1159;89;America/Sao_Paulo
-2511400;PicuÌ;-650845;-363497;0;25;ParaÌba;2129;83;America/Sao_Paulo
-3537800;Piedade;-237139;-474256;0;35;S„o Paulo;6857;15;America/Sao_Paulo
+4314423;Picada Caf√©;-294464;-511367;0;43;Rio Grande do Sul;6021;54;America/Sao_Paulo
+1505635;Pi√ßarra;-643778;-488716;0;15;Par√°;58;94;America/Sao_Paulo
+2208007;Picos;-707721;-41467;0;22;Piau√≠;1159;89;America/Sao_Paulo
+2511400;Picu√≠;-650845;-363497;0;25;Para√≠ba;2129;83;America/Sao_Paulo
+3537800;Piedade;-237139;-474256;0;35;S√£o Paulo;6857;15;America/Sao_Paulo
 3150158;Piedade de Caratinga;-197593;-420756;0;31;Minas Gerais;686;33;America/Sao_Paulo
 3150208;Piedade de Ponte Nova;-202438;-427379;0;31;Minas Gerais;5003;31;America/Sao_Paulo
 3150307;Piedade do Rio Grande;-21469;-441938;0;31;Minas Gerais;5005;32;America/Sao_Paulo
 3150406;Piedade dos Gerais;-204715;-442243;0;31;Minas Gerais;5007;31;America/Sao_Paulo
-4119103;PiÍn;-260965;-494336;0;41;Paran·;7761;41;America/Sao_Paulo
-2924405;Pil„o Arcado;-100051;-424936;0;29;Bahia;3789;74;America/Sao_Paulo
-2511509;Pilar;-726403;-352523;0;25;ParaÌba;2131;83;America/Sao_Paulo
+4119103;Pi√™n;-260965;-494336;0;41;Paran√°;7761;41;America/Sao_Paulo
+2924405;Pil√£o Arcado;-100051;-424936;0;29;Bahia;3789;74;America/Sao_Paulo
+2511509;Pilar;-726403;-352523;0;25;Para√≠ba;2131;83;America/Sao_Paulo
 2706901;Pilar;-960135;-359543;0;27;Alagoas;2837;82;America/Sao_Paulo
-5216908;Pilar de Goi·s;-147608;-495784;0;52;Goi·s;9535;62;America/Sao_Paulo
-3537909;Pilar do Sul;-238077;-477222;0;35;S„o Paulo;6859;15;America/Sao_Paulo
-2410009;Pilıes;-626364;-380461;0;24;Rio Grande do Norte;1799;84;America/Sao_Paulo
-2511608;Pilıes;-686827;-35613;0;25;ParaÌba;2133;83;America/Sao_Paulo
-2511707;Pilıezinhos;-684277;-35531;0;25;ParaÌba;2135;83;America/Sao_Paulo
+5216908;Pilar de Goi√°s;-147608;-495784;0;52;Goi√°s;9535;62;America/Sao_Paulo
+3537909;Pilar do Sul;-238077;-477222;0;35;S√£o Paulo;6859;15;America/Sao_Paulo
+2410009;Pil√µes;-626364;-380461;0;24;Rio Grande do Norte;1799;84;America/Sao_Paulo
+2511608;Pil√µes;-686827;-35613;0;25;Para√≠ba;2133;83;America/Sao_Paulo
+2511707;Pil√µezinhos;-684277;-35531;0;25;Para√≠ba;2135;83;America/Sao_Paulo
 3150505;Pimenta;-204827;-458049;0;31;Minas Gerais;5009;37;America/Sao_Paulo
-1100189;Pimenta Bueno;-11672;-61198;0;11;RondÙnia;11;69;America/Porto_Velho
-2208106;Pimenteiras;-623839;-414113;0;22;PiauÌ;1161;89;America/Sao_Paulo
-1101468;Pimenteiras do Oeste;-134823;-610471;0;11;RondÙnia;14;69;America/Porto_Velho
-2924504;PindaÌ;-144921;-42686;0;29;Bahia;3791;77;America/Sao_Paulo
-3538006;Pindamonhangaba;-229246;-454613;0;35;S„o Paulo;6861;12;America/Sao_Paulo
-2108504;PindarÈ-Mirim;-360985;-45342;0;21;Maranh„o;867;98;America/Sao_Paulo
+1100189;Pimenta Bueno;-11672;-61198;0;11;Rond√¥nia;11;69;America/Porto_Velho
+2208106;Pimenteiras;-623839;-414113;0;22;Piau√≠;1161;89;America/Sao_Paulo
+1101468;Pimenteiras do Oeste;-134823;-610471;0;11;Rond√¥nia;14;69;America/Porto_Velho
+2924504;Pinda√≠;-144921;-42686;0;29;Bahia;3791;77;America/Sao_Paulo
+3538006;Pindamonhangaba;-229246;-454613;0;35;S√£o Paulo;6861;12;America/Sao_Paulo
+2108504;Pindar√©-Mirim;-360985;-45342;0;21;Maranh√£o;867;98;America/Sao_Paulo
 2707008;Pindoba;-947382;-362918;0;27;Alagoas;2839;82;America/Sao_Paulo
-2924603;PindobaÁu;-107433;-403675;0;29;Bahia;3793;74;America/Sao_Paulo
-3538105;Pindorama;-211853;-489086;0;35;S„o Paulo;6863;17;America/Sao_Paulo
+2924603;Pindoba√ßu;-107433;-403675;0;29;Bahia;3793;74;America/Sao_Paulo
+3538105;Pindorama;-211853;-489086;0;35;S√£o Paulo;6863;17;America/Sao_Paulo
 1717008;Pindorama do Tocantins;-111311;-475726;0;17;Tocantins;9537;63;America/Sao_Paulo
-2310852;Pindoretama;-401584;-383061;0;23;Cear·;1267;85;America/Sao_Paulo
-3150539;Pingo-d'¡gua;-197287;-424095;0;31;Minas Gerais;688;33;America/Sao_Paulo
-4119152;Pinhais;-254429;-491927;0;41;Paran·;5453;41;America/Sao_Paulo
+2310852;Pindoretama;-401584;-383061;0;23;Cear√°;1267;85;America/Sao_Paulo
+3150539;Pingo-d'√Ågua;-197287;-424095;0;31;Minas Gerais;688;33;America/Sao_Paulo
+4119152;Pinhais;-254429;-491927;0;41;Paran√°;5453;41;America/Sao_Paulo
 4314456;Pinhal;-27508;-532082;0;43;Rio Grande do Sul;7369;55;America/Sao_Paulo
 4314464;Pinhal da Serra;-278751;-511673;0;43;Rio Grande do Sul;1158;54;America/Sao_Paulo
-4119251;Pinhal de S„o Bento;-260324;-53482;0;41;Paran·;5495;46;America/Sao_Paulo
+4119251;Pinhal de S√£o Bento;-260324;-53482;0;41;Paran√°;5495;46;America/Sao_Paulo
 4314472;Pinhal Grande;-29345;-533206;0;43;Rio Grande do Sul;5787;55;America/Sao_Paulo
-4119202;Pinhal„o;-237982;-500536;0;41;Paran·;7763;43;America/Sao_Paulo
-3538204;Pinhalzinho;-227811;-465897;0;35;S„o Paulo;6867;11;America/Sao_Paulo
+4119202;Pinhal√£o;-237982;-500536;0;41;Paran√°;7763;43;America/Sao_Paulo
+3538204;Pinhalzinho;-227811;-465897;0;35;S√£o Paulo;6867;11;America/Sao_Paulo
 4212908;Pinhalzinho;-268495;-529913;0;42;Santa Catarina;8253;49;America/Sao_Paulo
-2805208;Pinh„o;-105677;-377242;0;28;Sergipe;3203;79;America/Sao_Paulo
-4119301;Pinh„o;-256944;-516536;0;41;Paran·;7765;42;America/Sao_Paulo
+2805208;Pinh√£o;-105677;-377242;0;28;Sergipe;3203;79;America/Sao_Paulo
+4119301;Pinh√£o;-256944;-516536;0;41;Paran√°;7765;42;America/Sao_Paulo
 3303955;Pinheiral;-225172;-440022;0;33;Rio de Janeiro;778;24;America/Sao_Paulo
 4314498;Pinheirinho do Vale;-272109;-53608;0;43;Rio Grande do Sul;5975;55;America/Sao_Paulo
-2108603;Pinheiro;-252224;-450788;0;21;Maranh„o;869;98;America/Sao_Paulo
+2108603;Pinheiro;-252224;-450788;0;21;Maranh√£o;869;98;America/Sao_Paulo
 4314506;Pinheiro Machado;-315794;-533798;0;43;Rio Grande do Sul;8793;53;America/Sao_Paulo
 4213005;Pinheiro Preto;-270483;-512243;0;42;Santa Catarina;8255;49;America/Sao_Paulo
-3204104;Pinheiros;-184141;-402171;0;32;EspÌrito Santo;5681;27;America/Sao_Paulo
+3204104;Pinheiros;-184141;-402171;0;32;Esp√≠rito Santo;5681;27;America/Sao_Paulo
 2924652;Pintadas;-118117;-399009;0;29;Bahia;3983;75;America/Sao_Paulo
 4314548;Pinto Bandeira;-290975;-514503;0;43;Rio Grande do Sul;1160;54;America/Sao_Paulo
-3150570;PintÛpolis;-160572;-451402;0;31;Minas Gerais;690;38;America/Sao_Paulo
-2208205;Pio IX;-683002;-406083;0;22;PiauÌ;1163;89;America/Sao_Paulo
-2108702;Pio XII;-389315;-451759;0;21;Maranh„o;871;98;America/Sao_Paulo
-3538303;Piquerobi;-218747;-517282;0;35;S„o Paulo;6869;18;America/Sao_Paulo
-2310902;Piquet Carneiro;-580025;-39417;0;23;Cear·;1519;88;America/Sao_Paulo
-3538501;Piquete;-226069;-451869;0;35;S„o Paulo;6871;12;America/Sao_Paulo
-3538600;Piracaia;-230525;-463594;0;35;S„o Paulo;6873;11;America/Sao_Paulo
-5217104;Piracanjuba;-17302;-49017;0;52;Goi·s;9539;64;America/Sao_Paulo
+3150570;Pint√≥polis;-160572;-451402;0;31;Minas Gerais;690;38;America/Sao_Paulo
+2208205;Pio IX;-683002;-406083;0;22;Piau√≠;1163;89;America/Sao_Paulo
+2108702;Pio XII;-389315;-451759;0;21;Maranh√£o;871;98;America/Sao_Paulo
+3538303;Piquerobi;-218747;-517282;0;35;S√£o Paulo;6869;18;America/Sao_Paulo
+2310902;Piquet Carneiro;-580025;-39417;0;23;Cear√°;1519;88;America/Sao_Paulo
+3538501;Piquete;-226069;-451869;0;35;S√£o Paulo;6871;12;America/Sao_Paulo
+3538600;Piracaia;-230525;-463594;0;35;S√£o Paulo;6873;11;America/Sao_Paulo
+5217104;Piracanjuba;-17302;-49017;0;52;Goi√°s;9539;64;America/Sao_Paulo
 3150604;Piracema;-205089;-444783;0;31;Minas Gerais;5011;37;America/Sao_Paulo
-3538709;Piracicaba;-227338;-476476;0;35;S„o Paulo;6875;19;America/Sao_Paulo
-2208304;Piracuruca;-393335;-417088;0;22;PiauÌ;1165;86;America/Sao_Paulo
-3304003;PiraÌ;-226215;-439081;0;33;Rio de Janeiro;5879;24;America/Sao_Paulo
-2924678;PiraÌ do Norte;-13759;-393836;0;29;Bahia;3019;73;America/Sao_Paulo
-4119400;PiraÌ do Sul;-245306;-499433;0;41;Paran·;7767;42;America/Sao_Paulo
-3538808;Piraju;-231981;-493803;0;35;S„o Paulo;6877;14;America/Sao_Paulo
+3538709;Piracicaba;-227338;-476476;0;35;S√£o Paulo;6875;19;America/Sao_Paulo
+2208304;Piracuruca;-393335;-417088;0;22;Piau√≠;1165;86;America/Sao_Paulo
+3304003;Pira√≠;-226215;-439081;0;33;Rio de Janeiro;5879;24;America/Sao_Paulo
+2924678;Pira√≠ do Norte;-13759;-393836;0;29;Bahia;3019;73;America/Sao_Paulo
+4119400;Pira√≠ do Sul;-245306;-499433;0;41;Paran√°;7767;42;America/Sao_Paulo
+3538808;Piraju;-231981;-493803;0;35;S√£o Paulo;6877;14;America/Sao_Paulo
 3150703;Pirajuba;-199092;-487027;0;31;Minas Gerais;5013;34;America/Sao_Paulo
-3538907;PirajuÌ;-21999;-494608;0;35;S„o Paulo;6879;14;America/Sao_Paulo
+3538907;Piraju√≠;-21999;-494608;0;35;S√£o Paulo;6879;14;America/Sao_Paulo
 2805307;Pirambu;-107215;-368544;0;28;Sergipe;3205;79;America/Sao_Paulo
 3150802;Piranga;-206834;-432967;0;31;Minas Gerais;5015;31;America/Sao_Paulo
-3539004;Pirangi;-210886;-486607;0;35;S„o Paulo;6881;17;America/Sao_Paulo
-3150901;PiranguÁu;-225249;-454945;0;31;Minas Gerais;5017;35;America/Sao_Paulo
+3539004;Pirangi;-210886;-486607;0;35;S√£o Paulo;6881;17;America/Sao_Paulo
+3150901;Pirangu√ßu;-225249;-454945;0;31;Minas Gerais;5017;35;America/Sao_Paulo
 3151008;Piranguinho;-22395;-455324;0;31;Minas Gerais;5019;35;America/Sao_Paulo
 2707107;Piranhas;-9624;-37757;0;27;Alagoas;2841;82;America/Sao_Paulo
-5217203;Piranhas;-164258;-518235;0;52;Goi·s;9541;64;America/Sao_Paulo
-2108801;Pirapemas;-372041;-442216;0;21;Maranh„o;873;98;America/Sao_Paulo
+5217203;Piranhas;-164258;-518235;0;52;Goi√°s;9541;64;America/Sao_Paulo
+2108801;Pirapemas;-372041;-442216;0;21;Maranh√£o;873;98;America/Sao_Paulo
 3151107;Pirapetinga;-216554;-423434;0;31;Minas Gerais;5021;32;America/Sao_Paulo
-4314555;PirapÛ;-280439;-552001;0;43;Rio Grande do Sul;7367;55;America/Sao_Paulo
+4314555;Pirap√≥;-280439;-552001;0;43;Rio Grande do Sul;7367;55;America/Sao_Paulo
 3151206;Pirapora;-173392;-44934;0;31;Minas Gerais;5023;38;America/Sao_Paulo
-3539103;Pirapora do Bom Jesus;-233965;-469991;0;35;S„o Paulo;6883;11;America/Sao_Paulo
-3539202;Pirapozinho;-222711;-514976;0;35;S„o Paulo;6885;18;America/Sao_Paulo
-4119509;Piraquara;-254422;-490624;0;41;Paran·;7769;41;America/Sao_Paulo
-1717206;PiraquÍ;-677302;-482958;0;17;Tocantins;355;63;America/Sao_Paulo
-3539301;Pirassununga;-21996;-474257;0;35;S„o Paulo;6887;19;America/Sao_Paulo
+3539103;Pirapora do Bom Jesus;-233965;-469991;0;35;S√£o Paulo;6883;11;America/Sao_Paulo
+3539202;Pirapozinho;-222711;-514976;0;35;S√£o Paulo;6885;18;America/Sao_Paulo
+4119509;Piraquara;-254422;-490624;0;41;Paran√°;7769;41;America/Sao_Paulo
+1717206;Piraqu√™;-677302;-482958;0;17;Tocantins;355;63;America/Sao_Paulo
+3539301;Pirassununga;-21996;-474257;0;35;S√£o Paulo;6887;19;America/Sao_Paulo
 4314605;Piratini;-314473;-530973;0;43;Rio Grande do Sul;8795;53;America/Sao_Paulo
-3539400;Piratininga;-224142;-491339;0;35;S„o Paulo;6889;14;America/Sao_Paulo
+3539400;Piratininga;-224142;-491339;0;35;S√£o Paulo;6889;14;America/Sao_Paulo
 4213104;Piratuba;-274242;-517668;0;42;Santa Catarina;8257;49;America/Sao_Paulo
-3151305;Pira˙ba;-212825;-430172;0;31;Minas Gerais;5025;32;America/Sao_Paulo
-5217302;PirenÛpolis;-158507;-489584;0;52;Goi·s;9543;62;America/Sao_Paulo
-5217401;Pires do Rio;-173019;-482768;0;52;Goi·s;9545;64;America/Sao_Paulo
-2310951;Pires Ferreira;-423922;-406442;0;23;Cear·;1269;88;America/Sao_Paulo
-2924702;Pirip·;-149444;-417168;0;29;Bahia;3795;77;America/Sao_Paulo
-2208403;Piripiri;-427157;-417716;0;22;PiauÌ;1167;86;America/Sao_Paulo
+3151305;Pira√∫ba;-212825;-430172;0;31;Minas Gerais;5025;32;America/Sao_Paulo
+5217302;Piren√≥polis;-158507;-489584;0;52;Goi√°s;9543;62;America/Sao_Paulo
+5217401;Pires do Rio;-173019;-482768;0;52;Goi√°s;9545;64;America/Sao_Paulo
+2310951;Pires Ferreira;-423922;-406442;0;23;Cear√°;1269;88;America/Sao_Paulo
+2924702;Pirip√°;-149444;-417168;0;29;Bahia;3795;77;America/Sao_Paulo
+2208403;Piripiri;-427157;-417716;0;22;Piau√≠;1167;86;America/Sao_Paulo
 2924801;Piritiba;-1173;-405587;0;29;Bahia;3797;74;America/Sao_Paulo
-2511806;Pirpirituba;-677922;-354906;0;25;ParaÌba;2137;83;America/Sao_Paulo
-4119608;Pitanga;-247588;-517596;0;41;Paran·;7771;42;America/Sao_Paulo
-3539509;Pitangueiras;-210132;-48221;0;35;S„o Paulo;6891;16;America/Sao_Paulo
-4119657;Pitangueiras;-232281;-515873;0;41;Paran·;5461;43;America/Sao_Paulo
+2511806;Pirpirituba;-677922;-354906;0;25;Para√≠ba;2137;83;America/Sao_Paulo
+4119608;Pitanga;-247588;-517596;0;41;Paran√°;7771;42;America/Sao_Paulo
+3539509;Pitangueiras;-210132;-48221;0;35;S√£o Paulo;6891;16;America/Sao_Paulo
+4119657;Pitangueiras;-232281;-515873;0;41;Paran√°;5461;43;America/Sao_Paulo
 3151404;Pitangui;-196741;-448964;0;31;Minas Gerais;5027;37;America/Sao_Paulo
-2511905;Pitimbu;-74664;-348151;0;25;ParaÌba;2139;83;America/Sao_Paulo
+2511905;Pitimbu;-74664;-348151;0;25;Para√≠ba;2139;83;America/Sao_Paulo
 1717503;Pium;-10442;-491876;0;17;Tocantins;9547;63;America/Sao_Paulo
-3204203;Pi˙ma;-208334;-407268;0;32;EspÌrito Santo;5683;28;America/Sao_Paulo
+3204203;Pi√∫ma;-208334;-407268;0;32;Esp√≠rito Santo;5683;28;America/Sao_Paulo
 3151503;Piumhi;-204762;-459589;0;31;Minas Gerais;5029;37;America/Sao_Paulo
-1505650;Placas;-386813;-542124;0;15;Par·;60;93;America/Sao_Paulo
-1200385;Pl·cido de Castro;-102806;-671371;0;12;Acre;151;68;America/Rio_Branco
-5217609;Planaltina;-15452;-476089;0;52;Goi·s;9595;61;America/Sao_Paulo
-4119707;Planaltina do Paran·;-230101;-529162;0;41;Paran·;7773;44;America/Sao_Paulo
+1505650;Placas;-386813;-542124;0;15;Par√°;60;93;America/Sao_Paulo
+1200385;Pl√°cido de Castro;-102806;-671371;0;12;Acre;151;68;America/Rio_Branco
+5217609;Planaltina;-15452;-476089;0;52;Goi√°s;9595;61;America/Sao_Paulo
+4119707;Planaltina do Paran√°;-230101;-529162;0;41;Paran√°;7773;44;America/Sao_Paulo
 2924900;Planaltino;-132618;-403695;0;29;Bahia;3799;73;America/Sao_Paulo
 2925006;Planalto;-146654;-404718;0;29;Bahia;3801;77;America/Sao_Paulo
 4314704;Planalto;-273297;-530575;0;43;Rio Grande do Sul;8797;55;America/Sao_Paulo
-3539608;Planalto;-210342;-49933;0;35;S„o Paulo;6893;18;America/Sao_Paulo
-4119806;Planalto;-257211;-537642;0;41;Paran·;7775;46;America/Sao_Paulo
+3539608;Planalto;-210342;-49933;0;35;S√£o Paulo;6893;18;America/Sao_Paulo
+4119806;Planalto;-257211;-537642;0;41;Paran√°;7775;46;America/Sao_Paulo
 4213153;Planalto Alegre;-270704;-52867;0;42;Santa Catarina;5593;49;America/Sao_Paulo
 5106455;Planalto da Serra;-146518;-547819;0;51;Mato Grosso;91;66;America/Porto_Velho
 3151602;Planura;-201376;-487;0;31;Minas Gerais;5031;34;America/Sao_Paulo
-3539707;Platina;-226371;-502104;0;35;S„o Paulo;6895;18;America/Sao_Paulo
-3539806;Po·;-235333;-463473;0;35;S„o Paulo;6897;11;America/Sao_Paulo
-2611200;PoÁ„o;-818726;-367111;0;26;Pernambuco;2523;87;America/Sao_Paulo
-2108900;PoÁ„o de Pedras;-474626;-449432;0;21;Maranh„o;875;99;America/Sao_Paulo
-2512002;Pocinhos;-706658;-360668;0;25;ParaÌba;2141;83;America/Sao_Paulo
-2410108;PoÁo Branco;-562233;-356635;0;24;Rio Grande do Norte;1801;84;America/Sao_Paulo
-2512036;PoÁo Dantas;-639876;-384909;0;25;ParaÌba;496;83;America/Sao_Paulo
-4314753;PoÁo das Antas;-294481;-516719;0;43;Rio Grande do Sul;7365;51;America/Sao_Paulo
-2707206;PoÁo das Trincheiras;-930742;-372889;0;27;Alagoas;2843;82;America/Sao_Paulo
-2512077;PoÁo de JosÈ de Moura;-656401;-385111;0;25;ParaÌba;498;83;America/Sao_Paulo
-3151701;PoÁo Fundo;-2178;-459658;0;31;Minas Gerais;5033;35;America/Sao_Paulo
-2805406;PoÁo Redondo;-980616;-376833;0;28;Sergipe;3207;79;America/Sao_Paulo
-2805505;PoÁo Verde;-107151;-381813;0;28;Sergipe;3209;79;America/Sao_Paulo
-2925105;PoÁıes;-145234;-403634;0;29;Bahia;3803;77;America/Sao_Paulo
-5106505;PoconÈ;-16266;-566261;0;51;Mato Grosso;9129;65;America/Porto_Velho
-3151800;PoÁos de Caldas;-2178;-465692;0;31;Minas Gerais;5035;35;America/Sao_Paulo
+3539707;Platina;-226371;-502104;0;35;S√£o Paulo;6895;18;America/Sao_Paulo
+3539806;Po√°;-235333;-463473;0;35;S√£o Paulo;6897;11;America/Sao_Paulo
+2611200;Po√ß√£o;-818726;-367111;0;26;Pernambuco;2523;87;America/Sao_Paulo
+2108900;Po√ß√£o de Pedras;-474626;-449432;0;21;Maranh√£o;875;99;America/Sao_Paulo
+2512002;Pocinhos;-706658;-360668;0;25;Para√≠ba;2141;83;America/Sao_Paulo
+2410108;Po√ßo Branco;-562233;-356635;0;24;Rio Grande do Norte;1801;84;America/Sao_Paulo
+2512036;Po√ßo Dantas;-639876;-384909;0;25;Para√≠ba;496;83;America/Sao_Paulo
+4314753;Po√ßo das Antas;-294481;-516719;0;43;Rio Grande do Sul;7365;51;America/Sao_Paulo
+2707206;Po√ßo das Trincheiras;-930742;-372889;0;27;Alagoas;2843;82;America/Sao_Paulo
+2512077;Po√ßo de Jos√© de Moura;-656401;-385111;0;25;Para√≠ba;498;83;America/Sao_Paulo
+3151701;Po√ßo Fundo;-2178;-459658;0;31;Minas Gerais;5033;35;America/Sao_Paulo
+2805406;Po√ßo Redondo;-980616;-376833;0;28;Sergipe;3207;79;America/Sao_Paulo
+2805505;Po√ßo Verde;-107151;-381813;0;28;Sergipe;3209;79;America/Sao_Paulo
+2925105;Po√ß√µes;-145234;-403634;0;29;Bahia;3803;77;America/Sao_Paulo
+5106505;Pocon√©;-16266;-566261;0;51;Mato Grosso;9129;65;America/Porto_Velho
+3151800;Po√ßos de Caldas;-2178;-465692;0;31;Minas Gerais;5035;35;America/Sao_Paulo
 3151909;Pocrane;-196208;-416334;0;31;Minas Gerais;5037;33;America/Sao_Paulo
 2925204;Pojuca;-124303;-383374;0;29;Bahia;3805;71;America/Sao_Paulo
-3539905;Poloni;-207829;-498258;0;35;S„o Paulo;6899;17;America/Sao_Paulo
-2512101;Pombal;-676606;-378003;0;25;ParaÌba;2143;83;America/Sao_Paulo
+3539905;Poloni;-207829;-498258;0;35;S√£o Paulo;6899;17;America/Sao_Paulo
+2512101;Pombal;-676606;-378003;0;25;Para√≠ba;2143;83;America/Sao_Paulo
 2611309;Pombos;-813982;-353967;0;26;Pernambuco;2525;81;America/Sao_Paulo
 4213203;Pomerode;-267384;-491785;0;42;Santa Catarina;8259;47;America/Sao_Paulo
-3540002;PompÈia;-22107;-50176;0;35;S„o Paulo;6901;14;America/Sao_Paulo
-3152006;PompÈu;-192257;-450141;0;31;Minas Gerais;5039;37;America/Sao_Paulo
-3540101;PongaÌ;-217396;-493604;0;35;S„o Paulo;6903;14;America/Sao_Paulo
-1505700;Ponta de Pedras;-139587;-488661;0;15;Par·;513;91;America/Sao_Paulo
-4119905;Ponta Grossa;-250916;-501668;0;41;Paran·;7777;42;America/Sao_Paulo
-5006606;Ponta Por„;-225296;-557203;0;50;Mato Grosso do Sul;9131;67;America/Porto_Velho
-3540200;Pontal;-210216;-480423;0;35;S„o Paulo;6905;16;America/Sao_Paulo
+3540002;Pomp√©ia;-22107;-50176;0;35;S√£o Paulo;6901;14;America/Sao_Paulo
+3152006;Pomp√©u;-192257;-450141;0;31;Minas Gerais;5039;37;America/Sao_Paulo
+3540101;Ponga√≠;-217396;-493604;0;35;S√£o Paulo;6903;14;America/Sao_Paulo
+1505700;Ponta de Pedras;-139587;-488661;0;15;Par√°;513;91;America/Sao_Paulo
+4119905;Ponta Grossa;-250916;-501668;0;41;Paran√°;7777;42;America/Sao_Paulo
+5006606;Ponta Por√£;-225296;-557203;0;50;Mato Grosso do Sul;9131;67;America/Porto_Velho
+3540200;Pontal;-210216;-480423;0;35;S√£o Paulo;6905;16;America/Sao_Paulo
 5106653;Pontal do Araguaia;-159274;-523273;0;51;Mato Grosso;95;66;America/Porto_Velho
-4119954;Pontal do Paran·;-256735;-485111;0;41;Paran·;870;41;America/Sao_Paulo
-5217708;Pontalina;-175225;-494489;0;52;Goi·s;9549;64;America/Sao_Paulo
-3540259;Pontalinda;-204396;-505258;0;35;S„o Paulo;2987;17;America/Sao_Paulo
-4314779;Pont„o;-280585;-526791;0;43;Rio Grande do Sul;5939;54;America/Sao_Paulo
+4119954;Pontal do Paran√°;-256735;-485111;0;41;Paran√°;870;41;America/Sao_Paulo
+5217708;Pontalina;-175225;-494489;0;52;Goi√°s;9549;64;America/Sao_Paulo
+3540259;Pontalinda;-204396;-505258;0;35;S√£o Paulo;2987;17;America/Sao_Paulo
+4314779;Pont√£o;-280585;-526791;0;43;Rio Grande do Sul;5939;54;America/Sao_Paulo
 4213302;Ponte Alta;-274835;-503764;0;42;Santa Catarina;8261;49;America/Sao_Paulo
 1717800;Ponte Alta do Bom Jesus;-120853;-464825;0;17;Tocantins;9551;63;America/Sao_Paulo
 4213351;Ponte Alta do Norte;-271591;-504659;0;42;Santa Catarina;5569;49;America/Sao_Paulo
@@ -3926,288 +3926,288 @@ codigo_ibge;municipio;latitude;longitude;capital;codigo_uf;estado;siafi_id;ddd;f
 4314787;Ponte Preta;-276587;-524848;0;43;Rio Grande do Sul;5967;54;America/Sao_Paulo
 4213401;Ponte Serrada;-268733;-520112;0;42;Santa Catarina;8263;49;America/Sao_Paulo
 5106752;Pontes e Lacerda;-152219;-593435;0;51;Mato Grosso;8999;65;America/Porto_Velho
-3540309;Pontes Gestal;-201727;-497064;0;35;S„o Paulo;6907;17;America/Sao_Paulo
-3204252;Ponto Belo;-181253;-405458;0;32;EspÌrito Santo;762;27;America/Sao_Paulo
+3540309;Pontes Gestal;-201727;-497064;0;35;S√£o Paulo;6907;17;America/Sao_Paulo
+3204252;Ponto Belo;-181253;-405458;0;32;Esp√≠rito Santo;762;27;America/Sao_Paulo
 3152131;Ponto Chique;-166282;-450588;0;31;Minas Gerais;692;38;America/Sao_Paulo
 3152170;Ponto dos Volantes;-167473;-415025;0;31;Minas Gerais;694;33;America/Sao_Paulo
 2925253;Ponto Novo;-108653;-401311;0;29;Bahia;3021;74;America/Sao_Paulo
-3540408;Populina;-199453;-50538;0;35;S„o Paulo;6909;17;America/Sao_Paulo
-2311009;Poranga;-474672;-409205;0;23;Cear·;1521;88;America/Sao_Paulo
-3540507;Porangaba;-231761;-481195;0;35;S„o Paulo;6911;15;America/Sao_Paulo
-5218003;Porangatu;-134391;-491503;0;52;Goi·s;9555;62;America/Sao_Paulo
-3304102;Porci˙ncula;-209632;-420465;0;33;Rio de Janeiro;5881;22;America/Sao_Paulo
-4120002;Porecatu;-227537;-513795;0;41;Paran·;7779;43;America/Sao_Paulo
+3540408;Populina;-199453;-50538;0;35;S√£o Paulo;6909;17;America/Sao_Paulo
+2311009;Poranga;-474672;-409205;0;23;Cear√°;1521;88;America/Sao_Paulo
+3540507;Porangaba;-231761;-481195;0;35;S√£o Paulo;6911;15;America/Sao_Paulo
+5218003;Porangatu;-134391;-491503;0;52;Goi√°s;9555;62;America/Sao_Paulo
+3304102;Porci√∫ncula;-209632;-420465;0;33;Rio de Janeiro;5881;22;America/Sao_Paulo
+4120002;Porecatu;-227537;-513795;0;41;Paran√°;7779;43;America/Sao_Paulo
 2410207;Portalegre;-602064;-379865;0;24;Rio Grande do Norte;1803;84;America/Sao_Paulo
-4314803;Port„o;-297015;-512429;0;43;Rio Grande do Sul;8799;51;America/Sao_Paulo
-5218052;Porteir„o;-178143;-501653;0;52;Goi·s;1060;64;America/Sao_Paulo
-2311108;Porteiras;-752265;-39114;0;23;Cear·;1523;88;America/Sao_Paulo
+4314803;Port√£o;-297015;-512429;0;43;Rio Grande do Sul;8799;51;America/Sao_Paulo
+5218052;Porteir√£o;-178143;-501653;0;52;Goi√°s;1060;64;America/Sao_Paulo
+2311108;Porteiras;-752265;-39114;0;23;Cear√°;1523;88;America/Sao_Paulo
 3152204;Porteirinha;-157404;-430281;0;31;Minas Gerais;5043;38;America/Sao_Paulo
-1505809;Portel;-193639;-508194;0;15;Par·;515;91;America/Sao_Paulo
-5218102;Portel‚ndia;-173554;-526799;0;52;Goi·s;9557;64;America/Sao_Paulo
-2208502;Porto;-388815;-426998;0;22;PiauÌ;1169;86;America/Sao_Paulo
+1505809;Portel;-193639;-508194;0;15;Par√°;515;91;America/Sao_Paulo
+5218102;Portel√¢ndia;-173554;-526799;0;52;Goi√°s;9557;64;America/Sao_Paulo
+2208502;Porto;-388815;-426998;0;22;Piau√≠;1169;86;America/Sao_Paulo
 1200807;Porto Acre;-958138;-675478;0;12;Acre;649;68;America/Rio_Branco
 4314902;Porto Alegre;-300318;-512065;1;43;Rio Grande do Sul;8801;51;America/Sao_Paulo
 5106778;Porto Alegre do Norte;-108761;-516357;0;51;Mato Grosso;9895;66;America/Porto_Velho
-2208551;Porto Alegre do PiauÌ;-696423;-441837;0;22;PiauÌ;372;89;America/Sao_Paulo
+2208551;Porto Alegre do Piau√≠;-696423;-441837;0;22;Piau√≠;372;89;America/Sao_Paulo
 1718006;Porto Alegre do Tocantins;-11618;-470621;0;17;Tocantins;9723;63;America/Sao_Paulo
-4120101;Porto Amazonas;-2554;-498946;0;41;Paran·;7781;42;America/Sao_Paulo
-4120150;Porto Barreiro;-255477;-524067;0;41;Paran·;872;42;America/Sao_Paulo
+4120101;Porto Amazonas;-2554;-498946;0;41;Paran√°;7781;42;America/Sao_Paulo
+4120150;Porto Barreiro;-255477;-524067;0;41;Paran√°;872;42;America/Sao_Paulo
 4213500;Porto Belo;-271586;-485469;0;42;Santa Catarina;8265;47;America/Sao_Paulo
 2707305;Porto Calvo;-905195;-353987;0;27;Alagoas;2845;82;America/Sao_Paulo
 2805604;Porto da Folha;-991626;-372842;0;28;Sergipe;3211;79;America/Sao_Paulo
-1505908;Porto de Moz;-174691;-522361;0;15;Par·;517;93;America/Sao_Paulo
+1505908;Porto de Moz;-174691;-522361;0;15;Par√°;517;93;America/Sao_Paulo
 2707404;Porto de Pedras;-916006;-353049;0;27;Alagoas;2847;82;America/Sao_Paulo
 2410256;Porto do Mangue;-505441;-367887;0;24;Rio Grande do Norte;426;84;America/Sao_Paulo
-5106802;Porto dos Ga˙chos;-11533;-574132;0;51;Mato Grosso;9135;66;America/Porto_Velho
-5106828;Porto Esperidi„o;-15857;-584619;0;51;Mato Grosso;9875;65;America/Porto_Velho
+5106802;Porto dos Ga√∫chos;-11533;-574132;0;51;Mato Grosso;9135;66;America/Porto_Velho
+5106828;Porto Esperidi√£o;-15857;-584619;0;51;Mato Grosso;9875;65;America/Porto_Velho
 5106851;Porto Estrela;-153235;-572204;0;51;Mato Grosso;101;65;America/Porto_Velho
-3540606;Porto Feliz;-232093;-475251;0;35;S„o Paulo;6913;15;America/Sao_Paulo
-3540705;Porto Ferreira;-218498;-47487;0;35;S„o Paulo;6915;19;America/Sao_Paulo
+3540606;Porto Feliz;-232093;-475251;0;35;S√£o Paulo;6913;15;America/Sao_Paulo
+3540705;Porto Ferreira;-218498;-47487;0;35;S√£o Paulo;6915;19;America/Sao_Paulo
 3152303;Porto Firme;-206642;-430834;0;31;Minas Gerais;5045;31;America/Sao_Paulo
-2109007;Porto Franco;-634149;-473962;0;21;Maranh„o;877;99;America/Sao_Paulo
-1600535;Porto Grande;71243;-514155;0;16;Amap·;671;96;America/Sao_Paulo
+2109007;Porto Franco;-634149;-473962;0;21;Maranh√£o;877;99;America/Sao_Paulo
+1600535;Porto Grande;71243;-514155;0;16;Amap√°;671;96;America/Sao_Paulo
 4315008;Porto Lucena;-278569;-5501;0;43;Rio Grande do Sul;8803;55;America/Sao_Paulo
-4315057;Porto Mau·;-275796;-546657;0;43;Rio Grande do Sul;6065;55;America/Sao_Paulo
+4315057;Porto Mau√°;-275796;-546657;0;43;Rio Grande do Sul;6065;55;America/Sao_Paulo
 5006903;Porto Murtinho;-216981;-578836;0;50;Mato Grosso do Sul;9137;67;America/Porto_Velho
 1718204;Porto Nacional;-107027;-48408;0;17;Tocantins;9559;63;America/Sao_Paulo
 3304110;Porto Real;-224175;-442952;0;33;Rio de Janeiro;780;24;America/Sao_Paulo
-2707503;Porto Real do ColÈgio;-101849;-368376;0;27;Alagoas;2849;82;America/Sao_Paulo
-4120200;Porto Rico;-227747;-532677;0;41;Paran·;7783;44;America/Sao_Paulo
-2109056;Porto Rico do Maranh„o;-185925;-445842;0;21;Maranh„o;212;98;America/Sao_Paulo
+2707503;Porto Real do Col√©gio;-101849;-368376;0;27;Alagoas;2849;82;America/Sao_Paulo
+4120200;Porto Rico;-227747;-532677;0;41;Paran√°;7783;44;America/Sao_Paulo
+2109056;Porto Rico do Maranh√£o;-185925;-445842;0;21;Maranh√£o;212;98;America/Sao_Paulo
 2925303;Porto Seguro;-164435;-390643;0;29;Bahia;3807;73;America/Sao_Paulo
-4213609;Porto Uni„o;-262451;-510759;0;42;Santa Catarina;8267;42;America/Sao_Paulo
-1100205;Porto Velho;-876077;-638999;1;11;RondÙnia;3;69;America/Porto_Velho
+4213609;Porto Uni√£o;-262451;-510759;0;42;Santa Catarina;8267;42;America/Sao_Paulo
+1100205;Porto Velho;-876077;-638999;1;11;Rond√¥nia;3;69;America/Porto_Velho
 4315073;Porto Vera Cruz;-277405;-548994;0;43;Rio Grande do Sul;6067;55;America/Sao_Paulo
-4120309;Porto VitÛria;-261674;-51231;0;41;Paran·;7785;42;America/Sao_Paulo
+4120309;Porto Vit√≥ria;-261674;-51231;0;41;Paran√°;7785;42;America/Sao_Paulo
 1200393;Porto Walter;-826323;-727537;0;12;Acre;657;68;America/Rio_Branco
 4315107;Porto Xavier;-279082;-551379;0;43;Rio Grande do Sul;8805;55;America/Sao_Paulo
-5218300;Posse;-140859;-463704;0;52;Goi·s;9561;62;America/Sao_Paulo
-3152402;PotÈ;-178077;-41786;0;31;Minas Gerais;5047;33;America/Sao_Paulo
-2311207;Potengi;-709154;-400233;0;23;Cear·;1525;88;America/Sao_Paulo
-3540754;Potim;-228343;-452552;0;35;S„o Paulo;2993;12;America/Sao_Paulo
-2925402;Potiragu·;-155943;-398638;0;29;Bahia;3809;73;America/Sao_Paulo
-3540804;Potirendaba;-210428;-493815;0;35;S„o Paulo;6917;17;America/Sao_Paulo
-2311231;Potiretama;-571287;-381578;0;23;Cear·;1271;88;America/Sao_Paulo
+5218300;Posse;-140859;-463704;0;52;Goi√°s;9561;62;America/Sao_Paulo
+3152402;Pot√©;-178077;-41786;0;31;Minas Gerais;5047;33;America/Sao_Paulo
+2311207;Potengi;-709154;-400233;0;23;Cear√°;1525;88;America/Sao_Paulo
+3540754;Potim;-228343;-452552;0;35;S√£o Paulo;2993;12;America/Sao_Paulo
+2925402;Potiragu√°;-155943;-398638;0;29;Bahia;3809;73;America/Sao_Paulo
+3540804;Potirendaba;-210428;-493815;0;35;S√£o Paulo;6917;17;America/Sao_Paulo
+2311231;Potiretama;-571287;-381578;0;23;Cear√°;1271;88;America/Sao_Paulo
 3152501;Pouso Alegre;-222266;-459389;0;31;Minas Gerais;5049;35;America/Sao_Paulo
 3152600;Pouso Alto;-221964;-449748;0;31;Minas Gerais;5051;35;America/Sao_Paulo
 4315131;Pouso Novo;-291738;-522136;0;43;Rio Grande do Sul;7363;51;America/Sao_Paulo
 4213708;Pouso Redondo;-272567;-499301;0;42;Santa Catarina;8269;47;America/Sao_Paulo
-5107008;PoxorÈu;-158299;-544208;0;51;Mato Grosso;9139;66;America/Porto_Velho
-3540853;Pracinha;-218496;-510868;0;35;S„o Paulo;812;18;America/Sao_Paulo
-1600550;Pracu˙ba;174543;-507892;0;16;Amap·;673;96;America/Sao_Paulo
+5107008;Poxor√©u;-158299;-544208;0;51;Mato Grosso;9139;66;America/Porto_Velho
+3540853;Pracinha;-218496;-510868;0;35;S√£o Paulo;812;18;America/Sao_Paulo
+1600550;Pracu√∫ba;174543;-507892;0;16;Amap√°;673;96;America/Sao_Paulo
 2925501;Prado;-173364;-392227;0;29;Bahia;3811;73;America/Sao_Paulo
-4120333;Prado Ferreira;-230357;-514429;0;41;Paran·;874;43;America/Sao_Paulo
-3540903;PradÛpolis;-213626;-480679;0;35;S„o Paulo;6919;16;America/Sao_Paulo
+4120333;Prado Ferreira;-230357;-514429;0;41;Paran√°;874;43;America/Sao_Paulo
+3540903;Prad√≥polis;-213626;-480679;0;35;S√£o Paulo;6919;16;America/Sao_Paulo
 3152709;Prados;-210597;-440778;0;31;Minas Gerais;5053;32;America/Sao_Paulo
-3541000;Praia Grande;-240084;-464121;0;35;S„o Paulo;6921;13;America/Sao_Paulo
+3541000;Praia Grande;-240084;-464121;0;35;S√£o Paulo;6921;13;America/Sao_Paulo
 4213807;Praia Grande;-291918;-499525;0;42;Santa Catarina;8271;48;America/Sao_Paulo
 1718303;Praia Norte;-539281;-478111;0;17;Tocantins;9725;63;America/Sao_Paulo
-1506005;Prainha;-1798;-534779;0;15;Par·;519;93;America/Sao_Paulo
-4120358;Pranchita;-260209;-537397;0;41;Paran·;7991;46;America/Sao_Paulo
+1506005;Prainha;-1798;-534779;0;15;Par√°;519;93;America/Sao_Paulo
+4120358;Pranchita;-260209;-537397;0;41;Paran√°;7991;46;America/Sao_Paulo
 3152808;Prata;-193086;-489276;0;31;Minas Gerais;5055;34;America/Sao_Paulo
-2512200;Prata;-768826;-370801;0;25;ParaÌba;2145;83;America/Sao_Paulo
-2208601;Prata do PiauÌ;-567265;-422046;0;22;PiauÌ;1171;86;America/Sao_Paulo
-3541059;Prat‚nia;-228112;-486636;0;35;S„o Paulo;814;14;America/Sao_Paulo
-3152907;Prat·polis;-207411;-468624;0;31;Minas Gerais;5057;35;America/Sao_Paulo
+2512200;Prata;-768826;-370801;0;25;Para√≠ba;2145;83;America/Sao_Paulo
+2208601;Prata do Piau√≠;-567265;-422046;0;22;Piau√≠;1171;86;America/Sao_Paulo
+3541059;Prat√¢nia;-228112;-486636;0;35;S√£o Paulo;814;14;America/Sao_Paulo
+3152907;Prat√°polis;-207411;-468624;0;31;Minas Gerais;5057;35;America/Sao_Paulo
 3153004;Pratinha;-19739;-463755;0;31;Minas Gerais;5059;34;America/Sao_Paulo
-3541109;Presidente Alves;-220999;-494381;0;35;S„o Paulo;6923;14;America/Sao_Paulo
-3541208;Presidente Bernardes;-220082;-515565;0;35;S„o Paulo;6925;18;America/Sao_Paulo
+3541109;Presidente Alves;-220999;-494381;0;35;S√£o Paulo;6923;14;America/Sao_Paulo
+3541208;Presidente Bernardes;-220082;-515565;0;35;S√£o Paulo;6925;18;America/Sao_Paulo
 3153103;Presidente Bernardes;-207656;-431895;0;31;Minas Gerais;5061;32;America/Sao_Paulo
 4213906;Presidente Castello Branco;-272218;-518089;0;42;Santa Catarina;8273;49;America/Sao_Paulo
-4120408;Presidente Castelo Branco;-232782;-521536;0;41;Paran·;7787;44;America/Sao_Paulo
+4120408;Presidente Castelo Branco;-232782;-521536;0;41;Paran√°;7787;44;America/Sao_Paulo
 2925600;Presidente Dutra;-112923;-419843;0;29;Bahia;3813;74;America/Sao_Paulo
-2109106;Presidente Dutra;-52898;-44495;0;21;Maranh„o;879;99;America/Sao_Paulo
-3541307;Presidente Epit·cio;-217651;-521111;0;35;S„o Paulo;6927;18;America/Sao_Paulo
+2109106;Presidente Dutra;-52898;-44495;0;21;Maranh√£o;879;99;America/Sao_Paulo
+3541307;Presidente Epit√°cio;-217651;-521111;0;35;S√£o Paulo;6927;18;America/Sao_Paulo
 1303536;Presidente Figueiredo;-202981;-600234;0;13;Amazonas;9841;92;America/Porto_Velho
-4214003;Presidente Get˙lio;-270474;-496246;0;42;Santa Catarina;8275;47;America/Sao_Paulo
-2925709;Presidente J‚nio Quadros;-146885;-416798;0;29;Bahia;3815;77;America/Sao_Paulo
+4214003;Presidente Get√∫lio;-270474;-496246;0;42;Santa Catarina;8275;47;America/Sao_Paulo
+2925709;Presidente J√¢nio Quadros;-146885;-416798;0;29;Bahia;3815;77;America/Sao_Paulo
 3153202;Presidente Juscelino;-186401;-4406;0;31;Minas Gerais;5063;38;America/Sao_Paulo
-2109205;Presidente Juscelino;-291872;-440715;0;21;Maranh„o;881;98;America/Sao_Paulo
+2109205;Presidente Juscelino;-291872;-440715;0;21;Maranh√£o;881;98;America/Sao_Paulo
 1718402;Presidente Kennedy;-85406;-485062;0;17;Tocantins;9629;63;America/Sao_Paulo
-3204302;Presidente Kennedy;-210964;-410468;0;32;EspÌrito Santo;5685;28;America/Sao_Paulo
+3204302;Presidente Kennedy;-210964;-410468;0;32;Esp√≠rito Santo;5685;28;America/Sao_Paulo
 3153301;Presidente Kubitschek;-186193;-435628;0;31;Minas Gerais;5065;38;America/Sao_Paulo
 4315149;Presidente Lucena;-295175;-511798;0;43;Rio Grande do Sul;6023;51;America/Sao_Paulo
-1100254;Presidente MÈdici;-11169;-618986;0;11;RondÙnia;19;69;America/Porto_Velho
-2109239;Presidente MÈdici;-238991;-4582;0;21;Maranh„o;214;98;America/Sao_Paulo
+1100254;Presidente M√©dici;-11169;-618986;0;11;Rond√¥nia;19;69;America/Porto_Velho
+2109239;Presidente M√©dici;-238991;-4582;0;21;Maranh√£o;214;98;America/Sao_Paulo
 4214102;Presidente Nereu;-272768;-493889;0;42;Santa Catarina;8277;47;America/Sao_Paulo
-3153400;Presidente Oleg·rio;-184096;-464165;0;31;Minas Gerais;5067;34;America/Sao_Paulo
-3541406;Presidente Prudente;-221207;-513925;0;35;S„o Paulo;6929;18;America/Sao_Paulo
-2109270;Presidente Sarney;-258799;-453595;0;21;Maranh„o;216;98;America/Sao_Paulo
+3153400;Presidente Oleg√°rio;-184096;-464165;0;31;Minas Gerais;5067;34;America/Sao_Paulo
+3541406;Presidente Prudente;-221207;-513925;0;35;S√£o Paulo;6929;18;America/Sao_Paulo
+2109270;Presidente Sarney;-258799;-453595;0;21;Maranh√£o;216;98;America/Sao_Paulo
 2925758;Presidente Tancredo Neves;-134471;-394203;0;29;Bahia;3023;73;America/Sao_Paulo
-2109304;Presidente Vargas;-340787;-440234;0;21;Maranh„o;883;98;America/Sao_Paulo
-3541505;Presidente Venceslau;-218732;-518447;0;35;S„o Paulo;6931;18;America/Sao_Paulo
+2109304;Presidente Vargas;-340787;-440234;0;21;Maranh√£o;883;98;America/Sao_Paulo
+3541505;Presidente Venceslau;-218732;-518447;0;35;S√£o Paulo;6931;18;America/Sao_Paulo
 2611408;Primavera;-832999;-353544;0;26;Pernambuco;2527;81;America/Sao_Paulo
-1506104;Primavera;-945439;-471253;0;15;Par·;521;91;America/Sao_Paulo
-1101476;Primavera de RondÙnia;-118295;-613153;0;11;RondÙnia;16;69;America/Porto_Velho
+1506104;Primavera;-945439;-471253;0;15;Par√°;521;91;America/Sao_Paulo
+1101476;Primavera de Rond√¥nia;-118295;-613153;0;11;Rond√¥nia;16;69;America/Porto_Velho
 5107040;Primavera do Leste;-15544;-542811;0;51;Mato Grosso;9871;66;America/Porto_Velho
-2109403;Primeira Cruz;-250568;-434232;0;21;Maranh„o;885;98;America/Sao_Paulo
-4120507;Primeiro de Maio;-228517;-510293;0;41;Paran·;7789;43;America/Sao_Paulo
+2109403;Primeira Cruz;-250568;-434232;0;21;Maranh√£o;885;98;America/Sao_Paulo
+4120507;Primeiro de Maio;-228517;-510293;0;41;Paran√°;7789;43;America/Sao_Paulo
 4214151;Princesa;-264441;-535994;0;42;Santa Catarina;934;49;America/Sao_Paulo
-2512309;Princesa Isabel;-773175;-379886;0;25;ParaÌba;2147;83;America/Sao_Paulo
-5218391;Professor Jamil;-172497;-49244;0;52;Goi·s;51;64;America/Sao_Paulo
+2512309;Princesa Isabel;-773175;-379886;0;25;Para√≠ba;2147;83;America/Sao_Paulo
+5218391;Professor Jamil;-172497;-49244;0;52;Goi√°s;51;64;America/Sao_Paulo
 4315156;Progresso;-292441;-523197;0;43;Rio Grande do Sul;7361;51;America/Sao_Paulo
-3541604;Promiss„o;-215356;-498599;0;35;S„o Paulo;6933;14;America/Sao_Paulo
-2805703;Propri·;-102138;-368442;0;28;Sergipe;3213;79;America/Sao_Paulo
-4315172;Prot·sio Alves;-287572;-514757;0;43;Rio Grande do Sul;7359;54;America/Sao_Paulo
+3541604;Promiss√£o;-215356;-498599;0;35;S√£o Paulo;6933;14;America/Sao_Paulo
+2805703;Propri√°;-102138;-368442;0;28;Sergipe;3213;79;America/Sao_Paulo
+4315172;Prot√°sio Alves;-287572;-514757;0;43;Rio Grande do Sul;7359;54;America/Sao_Paulo
 3153608;Prudente de Morais;-194742;-441591;0;31;Minas Gerais;5071;31;America/Sao_Paulo
-4120606;PrudentÛpolis;-252111;-509754;0;41;Paran·;7791;42;America/Sao_Paulo
+4120606;Prudent√≥polis;-252111;-509754;0;41;Paran√°;7791;42;America/Sao_Paulo
 1718451;Pugmil;-10424;-488957;0;17;Tocantins;94;63;America/Sao_Paulo
 2410405;Pureza;-546393;-355554;0;24;Rio Grande do Norte;1807;84;America/Sao_Paulo
 4315206;Putinga;-290045;-521569;0;43;Rio Grande do Sul;8807;51;America/Sao_Paulo
-2512408;Puxinan„;-715479;-359543;0;25;ParaÌba;2149;83;America/Sao_Paulo
-3541653;Quadra;-232993;-480547;0;35;S„o Paulo;816;15;America/Sao_Paulo
-4315305;QuaraÌ;-30384;-564483;0;43;Rio Grande do Sul;8809;55;America/Sao_Paulo
+2512408;Puxinan√£;-715479;-359543;0;25;Para√≠ba;2149;83;America/Sao_Paulo
+3541653;Quadra;-232993;-480547;0;35;S√£o Paulo;816;15;America/Sao_Paulo
+4315305;Quara√≠;-30384;-564483;0;43;Rio Grande do Sul;8809;55;America/Sao_Paulo
 3153707;Quartel Geral;-192703;-455569;0;31;Minas Gerais;5073;37;America/Sao_Paulo
-4120655;Quarto Centen·rio;-242775;-530759;0;41;Paran·;876;44;America/Sao_Paulo
-3541703;Quat·;-222456;-506966;0;35;S„o Paulo;6935;18;America/Sao_Paulo
-4120705;Quatigu·;-235671;-49916;0;41;Paran·;7793;43;America/Sao_Paulo
-1506112;Quatipuru;-899604;-470134;0;15;Par·;62;91;America/Sao_Paulo
+4120655;Quarto Centen√°rio;-242775;-530759;0;41;Paran√°;876;44;America/Sao_Paulo
+3541703;Quat√°;-222456;-506966;0;35;S√£o Paulo;6935;18;America/Sao_Paulo
+4120705;Quatigu√°;-235671;-49916;0;41;Paran√°;7793;43;America/Sao_Paulo
+1506112;Quatipuru;-899604;-470134;0;15;Par√°;62;91;America/Sao_Paulo
 3304128;Quatis;-224045;-442597;0;33;Rio de Janeiro;2923;24;America/Sao_Paulo
-4120804;Quatro Barras;-253673;-490763;0;41;Paran·;7795;41;America/Sao_Paulo
-4315313;Quatro Irm„os;-278257;-524424;0;43;Rio Grande do Sul;1162;54;America/Sao_Paulo
-4120853;Quatro Pontes;-245752;-539759;0;41;Paran·;5535;45;America/Sao_Paulo
+4120804;Quatro Barras;-253673;-490763;0;41;Paran√°;7795;41;America/Sao_Paulo
+4315313;Quatro Irm√£os;-278257;-524424;0;43;Rio Grande do Sul;1162;54;America/Sao_Paulo
+4120853;Quatro Pontes;-245752;-539759;0;41;Paran√°;5535;45;America/Sao_Paulo
 2707602;Quebrangulo;-932001;-364692;0;27;Alagoas;2851;82;America/Sao_Paulo
-4120903;Quedas do IguaÁu;-254492;-529102;0;41;Paran·;7955;46;America/Sao_Paulo
-2208650;Queimada Nova;-857064;-414106;0;22;PiauÌ;2279;89;America/Sao_Paulo
-2512507;Queimadas;-735029;-359031;0;25;ParaÌba;2151;83;America/Sao_Paulo
+4120903;Quedas do Igua√ßu;-254492;-529102;0;41;Paran√°;7955;46;America/Sao_Paulo
+2208650;Queimada Nova;-857064;-414106;0;22;Piau√≠;2279;89;America/Sao_Paulo
+2512507;Queimadas;-735029;-359031;0;25;Para√≠ba;2151;83;America/Sao_Paulo
 2925808;Queimadas;-109736;-396293;0;29;Bahia;3817;75;America/Sao_Paulo
 3304144;Queimados;-227102;-435518;0;33;Rio de Janeiro;2911;21;America/Sao_Paulo
-3541802;Queiroz;-217969;-502415;0;35;S„o Paulo;6937;14;America/Sao_Paulo
-3541901;Queluz;-225312;-447781;0;35;S„o Paulo;6939;12;America/Sao_Paulo
+3541802;Queiroz;-217969;-502415;0;35;S√£o Paulo;6937;14;America/Sao_Paulo
+3541901;Queluz;-225312;-447781;0;35;S√£o Paulo;6939;12;America/Sao_Paulo
 3153806;Queluzito;-207416;-438851;0;31;Minas Gerais;5075;31;America/Sao_Paulo
-5107065;QuerÍncia;-126093;-521821;0;51;Mato Grosso;97;66;America/Porto_Velho
-4121000;QuerÍncia do Norte;-230838;-53483;0;41;Paran·;7797;44;America/Sao_Paulo
+5107065;Quer√™ncia;-126093;-521821;0;51;Mato Grosso;97;66;America/Porto_Velho
+4121000;Quer√™ncia do Norte;-230838;-53483;0;41;Paran√°;7797;44;America/Sao_Paulo
 4315321;Quevedos;-293504;-540789;0;43;Rio Grande do Sul;5789;55;America/Sao_Paulo
 2925907;Quijingue;-107505;-392137;0;29;Bahia;3819;75;America/Sao_Paulo
 4214201;Quilombo;-267264;-52724;0;42;Santa Catarina;8279;49;America/Sao_Paulo
-4121109;Quinta do Sol;-238533;-521309;0;41;Paran·;7799;44;America/Sao_Paulo
-3542008;Quintana;-220692;-50307;0;35;S„o Paulo;6941;14;America/Sao_Paulo
+4121109;Quinta do Sol;-238533;-521309;0;41;Paran√°;7799;44;America/Sao_Paulo
+3542008;Quintana;-220692;-50307;0;35;S√£o Paulo;6941;14;America/Sao_Paulo
 4315354;Quinze de Novembro;-287466;-531011;0;43;Rio Grande do Sul;7357;54;America/Sao_Paulo
-2611507;Quipap·;-881175;-360137;0;26;Pernambuco;2529;81;America/Sao_Paulo
-5218508;QuirinÛpolis;-184472;-504547;0;52;Goi·s;9563;64;America/Sao_Paulo
-3304151;Quissam„;-221031;-414693;0;33;Rio de Janeiro;6007;22;America/Sao_Paulo
-4121208;Quitandinha;-258734;-494973;0;41;Paran·;7801;41;America/Sao_Paulo
-2311264;QuiterianÛpolis;-58425;-407002;0;23;Cear·;9917;88;America/Sao_Paulo
-2512606;Quixab·;-70224;-371458;0;25;ParaÌba;2153;83;America/Sao_Paulo
+2611507;Quipap√°;-881175;-360137;0;26;Pernambuco;2529;81;America/Sao_Paulo
+5218508;Quirin√≥polis;-184472;-504547;0;52;Goi√°s;9563;64;America/Sao_Paulo
+3304151;Quissam√£;-221031;-414693;0;33;Rio de Janeiro;6007;22;America/Sao_Paulo
+4121208;Quitandinha;-258734;-494973;0;41;Paran√°;7801;41;America/Sao_Paulo
+2311264;Quiterian√≥polis;-58425;-407002;0;23;Cear√°;9917;88;America/Sao_Paulo
+2512606;Quixab√°;-70224;-371458;0;25;Para√≠ba;2153;83;America/Sao_Paulo
 2611533;Quixaba;-770734;-378446;0;26;Pernambuco;2637;87;America/Sao_Paulo
 2925931;Quixabeira;-114031;-4012;0;29;Bahia;3025;74;America/Sao_Paulo
-2311306;Quixad·;-49663;-390155;0;23;Cear·;1527;88;America/Sao_Paulo
-2311355;QuixelÙ;-624637;-392011;0;23;Cear·;9853;88;America/Sao_Paulo
-2311405;Quixeramobim;-519067;-392889;0;23;Cear·;1529;88;America/Sao_Paulo
-2311504;QuixerÈ;-507148;-379802;0;23;Cear·;1531;88;America/Sao_Paulo
+2311306;Quixad√°;-49663;-390155;0;23;Cear√°;1527;88;America/Sao_Paulo
+2311355;Quixel√¥;-624637;-392011;0;23;Cear√°;9853;88;America/Sao_Paulo
+2311405;Quixeramobim;-519067;-392889;0;23;Cear√°;1529;88;America/Sao_Paulo
+2311504;Quixer√©;-507148;-379802;0;23;Cear√°;1531;88;America/Sao_Paulo
 2410504;Rafael Fernandes;-618987;-382211;0;24;Rio Grande do Norte;1809;84;America/Sao_Paulo
 2410603;Rafael Godeiro;-607244;-37716;0;24;Rio Grande do Norte;1893;84;America/Sao_Paulo
 2925956;Rafael Jambeiro;-124053;-395007;0;29;Bahia;3985;75;America/Sao_Paulo
-3542107;Rafard;-230105;-475318;0;35;S„o Paulo;6943;19;America/Sao_Paulo
-4121257;Ramil‚ndia;-251195;-54023;0;41;Paran·;5527;45;America/Sao_Paulo
-3542206;Rancharia;-222269;-50893;0;35;S„o Paulo;6945;18;America/Sao_Paulo
-4121307;Rancho Alegre;-230676;-509145;0;41;Paran·;7803;43;America/Sao_Paulo
-4121356;Rancho Alegre D'Oeste;-243065;-529552;0;41;Paran·;5513;44;America/Sao_Paulo
+3542107;Rafard;-230105;-475318;0;35;S√£o Paulo;6943;19;America/Sao_Paulo
+4121257;Ramil√¢ndia;-251195;-54023;0;41;Paran√°;5527;45;America/Sao_Paulo
+3542206;Rancharia;-222269;-50893;0;35;S√£o Paulo;6945;18;America/Sao_Paulo
+4121307;Rancho Alegre;-230676;-509145;0;41;Paran√°;7803;43;America/Sao_Paulo
+4121356;Rancho Alegre D'Oeste;-243065;-529552;0;41;Paran√°;5513;44;America/Sao_Paulo
 4214300;Rancho Queimado;-276727;-490191;0;42;Santa Catarina;8281;48;America/Sao_Paulo
-2109452;Raposa;-24254;-440973;0;21;Maranh„o;218;98;America/Sao_Paulo
+2109452;Raposa;-24254;-440973;0;21;Maranh√£o;218;98;America/Sao_Paulo
 3153905;Raposos;-199636;-438079;0;31;Minas Gerais;5077;31;America/Sao_Paulo
 3154002;Raul Soares;-201061;-424502;0;31;Minas Gerais;5079;33;America/Sao_Paulo
-4121406;Realeza;-257711;-53526;0;41;Paran·;7805;46;America/Sao_Paulo
-4121505;RebouÁas;-256232;-506877;0;41;Paran·;7807;42;America/Sao_Paulo
+4121406;Realeza;-257711;-53526;0;41;Paran√°;7805;46;America/Sao_Paulo
+4121505;Rebou√ßas;-256232;-506877;0;41;Paran√°;7807;42;America/Sao_Paulo
 2611606;Recife;-804666;-348771;1;26;Pernambuco;2531;81;America/Sao_Paulo
 3154101;Recreio;-215289;-424676;0;31;Minas Gerais;5081;32;America/Sao_Paulo
-1718501;Recursol‚ndia;-87227;-472421;0;17;Tocantins;357;63;America/Sao_Paulo
-1506138;RedenÁ„o;-802529;-500317;0;15;Par·;567;94;America/Sao_Paulo
-2311603;RedenÁ„o;-421587;-387277;0;23;Cear·;1533;85;America/Sao_Paulo
-3542305;RedenÁ„o da Serra;-232638;-455422;0;35;S„o Paulo;6947;12;America/Sao_Paulo
-2208700;RedenÁ„o do GurguÈia;-947937;-445811;0;22;PiauÌ;1173;89;America/Sao_Paulo
+1718501;Recursol√¢ndia;-87227;-472421;0;17;Tocantins;357;63;America/Sao_Paulo
+1506138;Reden√ß√£o;-802529;-500317;0;15;Par√°;567;94;America/Sao_Paulo
+2311603;Reden√ß√£o;-421587;-387277;0;23;Cear√°;1533;85;America/Sao_Paulo
+3542305;Reden√ß√£o da Serra;-232638;-455422;0;35;S√£o Paulo;6947;12;America/Sao_Paulo
+2208700;Reden√ß√£o do Gurgu√©ia;-947937;-445811;0;22;Piau√≠;1173;89;America/Sao_Paulo
 4315404;Redentora;-27664;-536407;0;43;Rio Grande do Sul;8811;55;America/Sao_Paulo
 3154150;Reduto;-202401;-419848;0;31;Minas Gerais;696;33;America/Sao_Paulo
-2208809;RegeneraÁ„o;-623115;-426842;0;22;PiauÌ;1175;86;America/Sao_Paulo
-3542404;Regente FeijÛ;-222181;-513055;0;35;S„o Paulo;6949;18;America/Sao_Paulo
-3542503;ReginÛpolis;-218914;-492268;0;35;S„o Paulo;6951;14;America/Sao_Paulo
-3542602;Registro;-244979;-478449;0;35;S„o Paulo;6953;13;America/Sao_Paulo
+2208809;Regenera√ß√£o;-623115;-426842;0;22;Piau√≠;1175;86;America/Sao_Paulo
+3542404;Regente Feij√≥;-222181;-513055;0;35;S√£o Paulo;6949;18;America/Sao_Paulo
+3542503;Regin√≥polis;-218914;-492268;0;35;S√£o Paulo;6951;14;America/Sao_Paulo
+3542602;Registro;-244979;-478449;0;35;S√£o Paulo;6953;13;America/Sao_Paulo
 4315453;Relvado;-291164;-520778;0;43;Rio Grande do Sul;7355;51;America/Sao_Paulo
 2926004;Remanso;-961944;-420848;0;29;Bahia;3821;74;America/Sao_Paulo
-2512705;RemÌgio;-694992;-358011;0;25;ParaÌba;2155;83;America/Sao_Paulo
-4121604;RenascenÁa;-261588;-529703;0;41;Paran·;7809;46;America/Sao_Paulo
-2311702;Reriutaba;-414191;-405759;0;23;Cear·;1535;88;America/Sao_Paulo
+2512705;Rem√≠gio;-694992;-358011;0;25;Para√≠ba;2155;83;America/Sao_Paulo
+4121604;Renascen√ßa;-261588;-529703;0;41;Paran√°;7809;46;America/Sao_Paulo
+2311702;Reriutaba;-414191;-405759;0;23;Cear√°;1535;88;America/Sao_Paulo
 3304201;Resende;-224705;-444509;0;33;Rio de Janeiro;5883;24;America/Sao_Paulo
 3154200;Resende Costa;-209171;-442407;0;31;Minas Gerais;5083;32;America/Sao_Paulo
-4121703;Reserva;-246492;-508466;0;41;Paran·;7811;42;America/Sao_Paulo
-5107156;Reserva do CabaÁal;-150743;-584585;0;51;Mato Grosso;9879;65;America/Porto_Velho
-4121752;Reserva do IguaÁu;-258319;-520272;0;41;Paran·;878;42;America/Sao_Paulo
+4121703;Reserva;-246492;-508466;0;41;Paran√°;7811;42;America/Sao_Paulo
+5107156;Reserva do Caba√ßal;-150743;-584585;0;51;Mato Grosso;9879;65;America/Porto_Velho
+4121752;Reserva do Igua√ßu;-258319;-520272;0;41;Paran√°;878;42;America/Sao_Paulo
 3154309;Resplendor;-193194;-412462;0;31;Minas Gerais;5085;33;America/Sao_Paulo
 3154408;Ressaquinha;-210642;-437598;0;31;Minas Gerais;5087;32;America/Sao_Paulo
-3542701;Restinga;-206056;-474833;0;35;S„o Paulo;6955;16;America/Sao_Paulo
-4315503;Restinga SÍca;-298188;-533807;0;43;Rio Grande do Sul;8813;55;America/Sao_Paulo
-2926103;Retirol‚ndia;-114832;-394234;0;29;Bahia;3823;75;America/Sao_Paulo
-2512747;Riach„o;-654269;-35661;0;25;ParaÌba;502;83;America/Sao_Paulo
-2109502;Riach„o;-735819;-466225;0;21;Maranh„o;887;99;America/Sao_Paulo
-2926202;Riach„o das Neves;-117508;-449143;0;29;Bahia;3825;77;America/Sao_Paulo
-2512754;Riach„o do Bacamarte;-725347;-356693;0;25;ParaÌba;504;83;America/Sao_Paulo
-2805802;Riach„o do Dantas;-110729;-37731;0;28;Sergipe;3215;79;America/Sao_Paulo
-2926301;Riach„o do JacuÌpe;-118067;-393818;0;29;Bahia;3827;75;America/Sao_Paulo
-2512762;Riach„o do PoÁo;-714173;-352914;0;25;ParaÌba;506;83;America/Sao_Paulo
+3542701;Restinga;-206056;-474833;0;35;S√£o Paulo;6955;16;America/Sao_Paulo
+4315503;Restinga S√™ca;-298188;-533807;0;43;Rio Grande do Sul;8813;55;America/Sao_Paulo
+2926103;Retirol√¢ndia;-114832;-394234;0;29;Bahia;3823;75;America/Sao_Paulo
+2512747;Riach√£o;-654269;-35661;0;25;Para√≠ba;502;83;America/Sao_Paulo
+2109502;Riach√£o;-735819;-466225;0;21;Maranh√£o;887;99;America/Sao_Paulo
+2926202;Riach√£o das Neves;-117508;-449143;0;29;Bahia;3825;77;America/Sao_Paulo
+2512754;Riach√£o do Bacamarte;-725347;-356693;0;25;Para√≠ba;504;83;America/Sao_Paulo
+2805802;Riach√£o do Dantas;-110729;-37731;0;28;Sergipe;3215;79;America/Sao_Paulo
+2926301;Riach√£o do Jacu√≠pe;-118067;-393818;0;29;Bahia;3827;75;America/Sao_Paulo
+2512762;Riach√£o do Po√ßo;-714173;-352914;0;25;Para√≠ba;506;83;America/Sao_Paulo
 1718550;Riachinho;-644005;-481371;0;17;Tocantins;193;63;America/Sao_Paulo
 3154457;Riachinho;-162258;-459888;0;31;Minas Gerais;2901;38;America/Sao_Paulo
 2410702;Riacho da Cruz;-592654;-37949;0;24;Rio Grande do Norte;1811;84;America/Sao_Paulo
 2611705;Riacho das Almas;-813742;-358648;0;26;Pernambuco;2533;81;America/Sao_Paulo
 2410801;Riacho de Santana;-625139;-383116;0;24;Rio Grande do Norte;1813;84;America/Sao_Paulo
 2926400;Riacho de Santana;-136059;-429397;0;29;Bahia;3829;77;America/Sao_Paulo
-2512788;Riacho de Santo AntÙnio;-768023;-36157;0;25;ParaÌba;508;83;America/Sao_Paulo
-2512804;Riacho dos Cavalos;-644067;-376483;0;25;ParaÌba;2157;83;America/Sao_Paulo
+2512788;Riacho de Santo Ant√¥nio;-768023;-36157;0;25;Para√≠ba;508;83;America/Sao_Paulo
+2512804;Riacho dos Cavalos;-644067;-376483;0;25;Para√≠ba;2157;83;America/Sao_Paulo
 3154507;Riacho dos Machados;-160091;-430488;0;31;Minas Gerais;5089;38;America/Sao_Paulo
-2208858;Riacho Frio;-101244;-449503;0;22;PiauÌ;374;89;America/Sao_Paulo
+2208858;Riacho Frio;-101244;-449503;0;22;Piau√≠;374;89;America/Sao_Paulo
 2410900;Riachuelo;-582156;-358215;0;24;Rio Grande do Norte;1815;84;America/Sao_Paulo
 2805901;Riachuelo;-10735;-371966;0;28;Sergipe;3217;79;America/Sao_Paulo
-5218607;Rialma;-153145;-495814;0;52;Goi·s;9565;62;America/Sao_Paulo
-5218706;Rian·polis;-154456;-495114;0;52;Goi·s;9567;62;America/Sao_Paulo
-2109551;Ribamar Fiquene;-593067;-473888;0;21;Maranh„o;220;99;America/Sao_Paulo
+5218607;Rialma;-153145;-495814;0;52;Goi√°s;9565;62;America/Sao_Paulo
+5218706;Rian√°polis;-154456;-495114;0;52;Goi√°s;9567;62;America/Sao_Paulo
+2109551;Ribamar Fiquene;-593067;-473888;0;21;Maranh√£o;220;99;America/Sao_Paulo
 5007109;Ribas do Rio Pardo;-204445;-537588;0;50;Mato Grosso do Sul;9141;67;America/Porto_Velho
-3542800;Ribeira;-246517;-490044;0;35;S„o Paulo;6957;15;America/Sao_Paulo
+3542800;Ribeira;-246517;-490044;0;35;S√£o Paulo;6957;15;America/Sao_Paulo
 2926509;Ribeira do Amparo;-110421;-384242;0;29;Bahia;3831;75;America/Sao_Paulo
-2208874;Ribeira do PiauÌ;-769028;-427128;0;22;PiauÌ;376;89;America/Sao_Paulo
+2208874;Ribeira do Piau√≠;-769028;-427128;0;22;Piau√≠;376;89;America/Sao_Paulo
 2926608;Ribeira do Pombal;-108373;-385382;0;29;Bahia;3833;75;America/Sao_Paulo
-2611804;Ribeir„o;-850957;-353698;0;26;Pernambuco;2535;81;America/Sao_Paulo
-3542909;Ribeir„o Bonito;-220685;-48182;0;35;S„o Paulo;6959;16;America/Sao_Paulo
-3543006;Ribeir„o Branco;-242206;-487635;0;35;S„o Paulo;6961;15;America/Sao_Paulo
-5107180;Ribeir„o Cascalheira;-129367;-518244;0;51;Mato Grosso;9741;66;America/Porto_Velho
-4121802;Ribeir„o Claro;-231941;-497597;0;41;Paran·;7813;43;America/Sao_Paulo
-3543105;Ribeir„o Corrente;-204579;-475904;0;35;S„o Paulo;6963;16;America/Sao_Paulo
-3154606;Ribeir„o das Neves;-197621;-440844;0;31;Minas Gerais;5091;31;America/Sao_Paulo
-2926657;Ribeir„o do Largo;-154508;-407441;0;29;Bahia;3027;77;America/Sao_Paulo
-4121901;Ribeir„o do Pinhal;-234091;-503601;0;41;Paran·;7815;43;America/Sao_Paulo
-3543204;Ribeir„o do Sul;-22789;-49933;0;35;S„o Paulo;6965;14;America/Sao_Paulo
-3543238;Ribeir„o dos Õndios;-218382;-516103;0;35;S„o Paulo;818;18;America/Sao_Paulo
-3543253;Ribeir„o Grande;-241011;-483679;0;35;S„o Paulo;3057;15;America/Sao_Paulo
-3543303;Ribeir„o Pires;-237067;-464058;0;35;S„o Paulo;6967;11;America/Sao_Paulo
-3543402;Ribeir„o Preto;-211699;-478099;0;35;S„o Paulo;6969;16;America/Sao_Paulo
-3154705;Ribeir„o Vermelho;-211879;-450637;0;31;Minas Gerais;5093;35;America/Sao_Paulo
-5107198;Ribeir„ozinho;-164856;-526924;0;51;Mato Grosso;99;66;America/Porto_Velho
-2208908;Ribeiro GonÁalves;-755651;-452447;0;22;PiauÌ;1177;89;America/Sao_Paulo
-2806008;RibeirÛpolis;-105357;-37438;0;28;Sergipe;3219;79;America/Sao_Paulo
-3543600;Rifaina;-200803;-474291;0;35;S„o Paulo;6973;16;America/Sao_Paulo
-3543709;Rinc„o;-215894;-480728;0;35;S„o Paulo;6975;16;America/Sao_Paulo
-3543808;RinÛpolis;-217284;-507239;0;35;S„o Paulo;6977;18;America/Sao_Paulo
+2611804;Ribeir√£o;-850957;-353698;0;26;Pernambuco;2535;81;America/Sao_Paulo
+3542909;Ribeir√£o Bonito;-220685;-48182;0;35;S√£o Paulo;6959;16;America/Sao_Paulo
+3543006;Ribeir√£o Branco;-242206;-487635;0;35;S√£o Paulo;6961;15;America/Sao_Paulo
+5107180;Ribeir√£o Cascalheira;-129367;-518244;0;51;Mato Grosso;9741;66;America/Porto_Velho
+4121802;Ribeir√£o Claro;-231941;-497597;0;41;Paran√°;7813;43;America/Sao_Paulo
+3543105;Ribeir√£o Corrente;-204579;-475904;0;35;S√£o Paulo;6963;16;America/Sao_Paulo
+3154606;Ribeir√£o das Neves;-197621;-440844;0;31;Minas Gerais;5091;31;America/Sao_Paulo
+2926657;Ribeir√£o do Largo;-154508;-407441;0;29;Bahia;3027;77;America/Sao_Paulo
+4121901;Ribeir√£o do Pinhal;-234091;-503601;0;41;Paran√°;7815;43;America/Sao_Paulo
+3543204;Ribeir√£o do Sul;-22789;-49933;0;35;S√£o Paulo;6965;14;America/Sao_Paulo
+3543238;Ribeir√£o dos √çndios;-218382;-516103;0;35;S√£o Paulo;818;18;America/Sao_Paulo
+3543253;Ribeir√£o Grande;-241011;-483679;0;35;S√£o Paulo;3057;15;America/Sao_Paulo
+3543303;Ribeir√£o Pires;-237067;-464058;0;35;S√£o Paulo;6967;11;America/Sao_Paulo
+3543402;Ribeir√£o Preto;-211699;-478099;0;35;S√£o Paulo;6969;16;America/Sao_Paulo
+3154705;Ribeir√£o Vermelho;-211879;-450637;0;31;Minas Gerais;5093;35;America/Sao_Paulo
+5107198;Ribeir√£ozinho;-164856;-526924;0;51;Mato Grosso;99;66;America/Porto_Velho
+2208908;Ribeiro Gon√ßalves;-755651;-452447;0;22;Piau√≠;1177;89;America/Sao_Paulo
+2806008;Ribeir√≥polis;-105357;-37438;0;28;Sergipe;3219;79;America/Sao_Paulo
+3543600;Rifaina;-200803;-474291;0;35;S√£o Paulo;6973;16;America/Sao_Paulo
+3543709;Rinc√£o;-215894;-480728;0;35;S√£o Paulo;6975;16;America/Sao_Paulo
+3543808;Rin√≥polis;-217284;-507239;0;35;S√£o Paulo;6977;18;America/Sao_Paulo
 3154804;Rio Acima;-200876;-437878;0;31;Minas Gerais;5095;31;America/Sao_Paulo
-4122008;Rio Azul;-257306;-507985;0;41;Paran·;7817;42;America/Sao_Paulo
-3204351;Rio Bananal;-192719;-403366;0;32;EspÌrito Santo;5711;27;America/Sao_Paulo
-4122107;Rio Bom;-237606;-514122;0;41;Paran·;7819;43;America/Sao_Paulo
+4122008;Rio Azul;-257306;-507985;0;41;Paran√°;7817;42;America/Sao_Paulo
+3204351;Rio Bananal;-192719;-403366;0;32;Esp√≠rito Santo;5711;27;America/Sao_Paulo
+4122107;Rio Bom;-237606;-514122;0;41;Paran√°;7819;43;America/Sao_Paulo
 3304300;Rio Bonito;-227181;-426276;0;33;Rio de Janeiro;5885;21;America/Sao_Paulo
-4122156;Rio Bonito do IguaÁu;-254874;-525292;0;41;Paran·;5481;42;America/Sao_Paulo
+4122156;Rio Bonito do Igua√ßu;-254874;-525292;0;41;Paran√°;5481;42;America/Sao_Paulo
 5107206;Rio Branco;-152483;-581259;0;51;Mato Grosso;8995;65;America/Porto_Velho
 1200401;Rio Branco;-997499;-678243;1;12;Acre;139;68;America/Rio_Branco
-4122172;Rio Branco do IvaÌ;-243244;-513187;0;41;Paran·;880;43;America/Sao_Paulo
-4122206;Rio Branco do Sul;-251892;-493115;0;41;Paran·;7821;41;America/Sao_Paulo
+4122172;Rio Branco do Iva√≠;-243244;-513187;0;41;Paran√°;880;43;America/Sao_Paulo
+4122206;Rio Branco do Sul;-251892;-493115;0;41;Paran√°;7821;41;America/Sao_Paulo
 5007208;Rio Brilhante;-218033;-545427;0;50;Mato Grosso do Sul;9143;67;America/Porto_Velho
 3154903;Rio Casca;-202285;-426462;0;31;Minas Gerais;5097;31;America/Sao_Paulo
 3304409;Rio Claro;-2272;-441419;0;33;Rio de Janeiro;5887;24;America/Sao_Paulo
-3543907;Rio Claro;-223984;-475546;0;35;S„o Paulo;6979;19;America/Sao_Paulo
-1100262;Rio Crespo;-969965;-629011;0;11;RondÙnia;687;69;America/Porto_Velho
-1718659;Rio da ConceiÁ„o;-113949;-468847;0;17;Tocantins;323;63;America/Sao_Paulo
+3543907;Rio Claro;-223984;-475546;0;35;S√£o Paulo;6979;19;America/Sao_Paulo
+1100262;Rio Crespo;-969965;-629011;0;11;Rond√¥nia;687;69;America/Porto_Velho
+1718659;Rio da Concei√ß√£o;-113949;-468847;0;17;Tocantins;323;63;America/Sao_Paulo
 4214409;Rio das Antas;-268946;-510674;0;42;Santa Catarina;8283;49;America/Sao_Paulo
 3304508;Rio das Flores;-221692;-435856;0;33;Rio de Janeiro;5889;24;America/Sao_Paulo
 3304524;Rio das Ostras;-225174;-419475;0;33;Rio de Janeiro;2921;22;America/Sao_Paulo
-3544004;Rio das Pedras;-228417;-476047;0;35;S„o Paulo;6981;19;America/Sao_Paulo
+3544004;Rio das Pedras;-228417;-476047;0;35;S√£o Paulo;6981;19;America/Sao_Paulo
 2926707;Rio de Contas;-135852;-418048;0;29;Bahia;3835;77;America/Sao_Paulo
 3304557;Rio de Janeiro;-229129;-432003;1;33;Rio de Janeiro;6001;21;America/Sao_Paulo
-2926806;Rio do AntÙnio;-144071;-420721;0;29;Bahia;3837;77;America/Sao_Paulo
+2926806;Rio do Ant√¥nio;-144071;-420721;0;29;Bahia;3837;77;America/Sao_Paulo
 4214508;Rio do Campo;-269452;-50136;0;42;Santa Catarina;8285;47;America/Sao_Paulo
 2408953;Rio do Fogo;-52765;-353794;0;24;Rio Grande do Norte;422;84;America/Sao_Paulo
 4214607;Rio do Oeste;-271952;-497989;0;42;Santa Catarina;8287;47;America/Sao_Paulo
@@ -4217,41 +4217,41 @@ codigo_ibge;municipio;latitude;longitude;capital;codigo_uf;estado;siafi_id;ddd;f
 3155009;Rio Doce;-202412;-428995;0;31;Minas Gerais;5099;31;America/Sao_Paulo
 1718709;Rio dos Bois;-934425;-485245;0;17;Tocantins;359;63;America/Sao_Paulo
 4214706;Rio dos Cedros;-267398;-492718;0;42;Santa Catarina;8289;47;America/Sao_Paulo
-4315552;Rio dos Õndios;-272973;-528417;0;43;Rio Grande do Sul;5955;54;America/Sao_Paulo
+4315552;Rio dos √çndios;-272973;-528417;0;43;Rio Grande do Sul;5955;54;America/Sao_Paulo
 3155207;Rio Espera;-20855;-434721;0;31;Minas Gerais;5103;31;America/Sao_Paulo
 2611903;Rio Formoso;-86592;-351532;0;26;Pernambuco;2537;81;America/Sao_Paulo
 4214904;Rio Fortuna;-281244;-491068;0;42;Santa Catarina;8293;48;America/Sao_Paulo
 4315602;Rio Grande;-320349;-521071;0;43;Rio Grande do Sul;8815;53;America/Sao_Paulo
-3544103;Rio Grande da Serra;-237437;-463971;0;35;S„o Paulo;6983;11;America/Sao_Paulo
-2209005;Rio Grande do PiauÌ;-778029;-431369;0;22;PiauÌ;1179;89;America/Sao_Paulo
+3544103;Rio Grande da Serra;-237437;-463971;0;35;S√£o Paulo;6983;11;America/Sao_Paulo
+2209005;Rio Grande do Piau√≠;-778029;-431369;0;22;Piau√≠;1179;89;America/Sao_Paulo
 2707701;Rio Largo;-947783;-358394;0;27;Alagoas;2853;82;America/Sao_Paulo
 3155306;Rio Manso;-202666;-443069;0;31;Minas Gerais;5105;31;America/Sao_Paulo
-1506161;Rio Maria;-731236;-500379;0;15;Par·;569;94;America/Sao_Paulo
+1506161;Rio Maria;-731236;-500379;0;15;Par√°;569;94;America/Sao_Paulo
 4215000;Rio Negrinho;-262591;-495177;0;42;Santa Catarina;8295;47;America/Sao_Paulo
 5007307;Rio Negro;-19447;-549859;0;50;Mato Grosso do Sul;9145;67;America/Porto_Velho
-4122305;Rio Negro;-26095;-497982;0;41;Paran·;7823;47;America/Sao_Paulo
+4122305;Rio Negro;-26095;-497982;0;41;Paran√°;7823;47;America/Sao_Paulo
 3155405;Rio Novo;-214649;-431168;0;31;Minas Gerais;5107;32;America/Sao_Paulo
-3204401;Rio Novo do Sul;-208556;-409388;0;32;EspÌrito Santo;5687;28;America/Sao_Paulo
-3155504;Rio ParanaÌba;-191861;-462455;0;31;Minas Gerais;5109;34;America/Sao_Paulo
+3204401;Rio Novo do Sul;-208556;-409388;0;32;Esp√≠rito Santo;5687;28;America/Sao_Paulo
+3155504;Rio Parana√≠ba;-191861;-462455;0;31;Minas Gerais;5109;34;America/Sao_Paulo
 4315701;Rio Pardo;-29988;-523711;0;43;Rio Grande do Sul;8817;51;America/Sao_Paulo
 3155603;Rio Pardo de Minas;-15616;-425405;0;31;Minas Gerais;5111;38;America/Sao_Paulo
 3155702;Rio Piracicaba;-199284;-431829;0;31;Minas Gerais;5113;31;America/Sao_Paulo
 3155801;Rio Pomba;-212712;-431696;0;31;Minas Gerais;5115;32;America/Sao_Paulo
 3155900;Rio Preto;-220861;-438293;0;31;Minas Gerais;5117;32;America/Sao_Paulo
 1303569;Rio Preto da Eva;-27045;-596858;0;13;Amazonas;9843;92;America/Porto_Velho
-5218789;Rio Quente;-17774;-487725;0;52;Goi·s;9995;64;America/Sao_Paulo
+5218789;Rio Quente;-17774;-487725;0;52;Goi√°s;9995;64;America/Sao_Paulo
 2927002;Rio Real;-114814;-379332;0;29;Bahia;3841;75;America/Sao_Paulo
 4215059;Rio Rufino;-278592;-497754;0;42;Santa Catarina;5571;49;America/Sao_Paulo
 1718758;Rio Sono;-935002;-47888;0;17;Tocantins;9679;63;America/Sao_Paulo
-2512903;Rio Tinto;-680383;-350776;0;25;ParaÌba;2159;83;America/Sao_Paulo
-5218805;Rio Verde;-177923;-509192;0;52;Goi·s;9571;64;America/Sao_Paulo
+2512903;Rio Tinto;-680383;-350776;0;25;Para√≠ba;2159;83;America/Sao_Paulo
+5218805;Rio Verde;-177923;-509192;0;52;Goi√°s;9571;64;America/Sao_Paulo
 5007406;Rio Verde de Mato Grosso;-189249;-548434;0;50;Mato Grosso do Sul;9147;67;America/Porto_Velho
 3156007;Rio Vermelho;-182922;-430018;0;31;Minas Gerais;5119;33;America/Sao_Paulo
-3544202;Riol‚ndia;-199868;-496836;0;35;S„o Paulo;6985;17;America/Sao_Paulo
+3544202;Riol√¢ndia;-199868;-496836;0;35;S√£o Paulo;6985;17;America/Sao_Paulo
 4315750;Riozinho;-29639;-504488;0;43;Rio Grande do Sul;7353;51;America/Sao_Paulo
 4215075;Riqueza;-270653;-533265;0;42;Santa Catarina;5749;49;America/Sao_Paulo
-3156106;Rit·polis;-210276;-443204;0;31;Minas Gerais;5121;32;America/Sao_Paulo
-3543501;Riversul;-23829;-49429;0;35;S„o Paulo;6971;15;America/Sao_Paulo
+3156106;Rit√°polis;-210276;-443204;0;31;Minas Gerais;5121;32;America/Sao_Paulo
+3543501;Riversul;-23829;-49429;0;35;S√£o Paulo;6971;15;America/Sao_Paulo
 4315800;Roca Sales;-292884;-518658;0;43;Rio Grande do Sul;8819;51;America/Sao_Paulo
 5007505;Rochedo;-199565;-548848;0;50;Mato Grosso do Sul;9149;67;America/Porto_Velho
 3156205;Rochedo de Minas;-216284;-430165;0;31;Minas Gerais;5123;32;America/Sao_Paulo
@@ -4262,1310 +4262,1310 @@ codigo_ibge;municipio;latitude;longitude;capital;codigo_uf;estado;siafi_id;ddd;f
 2411007;Rodolfo Fernandes;-578393;-380579;0;24;Rio Grande do Norte;1817;84;America/Sao_Paulo
 1200427;Rodrigues Alves;-773864;-72661;0;12;Acre;659;68;America/Rio_Branco
 4315958;Rolador;-282566;-548186;0;43;Rio Grande do Sul;1164;55;America/Sao_Paulo
-4122404;Rol‚ndia;-233101;-513659;0;41;Paran·;7825;43;America/Sao_Paulo
+4122404;Rol√¢ndia;-233101;-513659;0;41;Paran√°;7825;43;America/Sao_Paulo
 4316006;Rolante;-296462;-505819;0;43;Rio Grande do Sul;8823;51;America/Sao_Paulo
-1100288;Rolim de Moura;-117271;-617714;0;11;RondÙnia;29;69;America/Porto_Velho
+1100288;Rolim de Moura;-117271;-617714;0;11;Rond√¥nia;29;69;America/Porto_Velho
 3156403;Romaria;-188838;-475782;0;31;Minas Gerais;5127;34;America/Sao_Paulo
-4215208;Romel‚ndia;-266809;-533172;0;42;Santa Catarina;8299;49;America/Sao_Paulo
-4122503;Roncador;-245958;-522716;0;41;Paran·;7827;44;America/Sao_Paulo
+4215208;Romel√¢ndia;-266809;-533172;0;42;Santa Catarina;8299;49;America/Sao_Paulo
+4122503;Roncador;-245958;-522716;0;41;Paran√°;7827;44;America/Sao_Paulo
 4316105;Ronda Alta;-277758;-528056;0;43;Rio Grande do Sul;8825;54;America/Sao_Paulo
 4316204;Rondinha;-278315;-529081;0;43;Rio Grande do Sul;8827;54;America/Sao_Paulo
-5107578;Rondol‚ndia;-108376;-614697;0;51;Mato Grosso;1092;66;America/Porto_Velho
-4122602;Rondon;-23412;-527659;0;41;Paran·;7829;44;America/Sao_Paulo
-1506187;Rondon do Par·;-477793;-48067;0;15;Par·;573;94;America/Sao_Paulo
-5107602;RondonÛpolis;-164673;-546372;0;51;Mato Grosso;9151;66;America/Porto_Velho
+5107578;Rondol√¢ndia;-108376;-614697;0;51;Mato Grosso;1092;66;America/Porto_Velho
+4122602;Rondon;-23412;-527659;0;41;Paran√°;7829;44;America/Sao_Paulo
+1506187;Rondon do Par√°;-477793;-48067;0;15;Par√°;573;94;America/Sao_Paulo
+5107602;Rondon√≥polis;-164673;-546372;0;51;Mato Grosso;9151;66;America/Porto_Velho
 4316303;Roque Gonzales;-281297;-550266;0;43;Rio Grande do Sul;8829;55;America/Sao_Paulo
-1400472;RorainÛpolis;939956;-604389;0;14;Roraima;36;95;America/Porto_Velho
-3544251;Rosana;-225782;-530603;0;35;S„o Paulo;7265;18;America/Sao_Paulo
-2109601;Ros·rio;-293444;-442531;0;21;Maranh„o;891;98;America/Sao_Paulo
-3156452;Ros·rio da Limeira;-209812;-425112;0;31;Minas Gerais;698;32;America/Sao_Paulo
-2806107;Ros·rio do Catete;-106904;-370357;0;28;Sergipe;3221;79;America/Sao_Paulo
-4122651;Ros·rio do IvaÌ;-242682;-51272;0;41;Paran·;8473;43;America/Sao_Paulo
-4316402;Ros·rio do Sul;-302515;-549221;0;43;Rio Grande do Sul;8831;55;America/Sao_Paulo
-5107701;Ros·rio Oeste;-148259;-564236;0;51;Mato Grosso;9153;65;America/Porto_Velho
-3544301;Roseira;-228938;-45307;0;35;S„o Paulo;6987;12;America/Sao_Paulo
+1400472;Rorain√≥polis;939956;-604389;0;14;Roraima;36;95;America/Porto_Velho
+3544251;Rosana;-225782;-530603;0;35;S√£o Paulo;7265;18;America/Sao_Paulo
+2109601;Ros√°rio;-293444;-442531;0;21;Maranh√£o;891;98;America/Sao_Paulo
+3156452;Ros√°rio da Limeira;-209812;-425112;0;31;Minas Gerais;698;32;America/Sao_Paulo
+2806107;Ros√°rio do Catete;-106904;-370357;0;28;Sergipe;3221;79;America/Sao_Paulo
+4122651;Ros√°rio do Iva√≠;-242682;-51272;0;41;Paran√°;8473;43;America/Sao_Paulo
+4316402;Ros√°rio do Sul;-302515;-549221;0;43;Rio Grande do Sul;8831;55;America/Sao_Paulo
+5107701;Ros√°rio Oeste;-148259;-564236;0;51;Mato Grosso;9153;65;America/Porto_Velho
+3544301;Roseira;-228938;-45307;0;35;S√£o Paulo;6987;12;America/Sao_Paulo
 2707800;Roteiro;-983503;-359782;0;27;Alagoas;2855;82;America/Sao_Paulo
 3156502;Rubelita;-164053;-42261;0;31;Minas Gerais;5129;38;America/Sao_Paulo
-3544400;Rubi·cea;-213006;-507296;0;35;S„o Paulo;6989;18;America/Sao_Paulo
-5218904;Rubiataba;-151617;-498048;0;52;Goi·s;9573;62;America/Sao_Paulo
+3544400;Rubi√°cea;-213006;-507296;0;35;S√£o Paulo;6989;18;America/Sao_Paulo
+5218904;Rubiataba;-151617;-498048;0;52;Goi√°s;9573;62;America/Sao_Paulo
 3156601;Rubim;-163775;-405397;0;31;Minas Gerais;5131;33;America/Sao_Paulo
-3544509;RubinÈia;-201759;-51007;0;35;S„o Paulo;6991;17;America/Sao_Paulo
-1506195;RurÛpolis;-410028;-549092;0;15;Par·;597;93;America/Sao_Paulo
-2311801;Russas;-492673;-379721;0;23;Cear·;1537;88;America/Sao_Paulo
+3544509;Rubin√©ia;-201759;-51007;0;35;S√£o Paulo;6991;17;America/Sao_Paulo
+1506195;Rur√≥polis;-410028;-549092;0;15;Par√°;597;93;America/Sao_Paulo
+2311801;Russas;-492673;-379721;0;23;Cear√°;1537;88;America/Sao_Paulo
 2411106;Ruy Barbosa;-588745;-35933;0;24;Rio Grande do Norte;1819;84;America/Sao_Paulo
 2927200;Ruy Barbosa;-122816;-404931;0;29;Bahia;3845;75;America/Sao_Paulo
-3156700;Sabar·;-19884;-438263;0;31;Minas Gerais;5133;31;America/Sao_Paulo
-4122701;Sab·udia;-233155;-51555;0;41;Paran·;7831;43;America/Sao_Paulo
-3544608;Sabino;-214593;-495755;0;35;S„o Paulo;6993;14;America/Sao_Paulo
-3156809;SabinÛpolis;-186653;-430752;0;31;Minas Gerais;5135;33;America/Sao_Paulo
-2311900;Saboeiro;-65346;-399017;0;23;Cear·;1539;88;America/Sao_Paulo
+3156700;Sabar√°;-19884;-438263;0;31;Minas Gerais;5133;31;America/Sao_Paulo
+4122701;Sab√°udia;-233155;-51555;0;41;Paran√°;7831;43;America/Sao_Paulo
+3544608;Sabino;-214593;-495755;0;35;S√£o Paulo;6993;14;America/Sao_Paulo
+3156809;Sabin√≥polis;-186653;-430752;0;31;Minas Gerais;5135;33;America/Sao_Paulo
+2311900;Saboeiro;-65346;-399017;0;23;Cear√°;1539;88;America/Sao_Paulo
 3156908;Sacramento;-198622;-474508;0;31;Minas Gerais;5137;34;America/Sao_Paulo
-4316428;Sagrada FamÌlia;-277085;-531351;0;43;Rio Grande do Sul;5987;55;America/Sao_Paulo
-3544707;Sagres;-218823;-509594;0;35;S„o Paulo;6995;18;America/Sao_Paulo
-2612000;SairÈ;-832864;-356967;0;26;Pernambuco;2539;81;America/Sao_Paulo
+4316428;Sagrada Fam√≠lia;-277085;-531351;0;43;Rio Grande do Sul;5987;55;America/Sao_Paulo
+3544707;Sagres;-218823;-509594;0;35;S√£o Paulo;6995;18;America/Sao_Paulo
+2612000;Sair√©;-832864;-356967;0;26;Pernambuco;2539;81;America/Sao_Paulo
 4316436;Saldanha Marinho;-283941;-53097;0;43;Rio Grande do Sul;7339;55;America/Sao_Paulo
-3544806;Sales;-213427;-494897;0;35;S„o Paulo;6997;17;America/Sao_Paulo
-3544905;Sales Oliveira;-207696;-478369;0;35;S„o Paulo;6999;16;America/Sao_Paulo
-3545001;SalesÛpolis;-235288;-458465;0;35;S„o Paulo;7001;11;America/Sao_Paulo
+3544806;Sales;-213427;-494897;0;35;S√£o Paulo;6997;17;America/Sao_Paulo
+3544905;Sales Oliveira;-207696;-478369;0;35;S√£o Paulo;6999;16;America/Sao_Paulo
+3545001;Sales√≥polis;-235288;-458465;0;35;S√£o Paulo;7001;11;America/Sao_Paulo
 4215307;Salete;-269798;-499988;0;42;Santa Catarina;8301;47;America/Sao_Paulo
-2513000;Salgadinho;-710098;-368458;0;25;ParaÌba;2161;83;America/Sao_Paulo
+2513000;Salgadinho;-710098;-368458;0;25;Para√≠ba;2161;83;America/Sao_Paulo
 2612109;Salgadinho;-79269;-356503;0;26;Pernambuco;2541;81;America/Sao_Paulo
 2806206;Salgado;-110288;-374804;0;28;Sergipe;3223;79;America/Sao_Paulo
-2513109;Salgado de S„o FÈlix;-735337;-354305;0;25;ParaÌba;2163;83;America/Sao_Paulo
-4122800;Salgado Filho;-261777;-533631;0;41;Paran·;7833;46;America/Sao_Paulo
+2513109;Salgado de S√£o F√©lix;-735337;-354305;0;25;Para√≠ba;2163;83;America/Sao_Paulo
+4122800;Salgado Filho;-261777;-533631;0;41;Paran√°;7833;46;America/Sao_Paulo
 2612208;Salgueiro;-807373;-391247;0;26;Pernambuco;2543;87;America/Sao_Paulo
 3157005;Salinas;-161753;-422964;0;31;Minas Gerais;5139;38;America/Sao_Paulo
 2927309;Salinas da Margarida;-12873;-387562;0;29;Bahia;3847;75;America/Sao_Paulo
-1506203;SalinÛpolis;-630815;-473465;0;15;Par·;523;91;America/Sao_Paulo
-2311959;Salitre;-728398;-4045;0;23;Cear·;1273;88;America/Sao_Paulo
-3545100;Salmour„o;-216267;-508614;0;35;S„o Paulo;7003;18;America/Sao_Paulo
-2612307;Salo·;-89723;-36691;0;26;Pernambuco;2545;87;America/Sao_Paulo
+1506203;Salin√≥polis;-630815;-473465;0;15;Par√°;523;91;America/Sao_Paulo
+2311959;Salitre;-728398;-4045;0;23;Cear√°;1273;88;America/Sao_Paulo
+3545100;Salmour√£o;-216267;-508614;0;35;S√£o Paulo;7003;18;America/Sao_Paulo
+2612307;Salo√°;-89723;-36691;0;26;Pernambuco;2545;87;America/Sao_Paulo
 4215356;Saltinho;-266049;-530578;0;42;Santa Catarina;936;49;America/Sao_Paulo
-3545159;Saltinho;-228442;-476754;0;35;S„o Paulo;5445;19;America/Sao_Paulo
-3545209;Salto;-231996;-472931;0;35;S„o Paulo;7005;11;America/Sao_Paulo
+3545159;Saltinho;-228442;-476754;0;35;S√£o Paulo;5445;19;America/Sao_Paulo
+3545209;Salto;-231996;-472931;0;35;S√£o Paulo;7005;11;America/Sao_Paulo
 3157104;Salto da Divisa;-160063;-399391;0;31;Minas Gerais;5141;33;America/Sao_Paulo
-3545308;Salto de Pirapora;-236474;-475743;0;35;S„o Paulo;7007;15;America/Sao_Paulo
-5107750;Salto do CÈu;-151303;-581317;0;51;Mato Grosso;8997;65;America/Porto_Velho
-4122909;Salto do ItararÈ;-236074;-496354;0;41;Paran·;7835;43;America/Sao_Paulo
-4316451;Salto do JacuÌ;-290951;-532133;0;43;Rio Grande do Sul;8975;55;America/Sao_Paulo
-4123006;Salto do Lontra;-257813;-533135;0;41;Paran·;7837;46;America/Sao_Paulo
-3545407;Salto Grande;-228894;-499831;0;35;S„o Paulo;7009;14;America/Sao_Paulo
+3545308;Salto de Pirapora;-236474;-475743;0;35;S√£o Paulo;7007;15;America/Sao_Paulo
+5107750;Salto do C√©u;-151303;-581317;0;51;Mato Grosso;8997;65;America/Porto_Velho
+4122909;Salto do Itarar√©;-236074;-496354;0;41;Paran√°;7835;43;America/Sao_Paulo
+4316451;Salto do Jacu√≠;-290951;-532133;0;43;Rio Grande do Sul;8975;55;America/Sao_Paulo
+4123006;Salto do Lontra;-257813;-533135;0;41;Paran√°;7837;46;America/Sao_Paulo
+3545407;Salto Grande;-228894;-499831;0;35;S√£o Paulo;7009;14;America/Sao_Paulo
 4215406;Salto Veloso;-26903;-514043;0;42;Santa Catarina;8303;49;America/Sao_Paulo
 2927408;Salvador;-129718;-385011;1;29;Bahia;3849;71;America/Sao_Paulo
-4316477;Salvador das Missıes;-281233;-548373;0;43;Rio Grande do Sul;6061;55;America/Sao_Paulo
+4316477;Salvador das Miss√µes;-281233;-548373;0;43;Rio Grande do Sul;6061;55;America/Sao_Paulo
 4316501;Salvador do Sul;-294386;-515077;0;43;Rio Grande do Sul;8833;51;America/Sao_Paulo
-1506302;Salvaterra;-758444;-485139;0;15;Par·;525;91;America/Sao_Paulo
-2109700;SambaÌba;-713447;-453515;0;21;Maranh„o;893;99;America/Sao_Paulo
+1506302;Salvaterra;-758444;-485139;0;15;Par√°;525;91;America/Sao_Paulo
+2109700;Samba√≠ba;-713447;-453515;0;21;Maranh√£o;893;99;America/Sao_Paulo
 1718808;Sampaio;-535423;-478782;0;17;Tocantins;9727;63;America/Sao_Paulo
 4316600;Sananduva;-27947;-518079;0;43;Rio Grande do Sul;8835;54;America/Sao_Paulo
-5219001;Sanclerl‚ndia;-16197;-503124;0;52;Goi·s;9575;64;America/Sao_Paulo
-1718840;Sandol‚ndia;-12538;-499242;0;17;Tocantins;331;63;America/Sao_Paulo
-3545506;Sandovalina;-224551;-517648;0;35;S„o Paulo;7011;18;America/Sao_Paulo
-4215455;Sang„o;-286326;-491322;0;42;Santa Catarina;5547;48;America/Sao_Paulo
-2612406;SanharÛ;-836097;-365696;0;26;Pernambuco;2547;87;America/Sao_Paulo
+5219001;Sanclerl√¢ndia;-16197;-503124;0;52;Goi√°s;9575;64;America/Sao_Paulo
+1718840;Sandol√¢ndia;-12538;-499242;0;17;Tocantins;331;63;America/Sao_Paulo
+3545506;Sandovalina;-224551;-517648;0;35;S√£o Paulo;7011;18;America/Sao_Paulo
+4215455;Sang√£o;-286326;-491322;0;42;Santa Catarina;5547;48;America/Sao_Paulo
+2612406;Sanhar√≥;-836097;-365696;0;26;Pernambuco;2547;87;America/Sao_Paulo
 4317103;Sant'Ana do Livramento;-308773;-555392;0;43;Rio Grande do Sul;8845;55;America/Sao_Paulo
-3545605;Santa AdÈlia;-212427;-488063;0;35;S„o Paulo;7013;17;America/Sao_Paulo
-3545704;Santa Albertina;-200311;-507297;0;35;S„o Paulo;7015;17;America/Sao_Paulo
-4123105;Santa AmÈlia;-232654;-504288;0;41;Paran·;7839;43;America/Sao_Paulo
-2927507;Santa B·rbara;-119515;-389681;0;29;Bahia;3851;75;America/Sao_Paulo
-3157203;Santa B·rbara;-199604;-434101;0;31;Minas Gerais;5143;31;America/Sao_Paulo
-3545803;Santa B·rbara d'Oeste;-227553;-474143;0;35;S„o Paulo;7017;19;America/Sao_Paulo
-5219100;Santa B·rbara de Goi·s;-165714;-496954;0;52;Goi·s;9577;62;America/Sao_Paulo
-3157252;Santa B·rbara do Leste;-199753;-421457;0;31;Minas Gerais;2667;33;America/Sao_Paulo
-3157278;Santa B·rbara do Monte Verde;-219592;-437027;0;31;Minas Gerais;700;32;America/Sao_Paulo
-1506351;Santa B·rbara do Par·;-119219;-48238;0;15;Par·;369;91;America/Sao_Paulo
-4316709;Santa B·rbara do Sul;-283653;-53251;0;43;Rio Grande do Sul;8837;55;America/Sao_Paulo
-3157302;Santa B·rbara do Tug˙rio;-212431;-435607;0;31;Minas Gerais;5145;32;America/Sao_Paulo
-3546009;Santa Branca;-233933;-458875;0;35;S„o Paulo;7021;12;America/Sao_Paulo
-2927606;Santa BrÌgida;-973227;-381209;0;29;Bahia;3853;75;America/Sao_Paulo
+3545605;Santa Ad√©lia;-212427;-488063;0;35;S√£o Paulo;7013;17;America/Sao_Paulo
+3545704;Santa Albertina;-200311;-507297;0;35;S√£o Paulo;7015;17;America/Sao_Paulo
+4123105;Santa Am√©lia;-232654;-504288;0;41;Paran√°;7839;43;America/Sao_Paulo
+2927507;Santa B√°rbara;-119515;-389681;0;29;Bahia;3851;75;America/Sao_Paulo
+3157203;Santa B√°rbara;-199604;-434101;0;31;Minas Gerais;5143;31;America/Sao_Paulo
+3545803;Santa B√°rbara d'Oeste;-227553;-474143;0;35;S√£o Paulo;7017;19;America/Sao_Paulo
+5219100;Santa B√°rbara de Goi√°s;-165714;-496954;0;52;Goi√°s;9577;62;America/Sao_Paulo
+3157252;Santa B√°rbara do Leste;-199753;-421457;0;31;Minas Gerais;2667;33;America/Sao_Paulo
+3157278;Santa B√°rbara do Monte Verde;-219592;-437027;0;31;Minas Gerais;700;32;America/Sao_Paulo
+1506351;Santa B√°rbara do Par√°;-119219;-48238;0;15;Par√°;369;91;America/Sao_Paulo
+4316709;Santa B√°rbara do Sul;-283653;-53251;0;43;Rio Grande do Sul;8837;55;America/Sao_Paulo
+3157302;Santa B√°rbara do Tug√∫rio;-212431;-435607;0;31;Minas Gerais;5145;32;America/Sao_Paulo
+3546009;Santa Branca;-233933;-458875;0;35;S√£o Paulo;7021;12;America/Sao_Paulo
+2927606;Santa Br√≠gida;-973227;-381209;0;29;Bahia;3853;75;America/Sao_Paulo
 5107248;Santa Carmem;-119125;-552263;0;51;Mato Grosso;123;66;America/Porto_Velho
-4215505;Santa CecÌlia;-269592;-504252;0;42;Santa Catarina;8305;49;America/Sao_Paulo
-2513158;Santa CecÌlia;-77389;-358764;0;25;ParaÌba;510;83;America/Sao_Paulo
-4123204;Santa CecÌlia do Pav„o;-235201;-507835;0;41;Paran·;7841;43;America/Sao_Paulo
-4316733;Santa CecÌlia do Sul;-281609;-519279;0;43;Rio Grande do Sul;1166;54;America/Sao_Paulo
-3546108;Santa Clara d'Oeste;-2009;-509491;0;35;S„o Paulo;7023;17;America/Sao_Paulo
+4215505;Santa Cec√≠lia;-269592;-504252;0;42;Santa Catarina;8305;49;America/Sao_Paulo
+2513158;Santa Cec√≠lia;-77389;-358764;0;25;Para√≠ba;510;83;America/Sao_Paulo
+4123204;Santa Cec√≠lia do Pav√£o;-235201;-507835;0;41;Paran√°;7841;43;America/Sao_Paulo
+4316733;Santa Cec√≠lia do Sul;-281609;-519279;0;43;Rio Grande do Sul;1166;54;America/Sao_Paulo
+3546108;Santa Clara d'Oeste;-2009;-509491;0;35;S√£o Paulo;7023;17;America/Sao_Paulo
 4316758;Santa Clara do Sul;-294747;-520843;0;43;Rio Grande do Sul;6033;51;America/Sao_Paulo
 2411205;Santa Cruz;-622475;-360193;0;24;Rio Grande do Norte;1823;84;America/Sao_Paulo
-2513208;Santa Cruz;-65237;-380617;0;25;ParaÌba;2165;83;America/Sao_Paulo
+2513208;Santa Cruz;-65237;-380617;0;25;Para√≠ba;2165;83;America/Sao_Paulo
 2612455;Santa Cruz;-824153;-403434;0;26;Pernambuco;2297;87;America/Sao_Paulo
-2927705;Santa Cruz Cabr·lia;-162825;-390295;0;29;Bahia;3855;73;America/Sao_Paulo
+2927705;Santa Cruz Cabr√°lia;-162825;-390295;0;29;Bahia;3855;73;America/Sao_Paulo
 2612471;Santa Cruz da Baixa Verde;-781339;-381476;0;26;Pernambuco;2639;87;America/Sao_Paulo
-3546207;Santa Cruz da ConceiÁ„o;-221405;-474512;0;35;S„o Paulo;7025;19;America/Sao_Paulo
-3546256;Santa Cruz da EsperanÁa;-212951;-474304;0;35;S„o Paulo;820;16;America/Sao_Paulo
-2927804;Santa Cruz da VitÛria;-14964;-398115;0;29;Bahia;3857;73;America/Sao_Paulo
-3546306;Santa Cruz das Palmeiras;-218235;-47248;0;35;S„o Paulo;7027;19;America/Sao_Paulo
-5219209;Santa Cruz de Goi·s;-173155;-484809;0;52;Goi·s;9579;64;America/Sao_Paulo
+3546207;Santa Cruz da Concei√ß√£o;-221405;-474512;0;35;S√£o Paulo;7025;19;America/Sao_Paulo
+3546256;Santa Cruz da Esperan√ßa;-212951;-474304;0;35;S√£o Paulo;820;16;America/Sao_Paulo
+2927804;Santa Cruz da Vit√≥ria;-14964;-398115;0;29;Bahia;3857;73;America/Sao_Paulo
+3546306;Santa Cruz das Palmeiras;-218235;-47248;0;35;S√£o Paulo;7027;19;America/Sao_Paulo
+5219209;Santa Cruz de Goi√°s;-173155;-484809;0;52;Goi√°s;9579;64;America/Sao_Paulo
 3157336;Santa Cruz de Minas;-211241;-442202;0;31;Minas Gerais;702;32;America/Sao_Paulo
-4123303;Santa Cruz de Monte Castelo;-229582;-532949;0;41;Paran·;7843;44;America/Sao_Paulo
+4123303;Santa Cruz de Monte Castelo;-229582;-532949;0;41;Paran√°;7843;44;America/Sao_Paulo
 3157377;Santa Cruz de Salinas;-160967;-417418;0;31;Minas Gerais;704;38;America/Sao_Paulo
-1506401;Santa Cruz do Arari;-661019;-491771;0;15;Par·;527;91;America/Sao_Paulo
+1506401;Santa Cruz do Arari;-661019;-491771;0;15;Par√°;527;91;America/Sao_Paulo
 2612505;Santa Cruz do Capibaribe;-794802;-362061;0;26;Pernambuco;2549;81;America/Sao_Paulo
 3157401;Santa Cruz do Escalvado;-202372;-428169;0;31;Minas Gerais;5147;31;America/Sao_Paulo
-2209104;Santa Cruz do PiauÌ;-71785;-417609;0;22;PiauÌ;1181;89;America/Sao_Paulo
-3546405;Santa Cruz do Rio Pardo;-228988;-496354;0;35;S„o Paulo;7029;14;America/Sao_Paulo
+2209104;Santa Cruz do Piau√≠;-71785;-417609;0;22;Piau√≠;1181;89;America/Sao_Paulo
+3546405;Santa Cruz do Rio Pardo;-228988;-496354;0;35;S√£o Paulo;7029;14;America/Sao_Paulo
 4316808;Santa Cruz do Sul;-29722;-524343;0;43;Rio Grande do Sul;8839;51;America/Sao_Paulo
 5107743;Santa Cruz do Xingu;-101532;-523953;0;51;Mato Grosso;1094;66;America/Porto_Velho
-2209153;Santa Cruz dos Milagres;-580581;-419506;0;22;PiauÌ;1295;89;America/Sao_Paulo
-3157500;Santa EfigÍnia de Minas;-188235;-424388;0;31;Minas Gerais;5149;33;America/Sao_Paulo
-3546504;Santa Ernestina;-214618;-483953;0;35;S„o Paulo;7031;16;America/Sao_Paulo
-4123402;Santa FÈ;-2304;-51808;0;41;Paran·;7845;44;America/Sao_Paulo
-5219258;Santa FÈ de Goi·s;-157664;-511037;0;52;Goi·s;9743;62;America/Sao_Paulo
-3157609;Santa FÈ de Minas;-166859;-454102;0;31;Minas Gerais;5151;38;America/Sao_Paulo
-1718865;Santa FÈ do Araguaia;-715803;-487165;0;17;Tocantins;195;63;America/Sao_Paulo
-3546603;Santa FÈ do Sul;-202083;-50932;0;35;S„o Paulo;7033;17;America/Sao_Paulo
-2209203;Santa Filomena;-911228;-459116;0;22;PiauÌ;1183;89;America/Sao_Paulo
+2209153;Santa Cruz dos Milagres;-580581;-419506;0;22;Piau√≠;1295;89;America/Sao_Paulo
+3157500;Santa Efig√™nia de Minas;-188235;-424388;0;31;Minas Gerais;5149;33;America/Sao_Paulo
+3546504;Santa Ernestina;-214618;-483953;0;35;S√£o Paulo;7031;16;America/Sao_Paulo
+4123402;Santa F√©;-2304;-51808;0;41;Paran√°;7845;44;America/Sao_Paulo
+5219258;Santa F√© de Goi√°s;-157664;-511037;0;52;Goi√°s;9743;62;America/Sao_Paulo
+3157609;Santa F√© de Minas;-166859;-454102;0;31;Minas Gerais;5151;38;America/Sao_Paulo
+1718865;Santa F√© do Araguaia;-715803;-487165;0;17;Tocantins;195;63;America/Sao_Paulo
+3546603;Santa F√© do Sul;-202083;-50932;0;35;S√£o Paulo;7033;17;America/Sao_Paulo
+2209203;Santa Filomena;-911228;-459116;0;22;Piau√≠;1183;89;America/Sao_Paulo
 2612554;Santa Filomena;-816688;-406079;0;26;Pernambuco;556;87;America/Sao_Paulo
-2109759;Santa Filomena do Maranh„o;-549671;-445638;0;21;Maranh„o;222;99;America/Sao_Paulo
-3546702;Santa Gertrudes;-224572;-475272;0;35;S„o Paulo;7035;19;America/Sao_Paulo
-4123501;Santa Helena;-248585;-54336;0;41;Paran·;7971;45;America/Sao_Paulo
+2109759;Santa Filomena do Maranh√£o;-549671;-445638;0;21;Maranh√£o;222;99;America/Sao_Paulo
+3546702;Santa Gertrudes;-224572;-475272;0;35;S√£o Paulo;7035;19;America/Sao_Paulo
+4123501;Santa Helena;-248585;-54336;0;41;Paran√°;7971;45;America/Sao_Paulo
 4215554;Santa Helena;-26937;-536214;0;42;Santa Catarina;5751;49;America/Sao_Paulo
-2109809;Santa Helena;-224426;-4529;0;21;Maranh„o;895;98;America/Sao_Paulo
-2513307;Santa Helena;-67176;-386427;0;25;ParaÌba;2167;83;America/Sao_Paulo
-5219308;Santa Helena de Goi·s;-178115;-505977;0;52;Goi·s;9581;64;America/Sao_Paulo
+2109809;Santa Helena;-224426;-4529;0;21;Maranh√£o;895;98;America/Sao_Paulo
+2513307;Santa Helena;-67176;-386427;0;25;Para√≠ba;2167;83;America/Sao_Paulo
+5219308;Santa Helena de Goi√°s;-178115;-505977;0;52;Goi√°s;9581;64;America/Sao_Paulo
 3157658;Santa Helena de Minas;-169707;-406727;0;31;Minas Gerais;706;33;America/Sao_Paulo
-2927903;Santa InÍs;-132793;-39814;0;29;Bahia;3859;73;America/Sao_Paulo
-4123600;Santa InÍs;-226376;-519024;0;41;Paran·;7847;44;America/Sao_Paulo
-2513356;Santa InÍs;-7621;-38554;0;25;ParaÌba;512;83;America/Sao_Paulo
-2109908;Santa InÍs;-365112;-453774;0;21;Maranh„o;957;98;America/Sao_Paulo
-3546801;Santa Isabel;-233172;-462237;0;35;S„o Paulo;7037;11;America/Sao_Paulo
-5219357;Santa Isabel;-152958;-494259;0;52;Goi·s;9689;62;America/Sao_Paulo
-4123709;Santa Isabel do IvaÌ;-230025;-531989;0;41;Paran·;7849;44;America/Sao_Paulo
+2927903;Santa In√™s;-132793;-39814;0;29;Bahia;3859;73;America/Sao_Paulo
+4123600;Santa In√™s;-226376;-519024;0;41;Paran√°;7847;44;America/Sao_Paulo
+2513356;Santa In√™s;-7621;-38554;0;25;Para√≠ba;512;83;America/Sao_Paulo
+2109908;Santa In√™s;-365112;-453774;0;21;Maranh√£o;957;98;America/Sao_Paulo
+3546801;Santa Isabel;-233172;-462237;0;35;S√£o Paulo;7037;11;America/Sao_Paulo
+5219357;Santa Isabel;-152958;-494259;0;52;Goi√°s;9689;62;America/Sao_Paulo
+4123709;Santa Isabel do Iva√≠;-230025;-531989;0;41;Paran√°;7849;44;America/Sao_Paulo
 1303601;Santa Isabel do Rio Negro;-410824;-650092;0;13;Amazonas;237;97;America/Porto_Velho
-4123808;Santa Izabel do Oeste;-258217;-534801;0;41;Paran·;7851;46;America/Sao_Paulo
-1506500;Santa Izabel do Par·;-129686;-481606;0;15;Par·;529;91;America/Sao_Paulo
+4123808;Santa Izabel do Oeste;-258217;-534801;0;41;Paran√°;7851;46;America/Sao_Paulo
+1506500;Santa Izabel do Par√°;-129686;-481606;0;15;Par√°;529;91;America/Sao_Paulo
 3157708;Santa Juliana;-193108;-475322;0;31;Minas Gerais;5153;34;America/Sao_Paulo
-3204500;Santa Leopoldina;-200999;-40527;0;32;EspÌrito Santo;5689;27;America/Sao_Paulo
-3546900;Santa L˙cia;-21685;-480885;0;35;S„o Paulo;7039;16;America/Sao_Paulo
-4123824;Santa L˙cia;-254104;-535638;0;41;Paran·;5469;45;America/Sao_Paulo
-2209302;Santa Luz;-89488;-441296;0;22;PiauÌ;1185;89;America/Sao_Paulo
-2110005;Santa Luzia;-406873;-4569;0;21;Maranh„o;897;98;America/Sao_Paulo
+3204500;Santa Leopoldina;-200999;-40527;0;32;Esp√≠rito Santo;5689;27;America/Sao_Paulo
+3546900;Santa L√∫cia;-21685;-480885;0;35;S√£o Paulo;7039;16;America/Sao_Paulo
+4123824;Santa L√∫cia;-254104;-535638;0;41;Paran√°;5469;45;America/Sao_Paulo
+2209302;Santa Luz;-89488;-441296;0;22;Piau√≠;1185;89;America/Sao_Paulo
+2110005;Santa Luzia;-406873;-4569;0;21;Maranh√£o;897;98;America/Sao_Paulo
 2928059;Santa Luzia;-154342;-393287;0;29;Bahia;3987;73;America/Sao_Paulo
 3157807;Santa Luzia;-197548;-438497;0;31;Minas Gerais;5155;31;America/Sao_Paulo
-2513406;Santa Luzia;-686092;-369178;0;25;ParaÌba;2169;83;America/Sao_Paulo
-1100296;Santa Luzia D'Oeste;-119074;-617777;0;11;RondÙnia;43;69;America/Porto_Velho
+2513406;Santa Luzia;-686092;-369178;0;25;Para√≠ba;2169;83;America/Sao_Paulo
+1100296;Santa Luzia D'Oeste;-119074;-617777;0;11;Rond√¥nia;43;69;America/Porto_Velho
 2806305;Santa Luzia do Itanhy;-113536;-374586;0;28;Sergipe;3225;79;America/Sao_Paulo
 2707909;Santa Luzia do Norte;-96037;-358232;0;27;Alagoas;2857;82;America/Sao_Paulo
-1506559;Santa Luzia do Par·;-152147;-469008;0;15;Par·;371;91;America/Sao_Paulo
-2110039;Santa Luzia do Paru·;-251123;-457801;0;21;Maranh„o;1285;98;America/Sao_Paulo
+1506559;Santa Luzia do Par√°;-152147;-469008;0;15;Par√°;371;91;America/Sao_Paulo
+2110039;Santa Luzia do Paru√°;-251123;-457801;0;21;Maranh√£o;1285;98;America/Sao_Paulo
 3157906;Santa Margarida;-203839;-422519;0;31;Minas Gerais;5157;31;America/Sao_Paulo
 4316972;Santa Margarida do Sul;-303393;-540817;0;43;Rio Grande do Sul;1168;55;America/Sao_Paulo
 4316907;Santa Maria;-296868;-538149;0;43;Rio Grande do Sul;8841;55;America/Sao_Paulo
 2409332;Santa Maria;-583802;-356914;0;24;Rio Grande do Norte;424;84;America/Sao_Paulo
 2612604;Santa Maria da Boa Vista;-879766;-398241;0;26;Pernambuco;2551;87;America/Sao_Paulo
-3547007;Santa Maria da Serra;-225661;-481593;0;35;S„o Paulo;7041;19;America/Sao_Paulo
-2928109;Santa Maria da VitÛria;-133859;-442011;0;29;Bahia;3863;77;America/Sao_Paulo
-1506583;Santa Maria das Barreiras;-885784;-497215;0;15;Par·;599;94;America/Sao_Paulo
+3547007;Santa Maria da Serra;-225661;-481593;0;35;S√£o Paulo;7041;19;America/Sao_Paulo
+2928109;Santa Maria da Vit√≥ria;-133859;-442011;0;29;Bahia;3863;77;America/Sao_Paulo
+1506583;Santa Maria das Barreiras;-885784;-497215;0;15;Par√°;599;94;America/Sao_Paulo
 3158003;Santa Maria de Itabira;-194431;-431064;0;31;Minas Gerais;5159;31;America/Sao_Paulo
-3204559;Santa Maria de Jetib·;-200253;-407439;0;32;EspÌrito Santo;5725;27;America/Sao_Paulo
-2612703;Santa Maria do Cambuc·;-783676;-358941;0;26;Pernambuco;2553;81;America/Sao_Paulo
+3204559;Santa Maria de Jetib√°;-200253;-407439;0;32;Esp√≠rito Santo;5725;27;America/Sao_Paulo
+2612703;Santa Maria do Cambuc√°;-783676;-358941;0;26;Pernambuco;2553;81;America/Sao_Paulo
 4316956;Santa Maria do Herval;-294902;-509919;0;43;Rio Grande do Sul;7337;51;America/Sao_Paulo
-4123857;Santa Maria do Oeste;-249377;-518696;0;41;Paran·;5505;42;America/Sao_Paulo
-1506609;Santa Maria do Par·;-135392;-475712;0;15;Par·;531;91;America/Sao_Paulo
+4123857;Santa Maria do Oeste;-249377;-518696;0;41;Paran√°;5505;42;America/Sao_Paulo
+1506609;Santa Maria do Par√°;-135392;-475712;0;15;Par√°;531;91;America/Sao_Paulo
 3158102;Santa Maria do Salto;-162479;-401512;0;31;Minas Gerais;5161;33;America/Sao_Paulo
-3158201;Santa Maria do SuaÁuÌ;-181896;-424139;0;31;Minas Gerais;5163;33;America/Sao_Paulo
+3158201;Santa Maria do Sua√ßu√≠;-181896;-424139;0;31;Minas Gerais;5163;33;America/Sao_Paulo
 1718881;Santa Maria do Tocantins;-88046;-477887;0;17;Tocantins;361;63;America/Sao_Paulo
 3304607;Santa Maria Madalena;-219547;-420098;0;33;Rio de Janeiro;5891;22;America/Sao_Paulo
-4123907;Santa Mariana;-231465;-505167;0;41;Paran·;7853;43;America/Sao_Paulo
-3547106;Santa Mercedes;-213495;-517564;0;35;S„o Paulo;7043;18;America/Sao_Paulo
-4123956;Santa MÙnica;-23108;-531103;0;41;Paran·;5519;44;America/Sao_Paulo
-2312205;Santa QuitÈria;-432608;-401523;0;23;Cear·;1545;88;America/Sao_Paulo
-2110104;Santa QuitÈria do Maranh„o;-349308;-425688;0;21;Maranh„o;899;98;America/Sao_Paulo
-2110203;Santa Rita;-314241;-443211;0;21;Maranh„o;901;98;America/Sao_Paulo
-2513703;Santa Rita;-711724;-349753;0;25;ParaÌba;2175;83;America/Sao_Paulo
-3547403;Santa Rita d'Oeste;-201414;-508358;0;35;S„o Paulo;7049;17;America/Sao_Paulo
+4123907;Santa Mariana;-231465;-505167;0;41;Paran√°;7853;43;America/Sao_Paulo
+3547106;Santa Mercedes;-213495;-517564;0;35;S√£o Paulo;7043;18;America/Sao_Paulo
+4123956;Santa M√¥nica;-23108;-531103;0;41;Paran√°;5519;44;America/Sao_Paulo
+2312205;Santa Quit√©ria;-432608;-401523;0;23;Cear√°;1545;88;America/Sao_Paulo
+2110104;Santa Quit√©ria do Maranh√£o;-349308;-425688;0;21;Maranh√£o;899;98;America/Sao_Paulo
+2110203;Santa Rita;-314241;-443211;0;21;Maranh√£o;901;98;America/Sao_Paulo
+2513703;Santa Rita;-711724;-349753;0;25;Para√≠ba;2175;83;America/Sao_Paulo
+3547403;Santa Rita d'Oeste;-201414;-508358;0;35;S√£o Paulo;7049;17;America/Sao_Paulo
 3159209;Santa Rita de Caldas;-220292;-463385;0;31;Minas Gerais;5183;35;America/Sao_Paulo
-2928406;Santa Rita de C·ssia;-110063;-445255;0;29;Bahia;3549;77;America/Sao_Paulo
+2928406;Santa Rita de C√°ssia;-110063;-445255;0;29;Bahia;3549;77;America/Sao_Paulo
 3159407;Santa Rita de Ibitipoca;-215658;-439163;0;31;Minas Gerais;5187;32;America/Sao_Paulo
 3159308;Santa Rita de Jacutinga;-221474;-440977;0;31;Minas Gerais;5185;32;America/Sao_Paulo
 3159357;Santa Rita de Minas;-19876;-421363;0;31;Minas Gerais;2669;33;America/Sao_Paulo
-5219407;Santa Rita do Araguaia;-173269;-532012;0;52;Goi·s;9583;64;America/Sao_Paulo
+5219407;Santa Rita do Araguaia;-173269;-532012;0;52;Goi√°s;9583;64;America/Sao_Paulo
 3159506;Santa Rita do Itueto;-193576;-413821;0;31;Minas Gerais;5189;33;America/Sao_Paulo
-5219456;Santa Rita do Novo Destino;-151351;-491203;0;52;Goi·s;1062;62;America/Sao_Paulo
+5219456;Santa Rita do Novo Destino;-151351;-491203;0;52;Goi√°s;1062;62;America/Sao_Paulo
 5007554;Santa Rita do Pardo;-213016;-528333;0;50;Mato Grosso do Sul;9745;67;America/Porto_Velho
-3547502;Santa Rita do Passa Quatro;-217083;-47478;0;35;S„o Paulo;7051;19;America/Sao_Paulo
-3159605;Santa Rita do SapucaÌ;-222461;-457034;0;31;Minas Gerais;5191;35;America/Sao_Paulo
+3547502;Santa Rita do Passa Quatro;-217083;-47478;0;35;S√£o Paulo;7051;19;America/Sao_Paulo
+3159605;Santa Rita do Sapuca√≠;-222461;-457034;0;31;Minas Gerais;5191;35;America/Sao_Paulo
 1718899;Santa Rita do Tocantins;-108617;-489161;0;17;Tocantins;96;63;America/Sao_Paulo
 5107768;Santa Rita do Trivelato;-138146;-552706;0;51;Mato Grosso;1096;65;America/Porto_Velho
 4317202;Santa Rosa;-278702;-544796;0;43;Rio Grande do Sul;8847;55;America/Sao_Paulo
 3159704;Santa Rosa da Serra;-195186;-459611;0;31;Minas Gerais;5193;34;America/Sao_Paulo
-5219506;Santa Rosa de Goi·s;-16084;-494953;0;52;Goi·s;9585;62;America/Sao_Paulo
+5219506;Santa Rosa de Goi√°s;-16084;-494953;0;52;Goi√°s;9585;62;America/Sao_Paulo
 4215604;Santa Rosa de Lima;-280331;-49133;0;42;Santa Catarina;8307;48;America/Sao_Paulo
 2806503;Santa Rosa de Lima;-106434;-371931;0;28;Sergipe;3229;79;America/Sao_Paulo
-3547601;Santa Rosa de Viterbo;-214776;-473622;0;35;S„o Paulo;7053;16;America/Sao_Paulo
-2209377;Santa Rosa do PiauÌ;-679581;-422814;0;22;PiauÌ;2261;89;America/Sao_Paulo
+3547601;Santa Rosa de Viterbo;-214776;-473622;0;35;S√£o Paulo;7053;16;America/Sao_Paulo
+2209377;Santa Rosa do Piau√≠;-679581;-422814;0;22;Piau√≠;2261;89;America/Sao_Paulo
 1200435;Santa Rosa do Purus;-944652;-704902;0;12;Acre;661;68;America/Rio_Branco
 4215653;Santa Rosa do Sul;-291313;-497109;0;42;Santa Catarina;9967;48;America/Sao_Paulo
 1718907;Santa Rosa do Tocantins;-114474;-481216;0;17;Tocantins;9729;63;America/Sao_Paulo
-3547650;Santa Salete;-202429;-506887;0;35;S„o Paulo;822;17;America/Sao_Paulo
-3204609;Santa Teresa;-199363;-405979;0;32;EspÌrito Santo;5691;27;America/Sao_Paulo
+3547650;Santa Salete;-202429;-506887;0;35;S√£o Paulo;822;17;America/Sao_Paulo
+3204609;Santa Teresa;-199363;-405979;0;32;Esp√≠rito Santo;5691;27;America/Sao_Paulo
 2928505;Santa Teresinha;-127697;-395215;0;29;Bahia;3869;75;America/Sao_Paulo
-2513802;Santa Teresinha;-707964;-374435;0;25;ParaÌba;2177;83;America/Sao_Paulo
+2513802;Santa Teresinha;-707964;-374435;0;25;Para√≠ba;2177;83;America/Sao_Paulo
 4317251;Santa Tereza;-291655;-517351;0;43;Rio Grande do Sul;5995;54;America/Sao_Paulo
-5219605;Santa Tereza de Goi·s;-137138;-490144;0;52;Goi·s;9587;62;America/Sao_Paulo
-4124020;Santa Tereza do Oeste;-250543;-536274;0;41;Paran·;9969;45;America/Sao_Paulo
+5219605;Santa Tereza de Goi√°s;-137138;-490144;0;52;Goi√°s;9587;62;America/Sao_Paulo
+4124020;Santa Tereza do Oeste;-250543;-536274;0;41;Paran√°;9969;45;America/Sao_Paulo
 1719004;Santa Tereza do Tocantins;-102746;-478033;0;17;Tocantins;9731;63;America/Sao_Paulo
 4215679;Santa Terezinha;-267813;-50009;0;42;Santa Catarina;5555;47;America/Sao_Paulo
 5107776;Santa Terezinha;-104704;-50514;0;51;Mato Grosso;9197;66;America/Porto_Velho
 2612802;Santa Terezinha;-737696;-374787;0;26;Pernambuco;2555;87;America/Sao_Paulo
-5219704;Santa Terezinha de Goi·s;-144326;-497091;0;52;Goi·s;9589;62;America/Sao_Paulo
-4124053;Santa Terezinha de Itaipu;-254391;-54402;0;41;Paran·;8467;45;America/Sao_Paulo
+5219704;Santa Terezinha de Goi√°s;-144326;-497091;0;52;Goi√°s;9589;62;America/Sao_Paulo
+4124053;Santa Terezinha de Itaipu;-254391;-54402;0;41;Paran√°;8467;45;America/Sao_Paulo
 4215687;Santa Terezinha do Progresso;-26624;-531997;0;42;Santa Catarina;938;49;America/Sao_Paulo
 1720002;Santa Terezinha do Tocantins;-644438;-476684;0;17;Tocantins;98;63;America/Sao_Paulo
-3159803;Santa VitÛria;-188414;-501208;0;31;Minas Gerais;5195;34;America/Sao_Paulo
-4317301;Santa VitÛria do Palmar;-33525;-533717;0;43;Rio Grande do Sul;8849;53;America/Sao_Paulo
+3159803;Santa Vit√≥ria;-188414;-501208;0;31;Minas Gerais;5195;34;America/Sao_Paulo
+4317301;Santa Vit√≥ria do Palmar;-33525;-533717;0;43;Rio Grande do Sul;8849;53;America/Sao_Paulo
 2928000;Santaluz;-112508;-39375;0;29;Bahia;3861;75;America/Sao_Paulo
 2928208;Santana;-129792;-440506;0;29;Bahia;3865;77;America/Sao_Paulo
-1600600;Santana;-45434;-511729;0;16;Amap·;615;96;America/Sao_Paulo
+1600600;Santana;-45434;-511729;0;16;Amap√°;615;96;America/Sao_Paulo
 4317004;Santana da Boa Vista;-308697;-5311;0;43;Rio Grande do Sul;8843;53;America/Sao_Paulo
-3547205;Santana da Ponte Pensa;-202523;-508014;0;35;S„o Paulo;7045;17;America/Sao_Paulo
+3547205;Santana da Ponte Pensa;-202523;-508014;0;35;S√£o Paulo;7045;17;America/Sao_Paulo
 3158300;Santana da Vargem;-212449;-455005;0;31;Minas Gerais;5165;35;America/Sao_Paulo
 3158409;Santana de Cataguases;-212893;-425524;0;31;Minas Gerais;5167;32;America/Sao_Paulo
-2513505;Santana de Mangueira;-754705;-383236;0;25;ParaÌba;2171;83;America/Sao_Paulo
-3547304;Santana de ParnaÌba;-234439;-469178;0;35;S„o Paulo;7047;11;America/Sao_Paulo
+2513505;Santana de Mangueira;-754705;-383236;0;25;Para√≠ba;2171;83;America/Sao_Paulo
+3547304;Santana de Parna√≠ba;-234439;-469178;0;35;S√£o Paulo;7047;11;America/Sao_Paulo
 3158508;Santana de Pirapama;-189962;-440409;0;31;Minas Gerais;5169;31;America/Sao_Paulo
-2312007;Santana do Acara˙;-346144;-402118;0;23;Cear·;1541;88;America/Sao_Paulo
-1506708;Santana do Araguaia;-93281;-5035;0;15;Par·;533;94;America/Sao_Paulo
-2312106;Santana do Cariri;-717613;-397302;0;23;Cear·;1543;88;America/Sao_Paulo
+2312007;Santana do Acara√∫;-346144;-402118;0;23;Cear√°;1541;88;America/Sao_Paulo
+1506708;Santana do Araguaia;-93281;-5035;0;15;Par√°;533;94;America/Sao_Paulo
+2312106;Santana do Cariri;-717613;-397302;0;23;Cear√°;1543;88;America/Sao_Paulo
 3158607;Santana do Deserto;-219512;-431583;0;31;Minas Gerais;5171;32;America/Sao_Paulo
-3158706;Santana do GarambÈu;-215983;-44105;0;31;Minas Gerais;5173;32;America/Sao_Paulo
+3158706;Santana do Garamb√©u;-215983;-44105;0;31;Minas Gerais;5173;32;America/Sao_Paulo
 2708006;Santana do Ipanema;-936999;-37248;0;27;Alagoas;2859;82;America/Sao_Paulo
-4124004;Santana do ItararÈ;-237587;-496293;0;41;Paran·;7855;43;America/Sao_Paulo
-3158805;Santana do JacarÈ;-209007;-451285;0;31;Minas Gerais;5175;35;America/Sao_Paulo
-3158904;Santana do ManhuaÁu;-201031;-419278;0;31;Minas Gerais;5177;33;America/Sao_Paulo
-2110237;Santana do Maranh„o;-3109;-424064;0;21;Maranh„o;224;98;America/Sao_Paulo
+4124004;Santana do Itarar√©;-237587;-496293;0;41;Paran√°;7855;43;America/Sao_Paulo
+3158805;Santana do Jacar√©;-209007;-451285;0;31;Minas Gerais;5175;35;America/Sao_Paulo
+3158904;Santana do Manhua√ßu;-201031;-419278;0;31;Minas Gerais;5177;33;America/Sao_Paulo
+2110237;Santana do Maranh√£o;-3109;-424064;0;21;Maranh√£o;224;98;America/Sao_Paulo
 2411403;Santana do Matos;-594605;-366578;0;24;Rio Grande do Norte;1827;84;America/Sao_Paulo
-2708105;Santana do Munda˙;-917141;-362176;0;27;Alagoas;2861;82;America/Sao_Paulo
-3158953;Santana do ParaÌso;-193661;-425446;0;31;Minas Gerais;2673;31;America/Sao_Paulo
-2209351;Santana do PiauÌ;-694696;-415178;0;22;PiauÌ;2281;89;America/Sao_Paulo
+2708105;Santana do Munda√∫;-917141;-362176;0;27;Alagoas;2861;82;America/Sao_Paulo
+3158953;Santana do Para√≠so;-193661;-425446;0;31;Minas Gerais;2673;31;America/Sao_Paulo
+2209351;Santana do Piau√≠;-694696;-415178;0;22;Piau√≠;2281;89;America/Sao_Paulo
 3159001;Santana do Riacho;-191662;-43722;0;31;Minas Gerais;5179;31;America/Sao_Paulo
-2806404;Santana do S„o Francisco;-102922;-366105;0;28;Sergipe;2647;79;America/Sao_Paulo
-2411429;Santana do SeridÛ;-676643;-367312;0;24;Rio Grande do Norte;1825;84;America/Sao_Paulo
-2513604;Santana dos Garrotes;-738162;-379819;0;25;ParaÌba;2173;83;America/Sao_Paulo
+2806404;Santana do S√£o Francisco;-102922;-366105;0;28;Sergipe;2647;79;America/Sao_Paulo
+2411429;Santana do Serid√≥;-676643;-367312;0;24;Rio Grande do Norte;1825;84;America/Sao_Paulo
+2513604;Santana dos Garrotes;-738162;-379819;0;25;Para√≠ba;2173;83;America/Sao_Paulo
 3159100;Santana dos Montes;-207868;-436949;0;31;Minas Gerais;5181;31;America/Sao_Paulo
-2928307;SantanÛpolis;-120311;-388694;0;29;Bahia;3867;75;America/Sao_Paulo
-1506807;SantarÈm;-243849;-546996;0;15;Par·;535;93;America/Sao_Paulo
-1506906;SantarÈm Novo;-93097;-473855;0;15;Par·;537;91;America/Sao_Paulo
+2928307;Santan√≥polis;-120311;-388694;0;29;Bahia;3867;75;America/Sao_Paulo
+1506807;Santar√©m;-243849;-546996;0;15;Par√°;535;93;America/Sao_Paulo
+1506906;Santar√©m Novo;-93097;-473855;0;15;Par√°;537;91;America/Sao_Paulo
 4317400;Santiago;-291897;-548666;0;43;Rio Grande do Sul;8851;55;America/Sao_Paulo
 4215695;Santiago do Sul;-266388;-526799;0;42;Santa Catarina;940;49;America/Sao_Paulo
 5107263;Santo Afonso;-144945;-570091;0;51;Mato Grosso;115;65;America/Porto_Velho
 2928604;Santo Amaro;-125472;-387137;0;29;Bahia;3871;75;America/Sao_Paulo
 4215703;Santo Amaro da Imperatriz;-276852;-487813;0;42;Santa Catarina;8309;48;America/Sao_Paulo
 2806602;Santo Amaro das Brotas;-107892;-370564;0;28;Sergipe;3231;79;America/Sao_Paulo
-2110278;Santo Amaro do Maranh„o;-250068;-43238;0;21;Maranh„o;226;98;America/Sao_Paulo
-3547700;Santo Anast·cio;-219747;-516527;0;35;S„o Paulo;7055;18;America/Sao_Paulo
-3547809;Santo AndrÈ;-236737;-465432;0;35;S„o Paulo;7057;11;America/Sao_Paulo
-2513851;Santo AndrÈ;-722016;-366213;0;25;ParaÌba;516;83;America/Sao_Paulo
-4317509;Santo ¬ngelo;-283001;-542668;0;43;Rio Grande do Sul;8853;55;America/Sao_Paulo
-2411502;Santo AntÙnio;-631195;-354739;0;24;Rio Grande do Norte;1829;84;America/Sao_Paulo
-3547908;Santo AntÙnio da Alegria;-210864;-471464;0;35;S„o Paulo;7059;16;America/Sao_Paulo
-5219712;Santo AntÙnio da Barra;-175585;-506345;0;52;Goi·s;83;64;America/Sao_Paulo
-4317608;Santo AntÙnio da Patrulha;-298268;-505175;0;43;Rio Grande do Sul;8855;51;America/Sao_Paulo
-4124103;Santo AntÙnio da Platina;-232959;-500815;0;41;Paran·;7859;43;America/Sao_Paulo
-4317707;Santo AntÙnio das Missıes;-28514;-552251;0;43;Rio Grande do Sul;8857;55;America/Sao_Paulo
-5219738;Santo AntÙnio de Goi·s;-164815;-493096;0;52;Goi·s;53;62;America/Sao_Paulo
-2928703;Santo AntÙnio de Jesus;-129614;-392584;0;29;Bahia;3873;75;America/Sao_Paulo
-2209401;Santo AntÙnio de Lisboa;-698676;-412252;0;22;PiauÌ;1187;89;America/Sao_Paulo
-3304706;Santo AntÙnio de P·dua;-21541;-421832;0;33;Rio de Janeiro;5893;22;America/Sao_Paulo
-3548005;Santo AntÙnio de Posse;-226029;-469192;0;35;S„o Paulo;7061;19;America/Sao_Paulo
-3159902;Santo AntÙnio do Amparo;-20943;-449176;0;31;Minas Gerais;5197;35;America/Sao_Paulo
-3548054;Santo AntÙnio do Aracangu·;-209331;-50498;0;35;S„o Paulo;2939;18;America/Sao_Paulo
-3160009;Santo AntÙnio do Aventureiro;-217606;-428115;0;31;Minas Gerais;5199;32;America/Sao_Paulo
-4124202;Santo AntÙnio do Caiu·;-227351;-52344;0;41;Paran·;7861;44;America/Sao_Paulo
-5219753;Santo AntÙnio do Descoberto;-159412;-482578;0;52;Goi·s;9677;61;America/Sao_Paulo
-3160108;Santo AntÙnio do Grama;-203185;-426047;0;31;Minas Gerais;5201;31;America/Sao_Paulo
-1303700;Santo AntÙnio do IÁ·;-309544;-679463;0;13;Amazonas;273;97;America/Porto_Velho
-3160207;Santo AntÙnio do ItambÈ;-184609;-433006;0;31;Minas Gerais;5203;33;America/Sao_Paulo
-3160306;Santo AntÙnio do Jacinto;-165332;-401817;0;31;Minas Gerais;5205;33;America/Sao_Paulo
-3548104;Santo AntÙnio do Jardim;-221121;-466845;0;35;S„o Paulo;7063;19;America/Sao_Paulo
-5107792;Santo AntÙnio do Leste;-14805;-536075;0;51;Mato Grosso;1098;66;America/Porto_Velho
-5107800;Santo AntÙnio do Leverger;-158632;-560788;0;51;Mato Grosso;9155;65;America/Porto_Velho
-3160405;Santo AntÙnio do Monte;-20085;-452947;0;31;Minas Gerais;5207;37;America/Sao_Paulo
-4317558;Santo AntÙnio do Palma;-284956;-520267;0;43;Rio Grande do Sul;5941;54;America/Sao_Paulo
-4124301;Santo AntÙnio do ParaÌso;-234969;-506455;0;41;Paran·;7863;43;America/Sao_Paulo
-3548203;Santo AntÙnio do Pinhal;-22827;-45663;0;35;S„o Paulo;7065;12;America/Sao_Paulo
-4317756;Santo AntÙnio do Planalto;-28403;-526992;0;43;Rio Grande do Sul;5957;54;America/Sao_Paulo
-3160454;Santo AntÙnio do Retiro;-153393;-426171;0;31;Minas Gerais;708;38;America/Sao_Paulo
-3160504;Santo AntÙnio do Rio Abaixo;-192374;-432604;0;31;Minas Gerais;5209;31;America/Sao_Paulo
-4124400;Santo AntÙnio do Sudoeste;-260737;-537251;0;41;Paran·;7857;46;America/Sao_Paulo
-1507003;Santo AntÙnio do Tau·;-11522;-481314;0;15;Par·;539;91;America/Sao_Paulo
-2110302;Santo AntÙnio dos Lopes;-486613;-443653;0;21;Maranh„o;903;99;America/Sao_Paulo
-2209450;Santo AntÙnio dos Milagres;-604647;-427123;0;22;PiauÌ;378;86;America/Sao_Paulo
+2110278;Santo Amaro do Maranh√£o;-250068;-43238;0;21;Maranh√£o;226;98;America/Sao_Paulo
+3547700;Santo Anast√°cio;-219747;-516527;0;35;S√£o Paulo;7055;18;America/Sao_Paulo
+3547809;Santo Andr√©;-236737;-465432;0;35;S√£o Paulo;7057;11;America/Sao_Paulo
+2513851;Santo Andr√©;-722016;-366213;0;25;Para√≠ba;516;83;America/Sao_Paulo
+4317509;Santo √Çngelo;-283001;-542668;0;43;Rio Grande do Sul;8853;55;America/Sao_Paulo
+2411502;Santo Ant√¥nio;-631195;-354739;0;24;Rio Grande do Norte;1829;84;America/Sao_Paulo
+3547908;Santo Ant√¥nio da Alegria;-210864;-471464;0;35;S√£o Paulo;7059;16;America/Sao_Paulo
+5219712;Santo Ant√¥nio da Barra;-175585;-506345;0;52;Goi√°s;83;64;America/Sao_Paulo
+4317608;Santo Ant√¥nio da Patrulha;-298268;-505175;0;43;Rio Grande do Sul;8855;51;America/Sao_Paulo
+4124103;Santo Ant√¥nio da Platina;-232959;-500815;0;41;Paran√°;7859;43;America/Sao_Paulo
+4317707;Santo Ant√¥nio das Miss√µes;-28514;-552251;0;43;Rio Grande do Sul;8857;55;America/Sao_Paulo
+5219738;Santo Ant√¥nio de Goi√°s;-164815;-493096;0;52;Goi√°s;53;62;America/Sao_Paulo
+2928703;Santo Ant√¥nio de Jesus;-129614;-392584;0;29;Bahia;3873;75;America/Sao_Paulo
+2209401;Santo Ant√¥nio de Lisboa;-698676;-412252;0;22;Piau√≠;1187;89;America/Sao_Paulo
+3304706;Santo Ant√¥nio de P√°dua;-21541;-421832;0;33;Rio de Janeiro;5893;22;America/Sao_Paulo
+3548005;Santo Ant√¥nio de Posse;-226029;-469192;0;35;S√£o Paulo;7061;19;America/Sao_Paulo
+3159902;Santo Ant√¥nio do Amparo;-20943;-449176;0;31;Minas Gerais;5197;35;America/Sao_Paulo
+3548054;Santo Ant√¥nio do Aracangu√°;-209331;-50498;0;35;S√£o Paulo;2939;18;America/Sao_Paulo
+3160009;Santo Ant√¥nio do Aventureiro;-217606;-428115;0;31;Minas Gerais;5199;32;America/Sao_Paulo
+4124202;Santo Ant√¥nio do Caiu√°;-227351;-52344;0;41;Paran√°;7861;44;America/Sao_Paulo
+5219753;Santo Ant√¥nio do Descoberto;-159412;-482578;0;52;Goi√°s;9677;61;America/Sao_Paulo
+3160108;Santo Ant√¥nio do Grama;-203185;-426047;0;31;Minas Gerais;5201;31;America/Sao_Paulo
+1303700;Santo Ant√¥nio do I√ß√°;-309544;-679463;0;13;Amazonas;273;97;America/Porto_Velho
+3160207;Santo Ant√¥nio do Itamb√©;-184609;-433006;0;31;Minas Gerais;5203;33;America/Sao_Paulo
+3160306;Santo Ant√¥nio do Jacinto;-165332;-401817;0;31;Minas Gerais;5205;33;America/Sao_Paulo
+3548104;Santo Ant√¥nio do Jardim;-221121;-466845;0;35;S√£o Paulo;7063;19;America/Sao_Paulo
+5107792;Santo Ant√¥nio do Leste;-14805;-536075;0;51;Mato Grosso;1098;66;America/Porto_Velho
+5107800;Santo Ant√¥nio do Leverger;-158632;-560788;0;51;Mato Grosso;9155;65;America/Porto_Velho
+3160405;Santo Ant√¥nio do Monte;-20085;-452947;0;31;Minas Gerais;5207;37;America/Sao_Paulo
+4317558;Santo Ant√¥nio do Palma;-284956;-520267;0;43;Rio Grande do Sul;5941;54;America/Sao_Paulo
+4124301;Santo Ant√¥nio do Para√≠so;-234969;-506455;0;41;Paran√°;7863;43;America/Sao_Paulo
+3548203;Santo Ant√¥nio do Pinhal;-22827;-45663;0;35;S√£o Paulo;7065;12;America/Sao_Paulo
+4317756;Santo Ant√¥nio do Planalto;-28403;-526992;0;43;Rio Grande do Sul;5957;54;America/Sao_Paulo
+3160454;Santo Ant√¥nio do Retiro;-153393;-426171;0;31;Minas Gerais;708;38;America/Sao_Paulo
+3160504;Santo Ant√¥nio do Rio Abaixo;-192374;-432604;0;31;Minas Gerais;5209;31;America/Sao_Paulo
+4124400;Santo Ant√¥nio do Sudoeste;-260737;-537251;0;41;Paran√°;7857;46;America/Sao_Paulo
+1507003;Santo Ant√¥nio do Tau√°;-11522;-481314;0;15;Par√°;539;91;America/Sao_Paulo
+2110302;Santo Ant√¥nio dos Lopes;-486613;-443653;0;21;Maranh√£o;903;99;America/Sao_Paulo
+2209450;Santo Ant√¥nio dos Milagres;-604647;-427123;0;22;Piau√≠;378;86;America/Sao_Paulo
 4317806;Santo Augusto;-278526;-537776;0;43;Rio Grande do Sul;8859;55;America/Sao_Paulo
 4317905;Santo Cristo;-278263;-54662;0;43;Rio Grande do Sul;8861;55;America/Sao_Paulo
-2928802;Santo EstÍv„o;-12428;-392505;0;29;Bahia;3875;75;America/Sao_Paulo
-3548302;Santo Expedito;-218467;-513929;0;35;S„o Paulo;7067;18;America/Sao_Paulo
+2928802;Santo Est√™v√£o;-12428;-392505;0;29;Bahia;3875;75;America/Sao_Paulo
+3548302;Santo Expedito;-218467;-513929;0;35;S√£o Paulo;7067;18;America/Sao_Paulo
 4317954;Santo Expedito do Sul;-279074;-516434;0;43;Rio Grande do Sul;5977;54;America/Sao_Paulo
-3160603;Santo HipÛlito;-182968;-442229;0;31;Minas Gerais;5211;38;America/Sao_Paulo
-4124509;Santo In·cio;-226957;-517969;0;41;Paran·;7865;44;America/Sao_Paulo
-2209500;Santo In·cio do PiauÌ;-742072;-419063;0;22;PiauÌ;1189;89;America/Sao_Paulo
-3548401;SantÛpolis do AguapeÌ;-216376;-505044;0;35;S„o Paulo;7069;18;America/Sao_Paulo
-3548500;Santos;-239535;-46335;0;35;S„o Paulo;7071;13;America/Sao_Paulo
+3160603;Santo Hip√≥lito;-182968;-442229;0;31;Minas Gerais;5211;38;America/Sao_Paulo
+4124509;Santo In√°cio;-226957;-517969;0;41;Paran√°;7865;44;America/Sao_Paulo
+2209500;Santo In√°cio do Piau√≠;-742072;-419063;0;22;Piau√≠;1189;89;America/Sao_Paulo
+3548401;Sant√≥polis do Aguape√≠;-216376;-505044;0;35;S√£o Paulo;7069;18;America/Sao_Paulo
+3548500;Santos;-239535;-46335;0;35;S√£o Paulo;7071;13;America/Sao_Paulo
 3160702;Santos Dumont;-214634;-435499;0;31;Minas Gerais;5213;32;America/Sao_Paulo
-2312304;S„o Benedito;-404713;-408596;0;23;Cear·;1547;88;America/Sao_Paulo
-2110401;S„o Benedito do Rio Preto;-333515;-435287;0;21;Maranh„o;905;98;America/Sao_Paulo
-2612901;S„o Benedito do Sul;-88166;-359453;0;26;Pernambuco;2557;81;America/Sao_Paulo
-2513927;S„o Bentinho;-688596;-377243;0;25;ParaÌba;518;83;America/Sao_Paulo
-2513901;S„o Bento;-648529;-374488;0;25;ParaÌba;2179;83;America/Sao_Paulo
-2110500;S„o Bento;-269781;-448289;0;21;Maranh„o;907;98;America/Sao_Paulo
-3160801;S„o Bento Abade;-215839;-450699;0;31;Minas Gerais;5215;35;America/Sao_Paulo
-2411601;S„o Bento do Norte;-509259;-359587;0;24;Rio Grande do Norte;1831;84;America/Sao_Paulo
-3548609;S„o Bento do SapucaÌ;-226837;-457287;0;35;S„o Paulo;7073;12;America/Sao_Paulo
-4215802;S„o Bento do Sul;-262495;-493831;0;42;Santa Catarina;8311;47;America/Sao_Paulo
-1720101;S„o Bento do Tocantins;-60258;-479012;0;17;Tocantins;197;63;America/Sao_Paulo
-2411700;S„o Bento do TrairÌ;-633798;-360863;0;24;Rio Grande do Norte;1833;84;America/Sao_Paulo
-2613008;S„o Bento do Una;-852637;-364465;0;26;Pernambuco;2559;81;America/Sao_Paulo
-4215752;S„o Bernardino;-264739;-529687;0;42;Santa Catarina;942;49;America/Sao_Paulo
-2110609;S„o Bernardo;-337223;-424191;0;21;Maranh„o;909;98;America/Sao_Paulo
-3548708;S„o Bernardo do Campo;-236914;-465646;0;35;S„o Paulo;7075;11;America/Sao_Paulo
-4215901;S„o Bonif·cio;-279009;-489326;0;42;Santa Catarina;8313;48;America/Sao_Paulo
-4318002;S„o Borja;-286578;-560036;0;43;Rio Grande do Sul;8863;55;America/Sao_Paulo
-2708204;S„o Br·s;-101141;-368522;0;27;Alagoas;2863;82;America/Sao_Paulo
-3160900;S„o Br·s do SuaÁuÌ;-206242;-439515;0;31;Minas Gerais;5217;31;America/Sao_Paulo
-2209559;S„o Braz do PiauÌ;-905797;-430076;0;22;PiauÌ;2263;89;America/Sao_Paulo
-2613107;S„o Caetano;-833763;-362869;0;26;Pernambuco;2561;81;America/Sao_Paulo
-1507102;S„o Caetano de Odivelas;-747293;-480246;0;15;Par·;541;91;America/Sao_Paulo
-3548807;S„o Caetano do Sul;-236229;-465548;0;35;S„o Paulo;7077;11;America/Sao_Paulo
-3548906;S„o Carlos;-220174;-47886;0;35;S„o Paulo;7079;16;America/Sao_Paulo
-4216008;S„o Carlos;-270798;-530037;0;42;Santa Catarina;8315;49;America/Sao_Paulo
-4124608;S„o Carlos do IvaÌ;-233158;-524761;0;41;Paran·;7867;44;America/Sao_Paulo
-2806701;S„o CristÛv„o;-110084;-372044;0;28;Sergipe;3233;79;America/Sao_Paulo
-4216057;S„o Cristov„o do Sul;-272666;-504388;0;42;Santa Catarina;5573;49;America/Sao_Paulo
-2928901;S„o DesidÈrio;-123572;-449769;0;29;Bahia;3877;77;America/Sao_Paulo
-2928950;S„o Domingos;-114649;-395268;0;29;Bahia;3029;75;America/Sao_Paulo
-4216107;S„o Domingos;-265548;-525313;0;42;Santa Catarina;8317;49;America/Sao_Paulo
-2513968;S„o Domingos;-680313;-379488;0;25;ParaÌba;522;83;America/Sao_Paulo
-2806800;S„o Domingos;-107916;-375685;0;28;Sergipe;3235;79;America/Sao_Paulo
-5219803;S„o Domingos;-13621;-467415;0;52;Goi·s;9591;62;America/Sao_Paulo
-3160959;S„o Domingos das Dores;-195246;-420106;0;31;Minas Gerais;710;33;America/Sao_Paulo
-1507151;S„o Domingos do Araguaia;-553732;-487366;0;15;Par·;381;94;America/Sao_Paulo
-2110658;S„o Domingos do Azeit„o;-681471;-446509;0;21;Maranh„o;228;99;America/Sao_Paulo
-1507201;S„o Domingos do Capim;-168768;-477665;0;15;Par·;543;91;America/Sao_Paulo
-2513943;S„o Domingos do Cariri;-763273;-364374;0;25;ParaÌba;520;83;America/Sao_Paulo
-2110708;S„o Domingos do Maranh„o;-558095;-443822;0;21;Maranh„o;911;99;America/Sao_Paulo
-3204658;S„o Domingos do Norte;-191452;-406281;0;32;EspÌrito Santo;2933;27;America/Sao_Paulo
-3161007;S„o Domingos do Prata;-198678;-42971;0;31;Minas Gerais;5219;31;America/Sao_Paulo
-4318051;S„o Domingos do Sul;-285312;-51886;0;43;Rio Grande do Sul;7351;54;America/Sao_Paulo
-2929107;S„o Felipe;-128394;-390893;0;29;Bahia;3881;75;America/Sao_Paulo
-1101484;S„o Felipe D'Oeste;-119023;-615026;0;11;RondÙnia;18;69;America/Porto_Velho
-2929008;S„o FÈlix;-126104;-389727;0;29;Bahia;3879;75;America/Sao_Paulo
-2110807;S„o FÈlix de Balsas;-707535;-448092;0;21;Maranh„o;913;99;America/Sao_Paulo
-3161056;S„o FÈlix de Minas;-185959;-414889;0;31;Minas Gerais;712;33;America/Sao_Paulo
-5107859;S„o FÈlix do Araguaia;-11615;-506706;0;51;Mato Grosso;9183;66;America/Porto_Velho
-2929057;S„o FÈlix do Coribe;-134019;-441837;0;29;Bahia;3031;77;America/Sao_Paulo
-2209609;S„o FÈlix do PiauÌ;-593485;-421172;0;22;PiauÌ;1191;86;America/Sao_Paulo
-1720150;S„o FÈlix do Tocantins;-101615;-466618;0;17;Tocantins;363;63;America/Sao_Paulo
-1507300;S„o FÈlix do Xingu;-664254;-519904;0;15;Par·;545;94;America/Sao_Paulo
-2411809;S„o Fernando;-637975;-371864;0;24;Rio Grande do Norte;1835;84;America/Sao_Paulo
-3304805;S„o FidÈlis;-216551;-41756;0;33;Rio de Janeiro;5895;22;America/Sao_Paulo
-3549003;S„o Francisco;-203623;-506952;0;35;S„o Paulo;7081;17;America/Sao_Paulo
-2513984;S„o Francisco;-660773;-380968;0;25;ParaÌba;524;83;America/Sao_Paulo
-2806909;S„o Francisco;-103442;-368869;0;28;Sergipe;3237;79;America/Sao_Paulo
-3161106;S„o Francisco;-159514;-448593;0;31;Minas Gerais;5221;38;America/Sao_Paulo
-4318101;S„o Francisco de Assis;-295547;-551253;0;43;Rio Grande do Sul;8865;55;America/Sao_Paulo
-2209658;S„o Francisco de Assis do PiauÌ;-823599;-416873;0;22;PiauÌ;380;89;America/Sao_Paulo
-5219902;S„o Francisco de Goi·s;-159256;-492605;0;52;Goi·s;9593;62;America/Sao_Paulo
-3304755;S„o Francisco de Itabapoana;-214702;-411091;0;33;Rio de Janeiro;782;22;America/Sao_Paulo
-4318200;S„o Francisco de Paula;-294404;-505828;0;43;Rio Grande do Sul;8867;54;America/Sao_Paulo
-3161205;S„o Francisco de Paula;-207036;-449838;0;31;Minas Gerais;5223;37;America/Sao_Paulo
-3161304;S„o Francisco de Sales;-198611;-497727;0;31;Minas Gerais;5225;34;America/Sao_Paulo
-2110856;S„o Francisco do Brej„o;-512584;-47389;0;21;Maranh„o;230;99;America/Sao_Paulo
-2929206;S„o Francisco do Conde;-126183;-386786;0;29;Bahia;3883;71;America/Sao_Paulo
-3161403;S„o Francisco do GlÛria;-207923;-422673;0;31;Minas Gerais;5227;32;America/Sao_Paulo
-1101492;S„o Francisco do GuaporÈ;-12052;-63568;0;11;RondÙnia;20;69;America/Porto_Velho
-2110906;S„o Francisco do Maranh„o;-625159;-428668;0;21;Maranh„o;915;99;America/Sao_Paulo
-2411908;S„o Francisco do Oeste;-597472;-381519;0;24;Rio Grande do Norte;1821;84;America/Sao_Paulo
-1507409;S„o Francisco do Par·;-116963;-477917;0;15;Par·;547;91;America/Sao_Paulo
-2209708;S„o Francisco do PiauÌ;-72463;-42541;0;22;PiauÌ;1193;89;America/Sao_Paulo
-4216206;S„o Francisco do Sul;-262579;-486344;0;42;Santa Catarina;8319;47;America/Sao_Paulo
-4318309;S„o Gabriel;-303337;-543217;0;43;Rio Grande do Sul;8869;55;America/Sao_Paulo
-2929255;S„o Gabriel;-112175;-418843;0;29;Bahia;3989;74;America/Sao_Paulo
-1303809;S„o Gabriel da Cachoeira;-11909;-67084;0;13;Amazonas;283;97;America/Porto_Velho
-3204708;S„o Gabriel da Palha;-190182;-405365;0;32;EspÌrito Santo;5693;27;America/Sao_Paulo
-5007695;S„o Gabriel do Oeste;-193889;-545507;0;50;Mato Grosso do Sul;9809;67;America/Porto_Velho
-3161502;S„o Geraldo;-209252;-428364;0;31;Minas Gerais;5229;32;America/Sao_Paulo
-3161601;S„o Geraldo da Piedade;-188411;-422867;0;31;Minas Gerais;5231;33;America/Sao_Paulo
-1507458;S„o Geraldo do Araguaia;-639471;-485592;0;15;Par·;619;94;America/Sao_Paulo
-3161650;S„o Geraldo do Baixio;-189097;-41363;0;31;Minas Gerais;714;33;America/Sao_Paulo
-3304904;S„o GonÁalo;-228268;-430634;0;33;Rio de Janeiro;5897;21;America/Sao_Paulo
-3161700;S„o GonÁalo do AbaetÈ;-183315;-458265;0;31;Minas Gerais;5233;38;America/Sao_Paulo
-2412005;S„o GonÁalo do Amarante;-579068;-353257;0;24;Rio Grande do Norte;1837;84;America/Sao_Paulo
-2312403;S„o GonÁalo do Amarante;-360515;-389726;0;23;Cear·;1549;85;America/Sao_Paulo
-2209757;S„o GonÁalo do GurguÈia;-100319;-453092;0;22;PiauÌ;382;89;America/Sao_Paulo
-3161809;S„o GonÁalo do Par·;-199822;-448593;0;31;Minas Gerais;5235;37;America/Sao_Paulo
-2209807;S„o GonÁalo do PiauÌ;-599393;-427095;0;22;PiauÌ;1195;86;America/Sao_Paulo
-3161908;S„o GonÁalo do Rio Abaixo;-198221;-43366;0;31;Minas Gerais;5237;31;America/Sao_Paulo
-3125507;S„o GonÁalo do Rio Preto;-180025;-433854;0;31;Minas Gerais;4509;38;America/Sao_Paulo
-3162005;S„o GonÁalo do SapucaÌ;-218932;-455893;0;31;Minas Gerais;5239;35;America/Sao_Paulo
-2929305;S„o GonÁalo dos Campos;-124331;-389663;0;29;Bahia;3885;75;America/Sao_Paulo
-3162104;S„o Gotardo;-193087;-460465;0;31;Minas Gerais;5241;34;America/Sao_Paulo
-4318408;S„o JerÙnimo;-299716;-517251;0;43;Rio Grande do Sul;8871;51;America/Sao_Paulo
-4124707;S„o JerÙnimo da Serra;-237218;-507475;0;41;Paran·;7869;43;America/Sao_Paulo
-4124806;S„o Jo„o;-258214;-527252;0;41;Paran·;7871;46;America/Sao_Paulo
-2613206;S„o Jo„o;-887576;-363653;0;26;Pernambuco;2563;87;America/Sao_Paulo
-2111003;S„o Jo„o Batista;-295398;-447953;0;21;Maranh„o;917;98;America/Sao_Paulo
-4216305;S„o Jo„o Batista;-272772;-488474;0;42;Santa Catarina;8321;48;America/Sao_Paulo
-3162203;S„o Jo„o Batista do GlÛria;-20635;-46508;0;31;Minas Gerais;5243;35;America/Sao_Paulo
-5220009;S„o Jo„o d'AlianÁa;-147048;-475228;0;52;Goi·s;9597;62;America/Sao_Paulo
-1400506;S„o Jo„o da Baliza;951659;-599133;0;14;Roraima;313;95;America/Porto_Velho
-3305000;S„o Jo„o da Barra;-21638;-410446;0;33;Rio de Janeiro;5899;22;America/Sao_Paulo
-3549102;S„o Jo„o da Boa Vista;-219707;-467944;0;35;S„o Paulo;7083;19;America/Sao_Paulo
-2209856;S„o Jo„o da Canabrava;-681203;-413415;0;22;PiauÌ;1291;89;America/Sao_Paulo
-2209872;S„o Jo„o da Fronteira;-395497;-412569;0;22;PiauÌ;384;86;America/Sao_Paulo
-3162252;S„o Jo„o da Lagoa;-168455;-443507;0;31;Minas Gerais;716;38;America/Sao_Paulo
-3162302;S„o Jo„o da Mata;-21928;-459297;0;31;Minas Gerais;5245;35;America/Sao_Paulo
-5220058;S„o Jo„o da Para˙na;-168126;-504092;0;52;Goi·s;9747;64;America/Sao_Paulo
-1507466;S„o Jo„o da Ponta;-857885;-47918;0;15;Par·;64;91;America/Sao_Paulo
-3162401;S„o Jo„o da Ponte;-159271;-440096;0;31;Minas Gerais;5247;38;America/Sao_Paulo
-2209906;S„o Jo„o da Serra;-551081;-418923;0;22;PiauÌ;1197;86;America/Sao_Paulo
-4318424;S„o Jo„o da Urtiga;-278195;-518257;0;43;Rio Grande do Sul;7349;54;America/Sao_Paulo
-2209955;S„o Jo„o da Varjota;-694082;-418889;0;22;PiauÌ;386;89;America/Sao_Paulo
-3549201;S„o Jo„o das Duas Pontes;-203879;-503792;0;35;S„o Paulo;7085;17;America/Sao_Paulo
-3162450;S„o Jo„o das Missıes;-148859;-440922;0;31;Minas Gerais;718;38;America/Sao_Paulo
-3549250;S„o Jo„o de Iracema;-205111;-503561;0;35;S„o Paulo;2941;17;America/Sao_Paulo
-3305109;S„o Jo„o de Meriti;-228058;-433729;0;33;Rio de Janeiro;5901;21;America/Sao_Paulo
-1507474;S„o Jo„o de Pirabas;-780222;-47181;0;15;Par·;393;91;America/Sao_Paulo
-3162500;S„o Jo„o del Rei;-211311;-442526;0;31;Minas Gerais;5249;32;America/Sao_Paulo
-1507508;S„o Jo„o do Araguaia;-536334;-487926;0;15;Par·;549;94;America/Sao_Paulo
-2209971;S„o Jo„o do Arraial;-38186;-424459;0;22;PiauÌ;388;86;America/Sao_Paulo
-4124905;S„o Jo„o do Caiu·;-228535;-523411;0;41;Paran·;7873;44;America/Sao_Paulo
-2514008;S„o Jo„o do Cariri;-738168;-365345;0;25;ParaÌba;2181;83;America/Sao_Paulo
-2111029;S„o Jo„o do Car˙;-35503;-462507;0;21;Maranh„o;232;98;America/Sao_Paulo
-4216354;S„o Jo„o do Itaperi˙;-266213;-487683;0;42;Santa Catarina;5551;47;America/Sao_Paulo
-4125001;S„o Jo„o do IvaÌ;-239833;-518215;0;41;Paran·;7875;43;America/Sao_Paulo
-2312502;S„o Jo„o do Jaguaribe;-527516;-382694;0;23;Cear·;1551;88;America/Sao_Paulo
-3162559;S„o Jo„o do ManhuaÁu;-203933;-421533;0;31;Minas Gerais;2677;33;America/Sao_Paulo
-3162575;S„o Jo„o do Manteninha;-18723;-411628;0;31;Minas Gerais;2679;33;America/Sao_Paulo
-4216255;S„o Jo„o do Oeste;-270984;-535977;0;42;Santa Catarina;5753;49;America/Sao_Paulo
-3162609;S„o Jo„o do Oriente;-193384;-421575;0;31;Minas Gerais;5251;33;America/Sao_Paulo
-3162658;S„o Jo„o do PacuÌ;-165373;-445134;0;31;Minas Gerais;720;38;America/Sao_Paulo
-3162708;S„o Jo„o do ParaÌso;-153168;-420213;0;31;Minas Gerais;5253;38;America/Sao_Paulo
-2111052;S„o Jo„o do ParaÌso;-645634;-470594;0;21;Maranh„o;234;99;America/Sao_Paulo
-3549300;S„o Jo„o do Pau d'Alho;-212662;-516672;0;35;S„o Paulo;7087;18;America/Sao_Paulo
-2210003;S„o Jo„o do PiauÌ;-835466;-422559;0;22;PiauÌ;1199;89;America/Sao_Paulo
-4318432;S„o Jo„o do PolÍsine;-296194;-534439;0;43;Rio Grande do Sul;5791;55;America/Sao_Paulo
-2500700;S„o Jo„o do Rio do Peixe;-672195;-384468;0;25;ParaÌba;1913;83;America/Sao_Paulo
-2412104;S„o Jo„o do Sabugi;-671387;-372027;0;24;Rio Grande do Norte;1839;84;America/Sao_Paulo
-2111078;S„o Jo„o do Soter;-510821;-438163;0;21;Maranh„o;236;99;America/Sao_Paulo
-4216404;S„o Jo„o do Sul;-292154;-498094;0;42;Santa Catarina;8323;48;America/Sao_Paulo
-2514107;S„o Jo„o do Tigre;-807703;-368547;0;25;ParaÌba;2183;83;America/Sao_Paulo
-4125100;S„o Jo„o do Triunfo;-25683;-502949;0;41;Paran·;7877;42;America/Sao_Paulo
-2111102;S„o Jo„o dos Patos;-64934;-437036;0;21;Maranh„o;919;99;America/Sao_Paulo
-3162807;S„o Jo„o Evangelista;-18548;-427655;0;31;Minas Gerais;5255;33;America/Sao_Paulo
-3162906;S„o Jo„o Nepomuceno;-215381;-430069;0;31;Minas Gerais;5257;32;America/Sao_Paulo
-4216503;S„o Joaquim;-282887;-499457;0;42;Santa Catarina;8325;49;America/Sao_Paulo
-3549409;S„o Joaquim da Barra;-205812;-478593;0;35;S„o Paulo;7089;16;America/Sao_Paulo
-3162922;S„o Joaquim de Bicas;-20048;-442749;0;31;Minas Gerais;722;31;America/Sao_Paulo
-2613305;S„o Joaquim do Monte;-843196;-358035;0;26;Pernambuco;2565;81;America/Sao_Paulo
-4318440;S„o Jorge;-284984;-517064;0;43;Rio Grande do Sul;7347;54;America/Sao_Paulo
-4125209;S„o Jorge d'Oeste;-257085;-529204;0;41;Paran·;7881;46;America/Sao_Paulo
-4125308;S„o Jorge do IvaÌ;-234336;-522929;0;41;Paran·;7879;44;America/Sao_Paulo
-4125357;S„o Jorge do PatrocÌnio;-237647;-538823;0;41;Paran·;7999;44;America/Sao_Paulo
-4216602;S„o JosÈ;-276136;-486366;0;42;Santa Catarina;8327;48;America/Sao_Paulo
-3162948;S„o JosÈ da Barra;-207178;-46313;0;31;Minas Gerais;724;35;America/Sao_Paulo
-3549508;S„o JosÈ da Bela Vista;-205935;-476424;0;35;S„o Paulo;7091;16;America/Sao_Paulo
-4125407;S„o JosÈ da Boa Vista;-239122;-496577;0;41;Paran·;7883;43;America/Sao_Paulo
-2613404;S„o JosÈ da Coroa Grande;-888937;-351515;0;26;Pernambuco;2567;81;America/Sao_Paulo
-2514206;S„o JosÈ da Lagoa Tapada;-693646;-381622;0;25;ParaÌba;2185;83;America/Sao_Paulo
-2708303;S„o JosÈ da Laje;-901278;-360515;0;27;Alagoas;2865;82;America/Sao_Paulo
-3162955;S„o JosÈ da Lapa;-196971;-439586;0;31;Minas Gerais;2649;31;America/Sao_Paulo
-3163003;S„o JosÈ da Safira;-183243;-421431;0;31;Minas Gerais;5259;33;America/Sao_Paulo
-2708402;S„o JosÈ da Tapera;-955768;-373831;0;27;Alagoas;2867;82;America/Sao_Paulo
-3163102;S„o JosÈ da Varginha;-197006;-44556;0;31;Minas Gerais;5261;37;America/Sao_Paulo
-2929354;S„o JosÈ da VitÛria;-150787;-393437;0;29;Bahia;3035;73;America/Sao_Paulo
-4318457;S„o JosÈ das Missıes;-277789;-531226;0;43;Rio Grande do Sul;5989;55;America/Sao_Paulo
-4125456;S„o JosÈ das Palmeiras;-248369;-540572;0;41;Paran·;8471;45;America/Sao_Paulo
-2514305;S„o JosÈ de Caiana;-724636;-382989;0;25;ParaÌba;2187;83;America/Sao_Paulo
-2514404;S„o JosÈ de Espinharas;-683974;-373214;0;25;ParaÌba;2189;83;America/Sao_Paulo
-2412203;S„o JosÈ de Mipibu;-60773;-352417;0;24;Rio Grande do Norte;1841;84;America/Sao_Paulo
-2514503;S„o JosÈ de Piranhas;-71187;-38502;0;25;ParaÌba;2191;83;America/Sao_Paulo
-2514552;S„o JosÈ de Princesa;-773633;-380894;0;25;ParaÌba;528;83;America/Sao_Paulo
-2111201;S„o JosÈ de Ribamar;-254704;-440597;0;21;Maranh„o;889;98;America/Sao_Paulo
-3305133;S„o JosÈ de Ub·;-213661;-419511;0;33;Rio de Janeiro;784;22;America/Sao_Paulo
-3163201;S„o JosÈ do Alegre;-223243;-455258;0;31;Minas Gerais;5263;35;America/Sao_Paulo
-3549607;S„o JosÈ do Barreiro;-226414;-445774;0;35;S„o Paulo;7093;12;America/Sao_Paulo
-2613503;S„o JosÈ do Belmonte;-785723;-387577;0;26;Pernambuco;2569;87;America/Sao_Paulo
-2514602;S„o JosÈ do Bonfim;-71607;-373036;0;25;ParaÌba;2193;83;America/Sao_Paulo
-2514651;S„o JosÈ do Brejo do Cruz;-621054;-373601;0;25;ParaÌba;530;83;America/Sao_Paulo
-3204807;S„o JosÈ do CalÁado;-210274;-416636;0;32;EspÌrito Santo;5695;28;America/Sao_Paulo
-2412302;S„o JosÈ do Campestre;-631087;-357067;0;24;Rio Grande do Norte;1843;84;America/Sao_Paulo
-4216701;S„o JosÈ do Cedro;-264561;-534955;0;42;Santa Catarina;8329;49;America/Sao_Paulo
-4216800;S„o JosÈ do Cerrito;-276602;-505733;0;42;Santa Catarina;8331;49;America/Sao_Paulo
-2210052;S„o JosÈ do Divino;-381411;-418308;0;22;PiauÌ;2285;86;America/Sao_Paulo
-3163300;S„o JosÈ do Divino;-184793;-413907;0;31;Minas Gerais;5265;33;America/Sao_Paulo
-2613602;S„o JosÈ do Egito;-746945;-37274;0;26;Pernambuco;2571;87;America/Sao_Paulo
-3163409;S„o JosÈ do Goiabal;-199214;-427035;0;31;Minas Gerais;5267;31;America/Sao_Paulo
-4318465;S„o JosÈ do Herval;-29052;-52295;0;43;Rio Grande do Sul;7345;54;America/Sao_Paulo
-4318481;S„o JosÈ do HortÍncio;-29528;-51245;0;43;Rio Grande do Sul;7343;51;America/Sao_Paulo
-4318499;S„o JosÈ do Inhacor·;-277251;-541275;0;43;Rio Grande do Sul;6059;55;America/Sao_Paulo
-2929370;S„o JosÈ do JacuÌpe;-114137;-398669;0;29;Bahia;3033;74;America/Sao_Paulo
-3163508;S„o JosÈ do Jacuri;-18281;-426729;0;31;Minas Gerais;5269;33;America/Sao_Paulo
-3163607;S„o JosÈ do Mantimento;-200058;-417486;0;31;Minas Gerais;5271;33;America/Sao_Paulo
-4318507;S„o JosÈ do Norte;-320151;-520331;0;43;Rio Grande do Sul;8873;53;America/Sao_Paulo
-4318606;S„o JosÈ do Ouro;-277707;-515966;0;43;Rio Grande do Sul;8875;54;America/Sao_Paulo
-2210102;S„o JosÈ do Peixe;-748554;-425672;0;22;PiauÌ;1201;89;America/Sao_Paulo
-2210201;S„o JosÈ do PiauÌ;-687194;-414731;0;22;PiauÌ;1203;89;America/Sao_Paulo
-5107297;S„o JosÈ do Povo;-164549;-542487;0;51;Mato Grosso;6087;66;America/Porto_Velho
-5107305;S„o JosÈ do Rio Claro;-134398;-567218;0;51;Mato Grosso;9199;65;America/Porto_Velho
-3549706;S„o JosÈ do Rio Pardo;-215953;-468873;0;35;S„o Paulo;7095;19;America/Sao_Paulo
-3549805;S„o JosÈ do Rio Preto;-208113;-493758;0;35;S„o Paulo;7097;17;America/Sao_Paulo
-2514701;S„o JosÈ do Sabugi;-676295;-367972;0;25;ParaÌba;2195;83;America/Sao_Paulo
-2412401;S„o JosÈ do SeridÛ;-644002;-368746;0;24;Rio Grande do Norte;1845;84;America/Sao_Paulo
-4318614;S„o JosÈ do Sul;-295448;-514821;0;43;Rio Grande do Sul;1170;51;America/Sao_Paulo
-3305158;S„o JosÈ do Vale do Rio Preto;-221525;-429327;0;33;Rio de Janeiro;6009;24;America/Sao_Paulo
-5107354;S„o JosÈ do Xingu;-107982;-527486;0;51;Mato Grosso;133;66;America/Porto_Velho
-4318622;S„o JosÈ dos Ausentes;-287476;-500677;0;43;Rio Grande do Sul;6015;54;America/Sao_Paulo
-2111250;S„o JosÈ dos BasÌlios;-505493;-445809;0;21;Maranh„o;238;99;America/Sao_Paulo
-3549904;S„o JosÈ dos Campos;-231896;-458841;0;35;S„o Paulo;7099;12;America/Sao_Paulo
-2514800;S„o JosÈ dos Cordeiros;-738775;-368085;0;25;ParaÌba;2197;83;America/Sao_Paulo
-4125506;S„o JosÈ dos Pinhais;-255313;-492031;0;41;Paran·;7885;41;America/Sao_Paulo
-5107107;S„o JosÈ dos Quatro Marcos;-156276;-581772;0;51;Mato Grosso;8993;65;America/Porto_Velho
-2514453;S„o JosÈ dos Ramos;-725238;-353725;0;25;ParaÌba;526;83;America/Sao_Paulo
-2210300;S„o Juli„o;-708391;-408246;0;22;PiauÌ;1205;89;America/Sao_Paulo
-4318705;S„o Leopoldo;-297545;-511498;0;43;Rio Grande do Sul;8877;51;America/Sao_Paulo
-3163706;S„o LourenÁo;-221166;-450506;0;31;Minas Gerais;5273;35;America/Sao_Paulo
-2613701;S„o LourenÁo da Mata;-800684;-350124;0;26;Pernambuco;2573;81;America/Sao_Paulo
-3549953;S„o LourenÁo da Serra;-238491;-469432;0;35;S„o Paulo;5447;11;America/Sao_Paulo
-4216909;S„o LourenÁo do Oeste;-263557;-528498;0;42;Santa Catarina;8333;49;America/Sao_Paulo
-2210359;S„o LourenÁo do PiauÌ;-916463;-425496;0;22;PiauÌ;2265;89;America/Sao_Paulo
-4318804;S„o LourenÁo do Sul;-313564;-519715;0;43;Rio Grande do Sul;8879;53;America/Sao_Paulo
-4217006;S„o Ludgero;-283144;-491806;0;42;Santa Catarina;8335;48;America/Sao_Paulo
-2111300;S„o LuÌs;-253874;-442825;1;21;Maranh„o;921;98;America/Sao_Paulo
-5220108;S„o LuÌs de Montes Belos;-165211;-503726;0;52;Goi·s;9599;64;America/Sao_Paulo
-2312601;S„o LuÌs do Curu;-366976;-392391;0;23;Cear·;1553;85;America/Sao_Paulo
-2210375;S„o Luis do PiauÌ;-681936;-413175;0;22;PiauÌ;390;89;America/Sao_Paulo
-2708501;S„o LuÌs do Quitunde;-931816;-355606;0;27;Alagoas;2869;82;America/Sao_Paulo
-2111409;S„o LuÌs Gonzaga do Maranh„o;-438541;-446654;0;21;Maranh„o;805;99;America/Sao_Paulo
-1400605;S„o Luiz;101019;-600419;0;14;Roraima;315;95;America/Porto_Velho
-5220157;S„o Luiz do Norte;-148608;-493285;0;52;Goi·s;9749;62;America/Sao_Paulo
-3550001;S„o Luiz do Paraitinga;-23222;-453109;0;35;S„o Paulo;7101;12;America/Sao_Paulo
-4318903;S„o Luiz Gonzaga;-28412;-549559;0;43;Rio Grande do Sul;8881;55;America/Sao_Paulo
-2514909;S„o Mamede;-692386;-370954;0;25;ParaÌba;2199;83;America/Sao_Paulo
-4125555;S„o Manoel do Paran·;-233941;-526454;0;41;Paran·;5515;44;America/Sao_Paulo
-3550100;S„o Manuel;-227321;-485723;0;35;S„o Paulo;7103;14;America/Sao_Paulo
-4319000;S„o Marcos;-289677;-510696;0;43;Rio Grande do Sul;8883;54;America/Sao_Paulo
-4217105;S„o Martinho;-281609;-489867;0;42;Santa Catarina;8337;48;America/Sao_Paulo
-4319109;S„o Martinho;-277112;-539699;0;43;Rio Grande do Sul;8885;55;America/Sao_Paulo
-4319125;S„o Martinho da Serra;-295397;-53859;0;43;Rio Grande do Sul;5793;55;America/Sao_Paulo
-3204906;S„o Mateus;-187214;-398579;0;32;EspÌrito Santo;5697;27;America/Sao_Paulo
-2111508;S„o Mateus do Maranh„o;-403736;-444707;0;21;Maranh„o;923;99;America/Sao_Paulo
-4125605;S„o Mateus do Sul;-258677;-50384;0;41;Paran·;7887;42;America/Sao_Paulo
-2412500;S„o Miguel;-620283;-384947;0;24;Rio Grande do Norte;1847;84;America/Sao_Paulo
-3550209;S„o Miguel Arcanjo;-238782;-479935;0;35;S„o Paulo;7105;15;America/Sao_Paulo
-2210383;S„o Miguel da Baixa Grande;-585646;-421934;0;22;PiauÌ;392;86;America/Sao_Paulo
-4217154;S„o Miguel da Boa Vista;-26687;-532511;0;42;Santa Catarina;5755;49;America/Sao_Paulo
-2929404;S„o Miguel das Matas;-130434;-394578;0;29;Bahia;3887;75;America/Sao_Paulo
-4319158;S„o Miguel das Missıes;-28556;-545559;0;43;Rio Grande do Sul;7341;55;America/Sao_Paulo
-2515005;S„o Miguel de Taipu;-724764;-352016;0;25;ParaÌba;2201;83;America/Sao_Paulo
-2807006;S„o Miguel do Aleixo;-103847;-373836;0;28;Sergipe;3239;79;America/Sao_Paulo
-3163805;S„o Miguel do Anta;-207067;-427174;0;31;Minas Gerais;5275;31;America/Sao_Paulo
-5220207;S„o Miguel do Araguaia;-132731;-501634;0;52;Goi·s;9601;62;America/Sao_Paulo
-2210391;S„o Miguel do Fidalgo;-759713;-423676;0;22;PiauÌ;394;89;America/Sao_Paulo
-2412559;S„o Miguel do Gostoso;-512302;-356354;0;24;Rio Grande do Norte;430;84;America/Sao_Paulo
-1507607;S„o Miguel do Guam·;-161307;-474784;0;15;Par·;551;91;America/Sao_Paulo
-1100320;S„o Miguel do GuaporÈ;-116953;-627192;0;11;RondÙnia;45;69;America/Porto_Velho
-4125704;S„o Miguel do IguaÁu;-253492;-542405;0;41;Paran·;7889;45;America/Sao_Paulo
-4217204;S„o Miguel do Oeste;-267242;-535163;0;42;Santa Catarina;8339;49;America/Sao_Paulo
-5220264;S„o Miguel do Passa Quatro;-170582;-48662;0;52;Goi·s;9751;62;America/Sao_Paulo
-2210409;S„o Miguel do Tapuio;-549729;-413165;0;22;PiauÌ;1207;86;America/Sao_Paulo
-1720200;S„o Miguel do Tocantins;-556305;-475743;0;17;Tocantins;199;63;America/Sao_Paulo
-2708600;S„o Miguel dos Campos;-978301;-360971;0;27;Alagoas;2871;82;America/Sao_Paulo
-2708709;S„o Miguel dos Milagres;-926493;-353763;0;27;Alagoas;2873;82;America/Sao_Paulo
-4319208;S„o Nicolau;-281834;-552654;0;43;Rio Grande do Sul;8887;55;America/Sao_Paulo
-5220280;S„o PatrÌcio;-1535;-49818;0;52;Goi·s;1064;62;America/Sao_Paulo
-3550308;S„o Paulo;-235329;-466395;1;35;S„o Paulo;7107;11;America/Sao_Paulo
-4319307;S„o Paulo das Missıes;-280195;-549404;0;43;Rio Grande do Sul;8889;55;America/Sao_Paulo
-1303908;S„o Paulo de OlivenÁa;-347292;-689646;0;13;Amazonas;275;97;America/Rio_Branco
-2412609;S„o Paulo do Potengi;-58994;-357642;0;24;Rio Grande do Norte;1849;84;America/Sao_Paulo
-2412708;S„o Pedro;-590559;-356317;0;24;Rio Grande do Norte;1851;84;America/Sao_Paulo
-3550407;S„o Pedro;-225483;-479096;0;35;S„o Paulo;7109;19;America/Sao_Paulo
-2111532;S„o Pedro da ¡gua Branca;-508472;-484291;0;21;Maranh„o;240;99;America/Sao_Paulo
-3305208;S„o Pedro da Aldeia;-228429;-421026;0;33;Rio de Janeiro;5903;22;America/Sao_Paulo
-5107404;S„o Pedro da Cipa;-160109;-549176;0;51;Mato Grosso;93;66;America/Porto_Velho
-4319356;S„o Pedro da Serra;-294193;-515134;0;43;Rio Grande do Sul;6043;51;America/Sao_Paulo
-3163904;S„o Pedro da Uni„o;-21131;-466123;0;31;Minas Gerais;5277;35;America/Sao_Paulo
-4319364;S„o Pedro das Missıes;-277706;-532513;0;43;Rio Grande do Sul;1172;55;America/Sao_Paulo
-4217253;S„o Pedro de Alc‚ntara;-275665;-488048;0;42;Santa Catarina;944;48;America/Sao_Paulo
-4319372;S„o Pedro do Buti·;-281243;-548926;0;43;Rio Grande do Sul;6063;55;America/Sao_Paulo
-4125753;S„o Pedro do IguaÁu;-249373;-538521;0;41;Paran·;5489;45;America/Sao_Paulo
-4125803;S„o Pedro do IvaÌ;-238634;-518568;0;41;Paran·;7891;43;America/Sao_Paulo
-4125902;S„o Pedro do Paran·;-228239;-532241;0;41;Paran·;7893;44;America/Sao_Paulo
-2210508;S„o Pedro do PiauÌ;-592078;-427192;0;22;PiauÌ;1209;86;America/Sao_Paulo
-3164100;S„o Pedro do SuaÁuÌ;-183609;-425981;0;31;Minas Gerais;5281;33;America/Sao_Paulo
-4319406;S„o Pedro do Sul;-296202;-541855;0;43;Rio Grande do Sul;8891;55;America/Sao_Paulo
-3550506;S„o Pedro do Turvo;-227453;-497428;0;35;S„o Paulo;7111;14;America/Sao_Paulo
-2111573;S„o Pedro dos Crentes;-682389;-465319;0;21;Maranh„o;242;99;America/Sao_Paulo
-3164001;S„o Pedro dos Ferros;-201732;-425251;0;31;Minas Gerais;5279;33;America/Sao_Paulo
-2412807;S„o Rafael;-579791;-368778;0;24;Rio Grande do Norte;1853;84;America/Sao_Paulo
-2111607;S„o Raimundo das Mangabeiras;-702183;-454809;0;21;Maranh„o;925;99;America/Sao_Paulo
-2111631;S„o Raimundo do Doca Bezerra;-511053;-450696;0;21;Maranh„o;244;99;America/Sao_Paulo
-2210607;S„o Raimundo Nonato;-901241;-426987;0;22;PiauÌ;1211;89;America/Sao_Paulo
-2111672;S„o Roberto;-50231;-45001;0;21;Maranh„o;246;99;America/Sao_Paulo
-3164209;S„o Rom„o;-163641;-450749;0;31;Minas Gerais;5283;38;America/Sao_Paulo
-3550605;S„o Roque;-235226;-471357;0;35;S„o Paulo;7113;11;America/Sao_Paulo
-3164308;S„o Roque de Minas;-20249;-463639;0;31;Minas Gerais;5285;37;America/Sao_Paulo
-3204955;S„o Roque do Cana„;-197411;-406526;0;32;EspÌrito Santo;764;27;America/Sao_Paulo
-1720259;S„o Salvador do Tocantins;-127458;-482352;0;17;Tocantins;333;63;America/Sao_Paulo
-3550704;S„o Sebasti„o;-237951;-454143;0;35;S„o Paulo;7115;12;America/Sao_Paulo
-2708808;S„o Sebasti„o;-993043;-36559;0;27;Alagoas;2875;82;America/Sao_Paulo
-4126009;S„o Sebasti„o da Amoreira;-234656;-507625;0;41;Paran·;7895;43;America/Sao_Paulo
-3164407;S„o Sebasti„o da Bela Vista;-221583;-457546;0;31;Minas Gerais;5287;35;America/Sao_Paulo
-1507706;S„o Sebasti„o da Boa Vista;-171597;-495249;0;15;Par·;553;91;America/Sao_Paulo
-3550803;S„o Sebasti„o da Grama;-217041;-468208;0;35;S„o Paulo;7117;19;America/Sao_Paulo
-3164431;S„o Sebasti„o da Vargem Alegre;-197477;-433679;0;31;Minas Gerais;726;32;America/Sao_Paulo
-2515104;S„o Sebasti„o de Lagoa de RoÁa;-711034;-358678;0;25;ParaÌba;2203;83;America/Sao_Paulo
-3305307;S„o Sebasti„o do Alto;-219578;-421328;0;33;Rio de Janeiro;5905;22;America/Sao_Paulo
-3164472;S„o Sebasti„o do Anta;-195064;-41985;0;31;Minas Gerais;728;33;America/Sao_Paulo
-4319505;S„o Sebasti„o do CaÌ;-295885;-513749;0;43;Rio Grande do Sul;8893;51;America/Sao_Paulo
-3164506;S„o Sebasti„o do Maranh„o;-180873;-425659;0;31;Minas Gerais;5289;33;America/Sao_Paulo
-3164605;S„o Sebasti„o do Oeste;-202758;-450063;0;31;Minas Gerais;5291;37;America/Sao_Paulo
-3164704;S„o Sebasti„o do ParaÌso;-209167;-469837;0;31;Minas Gerais;5293;35;America/Sao_Paulo
-2929503;S„o Sebasti„o do PassÈ;-125123;-384905;0;29;Bahia;3889;71;America/Sao_Paulo
-3164803;S„o Sebasti„o do Rio Preto;-192959;-431757;0;31;Minas Gerais;5295;31;America/Sao_Paulo
-3164902;S„o Sebasti„o do Rio Verde;-222183;-449761;0;31;Minas Gerais;5297;35;America/Sao_Paulo
-1720309;S„o Sebasti„o do Tocantins;-526131;-482021;0;17;Tocantins;9603;63;America/Sao_Paulo
-1303957;S„o Sebasti„o do Uatum„;-255915;-578731;0;13;Amazonas;9845;92;America/Porto_Velho
-2515203;S„o Sebasti„o do Umbuzeiro;-815289;-370138;0;25;ParaÌba;2205;83;America/Sao_Paulo
-4319604;S„o SepÈ;-301643;-535603;0;43;Rio Grande do Sul;8895;55;America/Sao_Paulo
-3550902;S„o Sim„o;-214732;-475518;0;35;S„o Paulo;7119;16;America/Sao_Paulo
-5220405;S„o Sim„o;-18996;-50547;0;52;Goi·s;9605;64;America/Sao_Paulo
-3165206;S„o ThomÈ das Letras;-217218;-449849;0;31;Minas Gerais;5303;35;America/Sao_Paulo
-3165008;S„o Tiago;-209075;-445098;0;31;Minas Gerais;5299;32;America/Sao_Paulo
-3165107;S„o Tom·s de Aquino;-207791;-470962;0;31;Minas Gerais;5301;35;America/Sao_Paulo
-4126108;S„o TomÈ;-235349;-525901;0;41;Paran·;7897;44;America/Sao_Paulo
-2412906;S„o TomÈ;-596404;-360798;0;24;Rio Grande do Norte;1855;84;America/Sao_Paulo
-4319703;S„o Valentim;-275583;-525237;0;43;Rio Grande do Sul;8897;54;America/Sao_Paulo
-4319711;S„o Valentim do Sul;-290451;-517684;0;43;Rio Grande do Sul;5997;54;America/Sao_Paulo
-1720499;S„o ValÈrio;-119743;-482353;0;17;Tocantins;9691;63;America/Sao_Paulo
-4319737;S„o ValÈrio do Sul;-277906;-539368;0;43;Rio Grande do Sul;6075;55;America/Sao_Paulo
-4319752;S„o Vendelino;-293729;-513675;0;43;Rio Grande do Sul;7293;51;America/Sao_Paulo
-3551009;S„o Vicente;-239574;-463883;0;35;S„o Paulo;7121;13;America/Sao_Paulo
-2413003;S„o Vicente;-621893;-366827;0;24;Rio Grande do Norte;1857;84;America/Sao_Paulo
-3165305;S„o Vicente de Minas;-217042;-444431;0;31;Minas Gerais;5305;35;America/Sao_Paulo
-2515401;S„o Vicente do SeridÛ;-685426;-364122;0;25;ParaÌba;2209;83;America/Sao_Paulo
-4319802;S„o Vicente do Sul;-296882;-546826;0;43;Rio Grande do Sul;8675;55;America/Sao_Paulo
-2613800;S„o Vicente Ferrer;-758969;-354808;0;26;Pernambuco;2575;81;America/Sao_Paulo
-2111706;S„o Vicente Ferrer;-289487;-448681;0;21;Maranh„o;927;98;America/Sao_Paulo
-2515302;SapÈ;-709359;-35228;0;25;ParaÌba;2207;83;America/Sao_Paulo
-2929602;SapeaÁu;-127208;-391824;0;29;Bahia;3891;75;America/Sao_Paulo
+2312304;S√£o Benedito;-404713;-408596;0;23;Cear√°;1547;88;America/Sao_Paulo
+2110401;S√£o Benedito do Rio Preto;-333515;-435287;0;21;Maranh√£o;905;98;America/Sao_Paulo
+2612901;S√£o Benedito do Sul;-88166;-359453;0;26;Pernambuco;2557;81;America/Sao_Paulo
+2513927;S√£o Bentinho;-688596;-377243;0;25;Para√≠ba;518;83;America/Sao_Paulo
+2513901;S√£o Bento;-648529;-374488;0;25;Para√≠ba;2179;83;America/Sao_Paulo
+2110500;S√£o Bento;-269781;-448289;0;21;Maranh√£o;907;98;America/Sao_Paulo
+3160801;S√£o Bento Abade;-215839;-450699;0;31;Minas Gerais;5215;35;America/Sao_Paulo
+2411601;S√£o Bento do Norte;-509259;-359587;0;24;Rio Grande do Norte;1831;84;America/Sao_Paulo
+3548609;S√£o Bento do Sapuca√≠;-226837;-457287;0;35;S√£o Paulo;7073;12;America/Sao_Paulo
+4215802;S√£o Bento do Sul;-262495;-493831;0;42;Santa Catarina;8311;47;America/Sao_Paulo
+1720101;S√£o Bento do Tocantins;-60258;-479012;0;17;Tocantins;197;63;America/Sao_Paulo
+2411700;S√£o Bento do Trair√≠;-633798;-360863;0;24;Rio Grande do Norte;1833;84;America/Sao_Paulo
+2613008;S√£o Bento do Una;-852637;-364465;0;26;Pernambuco;2559;81;America/Sao_Paulo
+4215752;S√£o Bernardino;-264739;-529687;0;42;Santa Catarina;942;49;America/Sao_Paulo
+2110609;S√£o Bernardo;-337223;-424191;0;21;Maranh√£o;909;98;America/Sao_Paulo
+3548708;S√£o Bernardo do Campo;-236914;-465646;0;35;S√£o Paulo;7075;11;America/Sao_Paulo
+4215901;S√£o Bonif√°cio;-279009;-489326;0;42;Santa Catarina;8313;48;America/Sao_Paulo
+4318002;S√£o Borja;-286578;-560036;0;43;Rio Grande do Sul;8863;55;America/Sao_Paulo
+2708204;S√£o Br√°s;-101141;-368522;0;27;Alagoas;2863;82;America/Sao_Paulo
+3160900;S√£o Br√°s do Sua√ßu√≠;-206242;-439515;0;31;Minas Gerais;5217;31;America/Sao_Paulo
+2209559;S√£o Braz do Piau√≠;-905797;-430076;0;22;Piau√≠;2263;89;America/Sao_Paulo
+2613107;S√£o Caetano;-833763;-362869;0;26;Pernambuco;2561;81;America/Sao_Paulo
+1507102;S√£o Caetano de Odivelas;-747293;-480246;0;15;Par√°;541;91;America/Sao_Paulo
+3548807;S√£o Caetano do Sul;-236229;-465548;0;35;S√£o Paulo;7077;11;America/Sao_Paulo
+3548906;S√£o Carlos;-220174;-47886;0;35;S√£o Paulo;7079;16;America/Sao_Paulo
+4216008;S√£o Carlos;-270798;-530037;0;42;Santa Catarina;8315;49;America/Sao_Paulo
+4124608;S√£o Carlos do Iva√≠;-233158;-524761;0;41;Paran√°;7867;44;America/Sao_Paulo
+2806701;S√£o Crist√≥v√£o;-110084;-372044;0;28;Sergipe;3233;79;America/Sao_Paulo
+4216057;S√£o Cristov√£o do Sul;-272666;-504388;0;42;Santa Catarina;5573;49;America/Sao_Paulo
+2928901;S√£o Desid√©rio;-123572;-449769;0;29;Bahia;3877;77;America/Sao_Paulo
+2928950;S√£o Domingos;-114649;-395268;0;29;Bahia;3029;75;America/Sao_Paulo
+4216107;S√£o Domingos;-265548;-525313;0;42;Santa Catarina;8317;49;America/Sao_Paulo
+2513968;S√£o Domingos;-680313;-379488;0;25;Para√≠ba;522;83;America/Sao_Paulo
+2806800;S√£o Domingos;-107916;-375685;0;28;Sergipe;3235;79;America/Sao_Paulo
+5219803;S√£o Domingos;-13621;-467415;0;52;Goi√°s;9591;62;America/Sao_Paulo
+3160959;S√£o Domingos das Dores;-195246;-420106;0;31;Minas Gerais;710;33;America/Sao_Paulo
+1507151;S√£o Domingos do Araguaia;-553732;-487366;0;15;Par√°;381;94;America/Sao_Paulo
+2110658;S√£o Domingos do Azeit√£o;-681471;-446509;0;21;Maranh√£o;228;99;America/Sao_Paulo
+1507201;S√£o Domingos do Capim;-168768;-477665;0;15;Par√°;543;91;America/Sao_Paulo
+2513943;S√£o Domingos do Cariri;-763273;-364374;0;25;Para√≠ba;520;83;America/Sao_Paulo
+2110708;S√£o Domingos do Maranh√£o;-558095;-443822;0;21;Maranh√£o;911;99;America/Sao_Paulo
+3204658;S√£o Domingos do Norte;-191452;-406281;0;32;Esp√≠rito Santo;2933;27;America/Sao_Paulo
+3161007;S√£o Domingos do Prata;-198678;-42971;0;31;Minas Gerais;5219;31;America/Sao_Paulo
+4318051;S√£o Domingos do Sul;-285312;-51886;0;43;Rio Grande do Sul;7351;54;America/Sao_Paulo
+2929107;S√£o Felipe;-128394;-390893;0;29;Bahia;3881;75;America/Sao_Paulo
+1101484;S√£o Felipe D'Oeste;-119023;-615026;0;11;Rond√¥nia;18;69;America/Porto_Velho
+2929008;S√£o F√©lix;-126104;-389727;0;29;Bahia;3879;75;America/Sao_Paulo
+2110807;S√£o F√©lix de Balsas;-707535;-448092;0;21;Maranh√£o;913;99;America/Sao_Paulo
+3161056;S√£o F√©lix de Minas;-185959;-414889;0;31;Minas Gerais;712;33;America/Sao_Paulo
+5107859;S√£o F√©lix do Araguaia;-11615;-506706;0;51;Mato Grosso;9183;66;America/Porto_Velho
+2929057;S√£o F√©lix do Coribe;-134019;-441837;0;29;Bahia;3031;77;America/Sao_Paulo
+2209609;S√£o F√©lix do Piau√≠;-593485;-421172;0;22;Piau√≠;1191;86;America/Sao_Paulo
+1720150;S√£o F√©lix do Tocantins;-101615;-466618;0;17;Tocantins;363;63;America/Sao_Paulo
+1507300;S√£o F√©lix do Xingu;-664254;-519904;0;15;Par√°;545;94;America/Sao_Paulo
+2411809;S√£o Fernando;-637975;-371864;0;24;Rio Grande do Norte;1835;84;America/Sao_Paulo
+3304805;S√£o Fid√©lis;-216551;-41756;0;33;Rio de Janeiro;5895;22;America/Sao_Paulo
+3549003;S√£o Francisco;-203623;-506952;0;35;S√£o Paulo;7081;17;America/Sao_Paulo
+2513984;S√£o Francisco;-660773;-380968;0;25;Para√≠ba;524;83;America/Sao_Paulo
+2806909;S√£o Francisco;-103442;-368869;0;28;Sergipe;3237;79;America/Sao_Paulo
+3161106;S√£o Francisco;-159514;-448593;0;31;Minas Gerais;5221;38;America/Sao_Paulo
+4318101;S√£o Francisco de Assis;-295547;-551253;0;43;Rio Grande do Sul;8865;55;America/Sao_Paulo
+2209658;S√£o Francisco de Assis do Piau√≠;-823599;-416873;0;22;Piau√≠;380;89;America/Sao_Paulo
+5219902;S√£o Francisco de Goi√°s;-159256;-492605;0;52;Goi√°s;9593;62;America/Sao_Paulo
+3304755;S√£o Francisco de Itabapoana;-214702;-411091;0;33;Rio de Janeiro;782;22;America/Sao_Paulo
+4318200;S√£o Francisco de Paula;-294404;-505828;0;43;Rio Grande do Sul;8867;54;America/Sao_Paulo
+3161205;S√£o Francisco de Paula;-207036;-449838;0;31;Minas Gerais;5223;37;America/Sao_Paulo
+3161304;S√£o Francisco de Sales;-198611;-497727;0;31;Minas Gerais;5225;34;America/Sao_Paulo
+2110856;S√£o Francisco do Brej√£o;-512584;-47389;0;21;Maranh√£o;230;99;America/Sao_Paulo
+2929206;S√£o Francisco do Conde;-126183;-386786;0;29;Bahia;3883;71;America/Sao_Paulo
+3161403;S√£o Francisco do Gl√≥ria;-207923;-422673;0;31;Minas Gerais;5227;32;America/Sao_Paulo
+1101492;S√£o Francisco do Guapor√©;-12052;-63568;0;11;Rond√¥nia;20;69;America/Porto_Velho
+2110906;S√£o Francisco do Maranh√£o;-625159;-428668;0;21;Maranh√£o;915;99;America/Sao_Paulo
+2411908;S√£o Francisco do Oeste;-597472;-381519;0;24;Rio Grande do Norte;1821;84;America/Sao_Paulo
+1507409;S√£o Francisco do Par√°;-116963;-477917;0;15;Par√°;547;91;America/Sao_Paulo
+2209708;S√£o Francisco do Piau√≠;-72463;-42541;0;22;Piau√≠;1193;89;America/Sao_Paulo
+4216206;S√£o Francisco do Sul;-262579;-486344;0;42;Santa Catarina;8319;47;America/Sao_Paulo
+4318309;S√£o Gabriel;-303337;-543217;0;43;Rio Grande do Sul;8869;55;America/Sao_Paulo
+2929255;S√£o Gabriel;-112175;-418843;0;29;Bahia;3989;74;America/Sao_Paulo
+1303809;S√£o Gabriel da Cachoeira;-11909;-67084;0;13;Amazonas;283;97;America/Porto_Velho
+3204708;S√£o Gabriel da Palha;-190182;-405365;0;32;Esp√≠rito Santo;5693;27;America/Sao_Paulo
+5007695;S√£o Gabriel do Oeste;-193889;-545507;0;50;Mato Grosso do Sul;9809;67;America/Porto_Velho
+3161502;S√£o Geraldo;-209252;-428364;0;31;Minas Gerais;5229;32;America/Sao_Paulo
+3161601;S√£o Geraldo da Piedade;-188411;-422867;0;31;Minas Gerais;5231;33;America/Sao_Paulo
+1507458;S√£o Geraldo do Araguaia;-639471;-485592;0;15;Par√°;619;94;America/Sao_Paulo
+3161650;S√£o Geraldo do Baixio;-189097;-41363;0;31;Minas Gerais;714;33;America/Sao_Paulo
+3304904;S√£o Gon√ßalo;-228268;-430634;0;33;Rio de Janeiro;5897;21;America/Sao_Paulo
+3161700;S√£o Gon√ßalo do Abaet√©;-183315;-458265;0;31;Minas Gerais;5233;38;America/Sao_Paulo
+2412005;S√£o Gon√ßalo do Amarante;-579068;-353257;0;24;Rio Grande do Norte;1837;84;America/Sao_Paulo
+2312403;S√£o Gon√ßalo do Amarante;-360515;-389726;0;23;Cear√°;1549;85;America/Sao_Paulo
+2209757;S√£o Gon√ßalo do Gurgu√©ia;-100319;-453092;0;22;Piau√≠;382;89;America/Sao_Paulo
+3161809;S√£o Gon√ßalo do Par√°;-199822;-448593;0;31;Minas Gerais;5235;37;America/Sao_Paulo
+2209807;S√£o Gon√ßalo do Piau√≠;-599393;-427095;0;22;Piau√≠;1195;86;America/Sao_Paulo
+3161908;S√£o Gon√ßalo do Rio Abaixo;-198221;-43366;0;31;Minas Gerais;5237;31;America/Sao_Paulo
+3125507;S√£o Gon√ßalo do Rio Preto;-180025;-433854;0;31;Minas Gerais;4509;38;America/Sao_Paulo
+3162005;S√£o Gon√ßalo do Sapuca√≠;-218932;-455893;0;31;Minas Gerais;5239;35;America/Sao_Paulo
+2929305;S√£o Gon√ßalo dos Campos;-124331;-389663;0;29;Bahia;3885;75;America/Sao_Paulo
+3162104;S√£o Gotardo;-193087;-460465;0;31;Minas Gerais;5241;34;America/Sao_Paulo
+4318408;S√£o Jer√¥nimo;-299716;-517251;0;43;Rio Grande do Sul;8871;51;America/Sao_Paulo
+4124707;S√£o Jer√¥nimo da Serra;-237218;-507475;0;41;Paran√°;7869;43;America/Sao_Paulo
+4124806;S√£o Jo√£o;-258214;-527252;0;41;Paran√°;7871;46;America/Sao_Paulo
+2613206;S√£o Jo√£o;-887576;-363653;0;26;Pernambuco;2563;87;America/Sao_Paulo
+2111003;S√£o Jo√£o Batista;-295398;-447953;0;21;Maranh√£o;917;98;America/Sao_Paulo
+4216305;S√£o Jo√£o Batista;-272772;-488474;0;42;Santa Catarina;8321;48;America/Sao_Paulo
+3162203;S√£o Jo√£o Batista do Gl√≥ria;-20635;-46508;0;31;Minas Gerais;5243;35;America/Sao_Paulo
+5220009;S√£o Jo√£o d'Alian√ßa;-147048;-475228;0;52;Goi√°s;9597;62;America/Sao_Paulo
+1400506;S√£o Jo√£o da Baliza;951659;-599133;0;14;Roraima;313;95;America/Porto_Velho
+3305000;S√£o Jo√£o da Barra;-21638;-410446;0;33;Rio de Janeiro;5899;22;America/Sao_Paulo
+3549102;S√£o Jo√£o da Boa Vista;-219707;-467944;0;35;S√£o Paulo;7083;19;America/Sao_Paulo
+2209856;S√£o Jo√£o da Canabrava;-681203;-413415;0;22;Piau√≠;1291;89;America/Sao_Paulo
+2209872;S√£o Jo√£o da Fronteira;-395497;-412569;0;22;Piau√≠;384;86;America/Sao_Paulo
+3162252;S√£o Jo√£o da Lagoa;-168455;-443507;0;31;Minas Gerais;716;38;America/Sao_Paulo
+3162302;S√£o Jo√£o da Mata;-21928;-459297;0;31;Minas Gerais;5245;35;America/Sao_Paulo
+5220058;S√£o Jo√£o da Para√∫na;-168126;-504092;0;52;Goi√°s;9747;64;America/Sao_Paulo
+1507466;S√£o Jo√£o da Ponta;-857885;-47918;0;15;Par√°;64;91;America/Sao_Paulo
+3162401;S√£o Jo√£o da Ponte;-159271;-440096;0;31;Minas Gerais;5247;38;America/Sao_Paulo
+2209906;S√£o Jo√£o da Serra;-551081;-418923;0;22;Piau√≠;1197;86;America/Sao_Paulo
+4318424;S√£o Jo√£o da Urtiga;-278195;-518257;0;43;Rio Grande do Sul;7349;54;America/Sao_Paulo
+2209955;S√£o Jo√£o da Varjota;-694082;-418889;0;22;Piau√≠;386;89;America/Sao_Paulo
+3549201;S√£o Jo√£o das Duas Pontes;-203879;-503792;0;35;S√£o Paulo;7085;17;America/Sao_Paulo
+3162450;S√£o Jo√£o das Miss√µes;-148859;-440922;0;31;Minas Gerais;718;38;America/Sao_Paulo
+3549250;S√£o Jo√£o de Iracema;-205111;-503561;0;35;S√£o Paulo;2941;17;America/Sao_Paulo
+3305109;S√£o Jo√£o de Meriti;-228058;-433729;0;33;Rio de Janeiro;5901;21;America/Sao_Paulo
+1507474;S√£o Jo√£o de Pirabas;-780222;-47181;0;15;Par√°;393;91;America/Sao_Paulo
+3162500;S√£o Jo√£o del Rei;-211311;-442526;0;31;Minas Gerais;5249;32;America/Sao_Paulo
+1507508;S√£o Jo√£o do Araguaia;-536334;-487926;0;15;Par√°;549;94;America/Sao_Paulo
+2209971;S√£o Jo√£o do Arraial;-38186;-424459;0;22;Piau√≠;388;86;America/Sao_Paulo
+4124905;S√£o Jo√£o do Caiu√°;-228535;-523411;0;41;Paran√°;7873;44;America/Sao_Paulo
+2514008;S√£o Jo√£o do Cariri;-738168;-365345;0;25;Para√≠ba;2181;83;America/Sao_Paulo
+2111029;S√£o Jo√£o do Car√∫;-35503;-462507;0;21;Maranh√£o;232;98;America/Sao_Paulo
+4216354;S√£o Jo√£o do Itaperi√∫;-266213;-487683;0;42;Santa Catarina;5551;47;America/Sao_Paulo
+4125001;S√£o Jo√£o do Iva√≠;-239833;-518215;0;41;Paran√°;7875;43;America/Sao_Paulo
+2312502;S√£o Jo√£o do Jaguaribe;-527516;-382694;0;23;Cear√°;1551;88;America/Sao_Paulo
+3162559;S√£o Jo√£o do Manhua√ßu;-203933;-421533;0;31;Minas Gerais;2677;33;America/Sao_Paulo
+3162575;S√£o Jo√£o do Manteninha;-18723;-411628;0;31;Minas Gerais;2679;33;America/Sao_Paulo
+4216255;S√£o Jo√£o do Oeste;-270984;-535977;0;42;Santa Catarina;5753;49;America/Sao_Paulo
+3162609;S√£o Jo√£o do Oriente;-193384;-421575;0;31;Minas Gerais;5251;33;America/Sao_Paulo
+3162658;S√£o Jo√£o do Pacu√≠;-165373;-445134;0;31;Minas Gerais;720;38;America/Sao_Paulo
+3162708;S√£o Jo√£o do Para√≠so;-153168;-420213;0;31;Minas Gerais;5253;38;America/Sao_Paulo
+2111052;S√£o Jo√£o do Para√≠so;-645634;-470594;0;21;Maranh√£o;234;99;America/Sao_Paulo
+3549300;S√£o Jo√£o do Pau d'Alho;-212662;-516672;0;35;S√£o Paulo;7087;18;America/Sao_Paulo
+2210003;S√£o Jo√£o do Piau√≠;-835466;-422559;0;22;Piau√≠;1199;89;America/Sao_Paulo
+4318432;S√£o Jo√£o do Pol√™sine;-296194;-534439;0;43;Rio Grande do Sul;5791;55;America/Sao_Paulo
+2500700;S√£o Jo√£o do Rio do Peixe;-672195;-384468;0;25;Para√≠ba;1913;83;America/Sao_Paulo
+2412104;S√£o Jo√£o do Sabugi;-671387;-372027;0;24;Rio Grande do Norte;1839;84;America/Sao_Paulo
+2111078;S√£o Jo√£o do Soter;-510821;-438163;0;21;Maranh√£o;236;99;America/Sao_Paulo
+4216404;S√£o Jo√£o do Sul;-292154;-498094;0;42;Santa Catarina;8323;48;America/Sao_Paulo
+2514107;S√£o Jo√£o do Tigre;-807703;-368547;0;25;Para√≠ba;2183;83;America/Sao_Paulo
+4125100;S√£o Jo√£o do Triunfo;-25683;-502949;0;41;Paran√°;7877;42;America/Sao_Paulo
+2111102;S√£o Jo√£o dos Patos;-64934;-437036;0;21;Maranh√£o;919;99;America/Sao_Paulo
+3162807;S√£o Jo√£o Evangelista;-18548;-427655;0;31;Minas Gerais;5255;33;America/Sao_Paulo
+3162906;S√£o Jo√£o Nepomuceno;-215381;-430069;0;31;Minas Gerais;5257;32;America/Sao_Paulo
+4216503;S√£o Joaquim;-282887;-499457;0;42;Santa Catarina;8325;49;America/Sao_Paulo
+3549409;S√£o Joaquim da Barra;-205812;-478593;0;35;S√£o Paulo;7089;16;America/Sao_Paulo
+3162922;S√£o Joaquim de Bicas;-20048;-442749;0;31;Minas Gerais;722;31;America/Sao_Paulo
+2613305;S√£o Joaquim do Monte;-843196;-358035;0;26;Pernambuco;2565;81;America/Sao_Paulo
+4318440;S√£o Jorge;-284984;-517064;0;43;Rio Grande do Sul;7347;54;America/Sao_Paulo
+4125209;S√£o Jorge d'Oeste;-257085;-529204;0;41;Paran√°;7881;46;America/Sao_Paulo
+4125308;S√£o Jorge do Iva√≠;-234336;-522929;0;41;Paran√°;7879;44;America/Sao_Paulo
+4125357;S√£o Jorge do Patroc√≠nio;-237647;-538823;0;41;Paran√°;7999;44;America/Sao_Paulo
+4216602;S√£o Jos√©;-276136;-486366;0;42;Santa Catarina;8327;48;America/Sao_Paulo
+3162948;S√£o Jos√© da Barra;-207178;-46313;0;31;Minas Gerais;724;35;America/Sao_Paulo
+3549508;S√£o Jos√© da Bela Vista;-205935;-476424;0;35;S√£o Paulo;7091;16;America/Sao_Paulo
+4125407;S√£o Jos√© da Boa Vista;-239122;-496577;0;41;Paran√°;7883;43;America/Sao_Paulo
+2613404;S√£o Jos√© da Coroa Grande;-888937;-351515;0;26;Pernambuco;2567;81;America/Sao_Paulo
+2514206;S√£o Jos√© da Lagoa Tapada;-693646;-381622;0;25;Para√≠ba;2185;83;America/Sao_Paulo
+2708303;S√£o Jos√© da Laje;-901278;-360515;0;27;Alagoas;2865;82;America/Sao_Paulo
+3162955;S√£o Jos√© da Lapa;-196971;-439586;0;31;Minas Gerais;2649;31;America/Sao_Paulo
+3163003;S√£o Jos√© da Safira;-183243;-421431;0;31;Minas Gerais;5259;33;America/Sao_Paulo
+2708402;S√£o Jos√© da Tapera;-955768;-373831;0;27;Alagoas;2867;82;America/Sao_Paulo
+3163102;S√£o Jos√© da Varginha;-197006;-44556;0;31;Minas Gerais;5261;37;America/Sao_Paulo
+2929354;S√£o Jos√© da Vit√≥ria;-150787;-393437;0;29;Bahia;3035;73;America/Sao_Paulo
+4318457;S√£o Jos√© das Miss√µes;-277789;-531226;0;43;Rio Grande do Sul;5989;55;America/Sao_Paulo
+4125456;S√£o Jos√© das Palmeiras;-248369;-540572;0;41;Paran√°;8471;45;America/Sao_Paulo
+2514305;S√£o Jos√© de Caiana;-724636;-382989;0;25;Para√≠ba;2187;83;America/Sao_Paulo
+2514404;S√£o Jos√© de Espinharas;-683974;-373214;0;25;Para√≠ba;2189;83;America/Sao_Paulo
+2412203;S√£o Jos√© de Mipibu;-60773;-352417;0;24;Rio Grande do Norte;1841;84;America/Sao_Paulo
+2514503;S√£o Jos√© de Piranhas;-71187;-38502;0;25;Para√≠ba;2191;83;America/Sao_Paulo
+2514552;S√£o Jos√© de Princesa;-773633;-380894;0;25;Para√≠ba;528;83;America/Sao_Paulo
+2111201;S√£o Jos√© de Ribamar;-254704;-440597;0;21;Maranh√£o;889;98;America/Sao_Paulo
+3305133;S√£o Jos√© de Ub√°;-213661;-419511;0;33;Rio de Janeiro;784;22;America/Sao_Paulo
+3163201;S√£o Jos√© do Alegre;-223243;-455258;0;31;Minas Gerais;5263;35;America/Sao_Paulo
+3549607;S√£o Jos√© do Barreiro;-226414;-445774;0;35;S√£o Paulo;7093;12;America/Sao_Paulo
+2613503;S√£o Jos√© do Belmonte;-785723;-387577;0;26;Pernambuco;2569;87;America/Sao_Paulo
+2514602;S√£o Jos√© do Bonfim;-71607;-373036;0;25;Para√≠ba;2193;83;America/Sao_Paulo
+2514651;S√£o Jos√© do Brejo do Cruz;-621054;-373601;0;25;Para√≠ba;530;83;America/Sao_Paulo
+3204807;S√£o Jos√© do Cal√ßado;-210274;-416636;0;32;Esp√≠rito Santo;5695;28;America/Sao_Paulo
+2412302;S√£o Jos√© do Campestre;-631087;-357067;0;24;Rio Grande do Norte;1843;84;America/Sao_Paulo
+4216701;S√£o Jos√© do Cedro;-264561;-534955;0;42;Santa Catarina;8329;49;America/Sao_Paulo
+4216800;S√£o Jos√© do Cerrito;-276602;-505733;0;42;Santa Catarina;8331;49;America/Sao_Paulo
+2210052;S√£o Jos√© do Divino;-381411;-418308;0;22;Piau√≠;2285;86;America/Sao_Paulo
+3163300;S√£o Jos√© do Divino;-184793;-413907;0;31;Minas Gerais;5265;33;America/Sao_Paulo
+2613602;S√£o Jos√© do Egito;-746945;-37274;0;26;Pernambuco;2571;87;America/Sao_Paulo
+3163409;S√£o Jos√© do Goiabal;-199214;-427035;0;31;Minas Gerais;5267;31;America/Sao_Paulo
+4318465;S√£o Jos√© do Herval;-29052;-52295;0;43;Rio Grande do Sul;7345;54;America/Sao_Paulo
+4318481;S√£o Jos√© do Hort√™ncio;-29528;-51245;0;43;Rio Grande do Sul;7343;51;America/Sao_Paulo
+4318499;S√£o Jos√© do Inhacor√°;-277251;-541275;0;43;Rio Grande do Sul;6059;55;America/Sao_Paulo
+2929370;S√£o Jos√© do Jacu√≠pe;-114137;-398669;0;29;Bahia;3033;74;America/Sao_Paulo
+3163508;S√£o Jos√© do Jacuri;-18281;-426729;0;31;Minas Gerais;5269;33;America/Sao_Paulo
+3163607;S√£o Jos√© do Mantimento;-200058;-417486;0;31;Minas Gerais;5271;33;America/Sao_Paulo
+4318507;S√£o Jos√© do Norte;-320151;-520331;0;43;Rio Grande do Sul;8873;53;America/Sao_Paulo
+4318606;S√£o Jos√© do Ouro;-277707;-515966;0;43;Rio Grande do Sul;8875;54;America/Sao_Paulo
+2210102;S√£o Jos√© do Peixe;-748554;-425672;0;22;Piau√≠;1201;89;America/Sao_Paulo
+2210201;S√£o Jos√© do Piau√≠;-687194;-414731;0;22;Piau√≠;1203;89;America/Sao_Paulo
+5107297;S√£o Jos√© do Povo;-164549;-542487;0;51;Mato Grosso;6087;66;America/Porto_Velho
+5107305;S√£o Jos√© do Rio Claro;-134398;-567218;0;51;Mato Grosso;9199;65;America/Porto_Velho
+3549706;S√£o Jos√© do Rio Pardo;-215953;-468873;0;35;S√£o Paulo;7095;19;America/Sao_Paulo
+3549805;S√£o Jos√© do Rio Preto;-208113;-493758;0;35;S√£o Paulo;7097;17;America/Sao_Paulo
+2514701;S√£o Jos√© do Sabugi;-676295;-367972;0;25;Para√≠ba;2195;83;America/Sao_Paulo
+2412401;S√£o Jos√© do Serid√≥;-644002;-368746;0;24;Rio Grande do Norte;1845;84;America/Sao_Paulo
+4318614;S√£o Jos√© do Sul;-295448;-514821;0;43;Rio Grande do Sul;1170;51;America/Sao_Paulo
+3305158;S√£o Jos√© do Vale do Rio Preto;-221525;-429327;0;33;Rio de Janeiro;6009;24;America/Sao_Paulo
+5107354;S√£o Jos√© do Xingu;-107982;-527486;0;51;Mato Grosso;133;66;America/Porto_Velho
+4318622;S√£o Jos√© dos Ausentes;-287476;-500677;0;43;Rio Grande do Sul;6015;54;America/Sao_Paulo
+2111250;S√£o Jos√© dos Bas√≠lios;-505493;-445809;0;21;Maranh√£o;238;99;America/Sao_Paulo
+3549904;S√£o Jos√© dos Campos;-231896;-458841;0;35;S√£o Paulo;7099;12;America/Sao_Paulo
+2514800;S√£o Jos√© dos Cordeiros;-738775;-368085;0;25;Para√≠ba;2197;83;America/Sao_Paulo
+4125506;S√£o Jos√© dos Pinhais;-255313;-492031;0;41;Paran√°;7885;41;America/Sao_Paulo
+5107107;S√£o Jos√© dos Quatro Marcos;-156276;-581772;0;51;Mato Grosso;8993;65;America/Porto_Velho
+2514453;S√£o Jos√© dos Ramos;-725238;-353725;0;25;Para√≠ba;526;83;America/Sao_Paulo
+2210300;S√£o Juli√£o;-708391;-408246;0;22;Piau√≠;1205;89;America/Sao_Paulo
+4318705;S√£o Leopoldo;-297545;-511498;0;43;Rio Grande do Sul;8877;51;America/Sao_Paulo
+3163706;S√£o Louren√ßo;-221166;-450506;0;31;Minas Gerais;5273;35;America/Sao_Paulo
+2613701;S√£o Louren√ßo da Mata;-800684;-350124;0;26;Pernambuco;2573;81;America/Sao_Paulo
+3549953;S√£o Louren√ßo da Serra;-238491;-469432;0;35;S√£o Paulo;5447;11;America/Sao_Paulo
+4216909;S√£o Louren√ßo do Oeste;-263557;-528498;0;42;Santa Catarina;8333;49;America/Sao_Paulo
+2210359;S√£o Louren√ßo do Piau√≠;-916463;-425496;0;22;Piau√≠;2265;89;America/Sao_Paulo
+4318804;S√£o Louren√ßo do Sul;-313564;-519715;0;43;Rio Grande do Sul;8879;53;America/Sao_Paulo
+4217006;S√£o Ludgero;-283144;-491806;0;42;Santa Catarina;8335;48;America/Sao_Paulo
+2111300;S√£o Lu√≠s;-253874;-442825;1;21;Maranh√£o;921;98;America/Sao_Paulo
+5220108;S√£o Lu√≠s de Montes Belos;-165211;-503726;0;52;Goi√°s;9599;64;America/Sao_Paulo
+2312601;S√£o Lu√≠s do Curu;-366976;-392391;0;23;Cear√°;1553;85;America/Sao_Paulo
+2210375;S√£o Luis do Piau√≠;-681936;-413175;0;22;Piau√≠;390;89;America/Sao_Paulo
+2708501;S√£o Lu√≠s do Quitunde;-931816;-355606;0;27;Alagoas;2869;82;America/Sao_Paulo
+2111409;S√£o Lu√≠s Gonzaga do Maranh√£o;-438541;-446654;0;21;Maranh√£o;805;99;America/Sao_Paulo
+1400605;S√£o Luiz;101019;-600419;0;14;Roraima;315;95;America/Porto_Velho
+5220157;S√£o Luiz do Norte;-148608;-493285;0;52;Goi√°s;9749;62;America/Sao_Paulo
+3550001;S√£o Luiz do Paraitinga;-23222;-453109;0;35;S√£o Paulo;7101;12;America/Sao_Paulo
+4318903;S√£o Luiz Gonzaga;-28412;-549559;0;43;Rio Grande do Sul;8881;55;America/Sao_Paulo
+2514909;S√£o Mamede;-692386;-370954;0;25;Para√≠ba;2199;83;America/Sao_Paulo
+4125555;S√£o Manoel do Paran√°;-233941;-526454;0;41;Paran√°;5515;44;America/Sao_Paulo
+3550100;S√£o Manuel;-227321;-485723;0;35;S√£o Paulo;7103;14;America/Sao_Paulo
+4319000;S√£o Marcos;-289677;-510696;0;43;Rio Grande do Sul;8883;54;America/Sao_Paulo
+4217105;S√£o Martinho;-281609;-489867;0;42;Santa Catarina;8337;48;America/Sao_Paulo
+4319109;S√£o Martinho;-277112;-539699;0;43;Rio Grande do Sul;8885;55;America/Sao_Paulo
+4319125;S√£o Martinho da Serra;-295397;-53859;0;43;Rio Grande do Sul;5793;55;America/Sao_Paulo
+3204906;S√£o Mateus;-187214;-398579;0;32;Esp√≠rito Santo;5697;27;America/Sao_Paulo
+2111508;S√£o Mateus do Maranh√£o;-403736;-444707;0;21;Maranh√£o;923;99;America/Sao_Paulo
+4125605;S√£o Mateus do Sul;-258677;-50384;0;41;Paran√°;7887;42;America/Sao_Paulo
+2412500;S√£o Miguel;-620283;-384947;0;24;Rio Grande do Norte;1847;84;America/Sao_Paulo
+3550209;S√£o Miguel Arcanjo;-238782;-479935;0;35;S√£o Paulo;7105;15;America/Sao_Paulo
+2210383;S√£o Miguel da Baixa Grande;-585646;-421934;0;22;Piau√≠;392;86;America/Sao_Paulo
+4217154;S√£o Miguel da Boa Vista;-26687;-532511;0;42;Santa Catarina;5755;49;America/Sao_Paulo
+2929404;S√£o Miguel das Matas;-130434;-394578;0;29;Bahia;3887;75;America/Sao_Paulo
+4319158;S√£o Miguel das Miss√µes;-28556;-545559;0;43;Rio Grande do Sul;7341;55;America/Sao_Paulo
+2515005;S√£o Miguel de Taipu;-724764;-352016;0;25;Para√≠ba;2201;83;America/Sao_Paulo
+2807006;S√£o Miguel do Aleixo;-103847;-373836;0;28;Sergipe;3239;79;America/Sao_Paulo
+3163805;S√£o Miguel do Anta;-207067;-427174;0;31;Minas Gerais;5275;31;America/Sao_Paulo
+5220207;S√£o Miguel do Araguaia;-132731;-501634;0;52;Goi√°s;9601;62;America/Sao_Paulo
+2210391;S√£o Miguel do Fidalgo;-759713;-423676;0;22;Piau√≠;394;89;America/Sao_Paulo
+2412559;S√£o Miguel do Gostoso;-512302;-356354;0;24;Rio Grande do Norte;430;84;America/Sao_Paulo
+1507607;S√£o Miguel do Guam√°;-161307;-474784;0;15;Par√°;551;91;America/Sao_Paulo
+1100320;S√£o Miguel do Guapor√©;-116953;-627192;0;11;Rond√¥nia;45;69;America/Porto_Velho
+4125704;S√£o Miguel do Igua√ßu;-253492;-542405;0;41;Paran√°;7889;45;America/Sao_Paulo
+4217204;S√£o Miguel do Oeste;-267242;-535163;0;42;Santa Catarina;8339;49;America/Sao_Paulo
+5220264;S√£o Miguel do Passa Quatro;-170582;-48662;0;52;Goi√°s;9751;62;America/Sao_Paulo
+2210409;S√£o Miguel do Tapuio;-549729;-413165;0;22;Piau√≠;1207;86;America/Sao_Paulo
+1720200;S√£o Miguel do Tocantins;-556305;-475743;0;17;Tocantins;199;63;America/Sao_Paulo
+2708600;S√£o Miguel dos Campos;-978301;-360971;0;27;Alagoas;2871;82;America/Sao_Paulo
+2708709;S√£o Miguel dos Milagres;-926493;-353763;0;27;Alagoas;2873;82;America/Sao_Paulo
+4319208;S√£o Nicolau;-281834;-552654;0;43;Rio Grande do Sul;8887;55;America/Sao_Paulo
+5220280;S√£o Patr√≠cio;-1535;-49818;0;52;Goi√°s;1064;62;America/Sao_Paulo
+3550308;S√£o Paulo;-235329;-466395;1;35;S√£o Paulo;7107;11;America/Sao_Paulo
+4319307;S√£o Paulo das Miss√µes;-280195;-549404;0;43;Rio Grande do Sul;8889;55;America/Sao_Paulo
+1303908;S√£o Paulo de Oliven√ßa;-347292;-689646;0;13;Amazonas;275;97;America/Rio_Branco
+2412609;S√£o Paulo do Potengi;-58994;-357642;0;24;Rio Grande do Norte;1849;84;America/Sao_Paulo
+2412708;S√£o Pedro;-590559;-356317;0;24;Rio Grande do Norte;1851;84;America/Sao_Paulo
+3550407;S√£o Pedro;-225483;-479096;0;35;S√£o Paulo;7109;19;America/Sao_Paulo
+2111532;S√£o Pedro da √Ågua Branca;-508472;-484291;0;21;Maranh√£o;240;99;America/Sao_Paulo
+3305208;S√£o Pedro da Aldeia;-228429;-421026;0;33;Rio de Janeiro;5903;22;America/Sao_Paulo
+5107404;S√£o Pedro da Cipa;-160109;-549176;0;51;Mato Grosso;93;66;America/Porto_Velho
+4319356;S√£o Pedro da Serra;-294193;-515134;0;43;Rio Grande do Sul;6043;51;America/Sao_Paulo
+3163904;S√£o Pedro da Uni√£o;-21131;-466123;0;31;Minas Gerais;5277;35;America/Sao_Paulo
+4319364;S√£o Pedro das Miss√µes;-277706;-532513;0;43;Rio Grande do Sul;1172;55;America/Sao_Paulo
+4217253;S√£o Pedro de Alc√¢ntara;-275665;-488048;0;42;Santa Catarina;944;48;America/Sao_Paulo
+4319372;S√£o Pedro do Buti√°;-281243;-548926;0;43;Rio Grande do Sul;6063;55;America/Sao_Paulo
+4125753;S√£o Pedro do Igua√ßu;-249373;-538521;0;41;Paran√°;5489;45;America/Sao_Paulo
+4125803;S√£o Pedro do Iva√≠;-238634;-518568;0;41;Paran√°;7891;43;America/Sao_Paulo
+4125902;S√£o Pedro do Paran√°;-228239;-532241;0;41;Paran√°;7893;44;America/Sao_Paulo
+2210508;S√£o Pedro do Piau√≠;-592078;-427192;0;22;Piau√≠;1209;86;America/Sao_Paulo
+3164100;S√£o Pedro do Sua√ßu√≠;-183609;-425981;0;31;Minas Gerais;5281;33;America/Sao_Paulo
+4319406;S√£o Pedro do Sul;-296202;-541855;0;43;Rio Grande do Sul;8891;55;America/Sao_Paulo
+3550506;S√£o Pedro do Turvo;-227453;-497428;0;35;S√£o Paulo;7111;14;America/Sao_Paulo
+2111573;S√£o Pedro dos Crentes;-682389;-465319;0;21;Maranh√£o;242;99;America/Sao_Paulo
+3164001;S√£o Pedro dos Ferros;-201732;-425251;0;31;Minas Gerais;5279;33;America/Sao_Paulo
+2412807;S√£o Rafael;-579791;-368778;0;24;Rio Grande do Norte;1853;84;America/Sao_Paulo
+2111607;S√£o Raimundo das Mangabeiras;-702183;-454809;0;21;Maranh√£o;925;99;America/Sao_Paulo
+2111631;S√£o Raimundo do Doca Bezerra;-511053;-450696;0;21;Maranh√£o;244;99;America/Sao_Paulo
+2210607;S√£o Raimundo Nonato;-901241;-426987;0;22;Piau√≠;1211;89;America/Sao_Paulo
+2111672;S√£o Roberto;-50231;-45001;0;21;Maranh√£o;246;99;America/Sao_Paulo
+3164209;S√£o Rom√£o;-163641;-450749;0;31;Minas Gerais;5283;38;America/Sao_Paulo
+3550605;S√£o Roque;-235226;-471357;0;35;S√£o Paulo;7113;11;America/Sao_Paulo
+3164308;S√£o Roque de Minas;-20249;-463639;0;31;Minas Gerais;5285;37;America/Sao_Paulo
+3204955;S√£o Roque do Cana√£;-197411;-406526;0;32;Esp√≠rito Santo;764;27;America/Sao_Paulo
+1720259;S√£o Salvador do Tocantins;-127458;-482352;0;17;Tocantins;333;63;America/Sao_Paulo
+3550704;S√£o Sebasti√£o;-237951;-454143;0;35;S√£o Paulo;7115;12;America/Sao_Paulo
+2708808;S√£o Sebasti√£o;-993043;-36559;0;27;Alagoas;2875;82;America/Sao_Paulo
+4126009;S√£o Sebasti√£o da Amoreira;-234656;-507625;0;41;Paran√°;7895;43;America/Sao_Paulo
+3164407;S√£o Sebasti√£o da Bela Vista;-221583;-457546;0;31;Minas Gerais;5287;35;America/Sao_Paulo
+1507706;S√£o Sebasti√£o da Boa Vista;-171597;-495249;0;15;Par√°;553;91;America/Sao_Paulo
+3550803;S√£o Sebasti√£o da Grama;-217041;-468208;0;35;S√£o Paulo;7117;19;America/Sao_Paulo
+3164431;S√£o Sebasti√£o da Vargem Alegre;-197477;-433679;0;31;Minas Gerais;726;32;America/Sao_Paulo
+2515104;S√£o Sebasti√£o de Lagoa de Ro√ßa;-711034;-358678;0;25;Para√≠ba;2203;83;America/Sao_Paulo
+3305307;S√£o Sebasti√£o do Alto;-219578;-421328;0;33;Rio de Janeiro;5905;22;America/Sao_Paulo
+3164472;S√£o Sebasti√£o do Anta;-195064;-41985;0;31;Minas Gerais;728;33;America/Sao_Paulo
+4319505;S√£o Sebasti√£o do Ca√≠;-295885;-513749;0;43;Rio Grande do Sul;8893;51;America/Sao_Paulo
+3164506;S√£o Sebasti√£o do Maranh√£o;-180873;-425659;0;31;Minas Gerais;5289;33;America/Sao_Paulo
+3164605;S√£o Sebasti√£o do Oeste;-202758;-450063;0;31;Minas Gerais;5291;37;America/Sao_Paulo
+3164704;S√£o Sebasti√£o do Para√≠so;-209167;-469837;0;31;Minas Gerais;5293;35;America/Sao_Paulo
+2929503;S√£o Sebasti√£o do Pass√©;-125123;-384905;0;29;Bahia;3889;71;America/Sao_Paulo
+3164803;S√£o Sebasti√£o do Rio Preto;-192959;-431757;0;31;Minas Gerais;5295;31;America/Sao_Paulo
+3164902;S√£o Sebasti√£o do Rio Verde;-222183;-449761;0;31;Minas Gerais;5297;35;America/Sao_Paulo
+1720309;S√£o Sebasti√£o do Tocantins;-526131;-482021;0;17;Tocantins;9603;63;America/Sao_Paulo
+1303957;S√£o Sebasti√£o do Uatum√£;-255915;-578731;0;13;Amazonas;9845;92;America/Porto_Velho
+2515203;S√£o Sebasti√£o do Umbuzeiro;-815289;-370138;0;25;Para√≠ba;2205;83;America/Sao_Paulo
+4319604;S√£o Sep√©;-301643;-535603;0;43;Rio Grande do Sul;8895;55;America/Sao_Paulo
+3550902;S√£o Sim√£o;-214732;-475518;0;35;S√£o Paulo;7119;16;America/Sao_Paulo
+5220405;S√£o Sim√£o;-18996;-50547;0;52;Goi√°s;9605;64;America/Sao_Paulo
+3165206;S√£o Thom√© das Letras;-217218;-449849;0;31;Minas Gerais;5303;35;America/Sao_Paulo
+3165008;S√£o Tiago;-209075;-445098;0;31;Minas Gerais;5299;32;America/Sao_Paulo
+3165107;S√£o Tom√°s de Aquino;-207791;-470962;0;31;Minas Gerais;5301;35;America/Sao_Paulo
+4126108;S√£o Tom√©;-235349;-525901;0;41;Paran√°;7897;44;America/Sao_Paulo
+2412906;S√£o Tom√©;-596404;-360798;0;24;Rio Grande do Norte;1855;84;America/Sao_Paulo
+4319703;S√£o Valentim;-275583;-525237;0;43;Rio Grande do Sul;8897;54;America/Sao_Paulo
+4319711;S√£o Valentim do Sul;-290451;-517684;0;43;Rio Grande do Sul;5997;54;America/Sao_Paulo
+1720499;S√£o Val√©rio;-119743;-482353;0;17;Tocantins;9691;63;America/Sao_Paulo
+4319737;S√£o Val√©rio do Sul;-277906;-539368;0;43;Rio Grande do Sul;6075;55;America/Sao_Paulo
+4319752;S√£o Vendelino;-293729;-513675;0;43;Rio Grande do Sul;7293;51;America/Sao_Paulo
+3551009;S√£o Vicente;-239574;-463883;0;35;S√£o Paulo;7121;13;America/Sao_Paulo
+2413003;S√£o Vicente;-621893;-366827;0;24;Rio Grande do Norte;1857;84;America/Sao_Paulo
+3165305;S√£o Vicente de Minas;-217042;-444431;0;31;Minas Gerais;5305;35;America/Sao_Paulo
+2515401;S√£o Vicente do Serid√≥;-685426;-364122;0;25;Para√≠ba;2209;83;America/Sao_Paulo
+4319802;S√£o Vicente do Sul;-296882;-546826;0;43;Rio Grande do Sul;8675;55;America/Sao_Paulo
+2613800;S√£o Vicente Ferrer;-758969;-354808;0;26;Pernambuco;2575;81;America/Sao_Paulo
+2111706;S√£o Vicente Ferrer;-289487;-448681;0;21;Maranh√£o;927;98;America/Sao_Paulo
+2515302;Sap√©;-709359;-35228;0;25;Para√≠ba;2207;83;America/Sao_Paulo
+2929602;Sapea√ßu;-127208;-391824;0;29;Bahia;3891;75;America/Sao_Paulo
 5107875;Sapezal;-129892;-587645;0;51;Mato Grosso;1046;65;America/Porto_Velho
 4319901;Sapiranga;-296349;-510064;0;43;Rio Grande do Sul;8899;51;America/Sao_Paulo
-4126207;Sapopema;-239078;-505801;0;41;Paran·;7899;43;America/Sao_Paulo
-3165404;SapucaÌ-Mirim;-227409;-45738;0;31;Minas Gerais;5307;35;America/Sao_Paulo
-1507755;Sapucaia;-694018;-496834;0;15;Par·;66;94;America/Sao_Paulo
+4126207;Sapopema;-239078;-505801;0;41;Paran√°;7899;43;America/Sao_Paulo
+3165404;Sapuca√≠-Mirim;-227409;-45738;0;31;Minas Gerais;5307;35;America/Sao_Paulo
+1507755;Sapucaia;-694018;-496834;0;15;Par√°;66;94;America/Sao_Paulo
 3305406;Sapucaia;-219949;-429142;0;33;Rio de Janeiro;5907;24;America/Sao_Paulo
 4320008;Sapucaia do Sul;-298276;-51145;0;43;Rio Grande do Sul;8901;51;America/Sao_Paulo
 3305505;Saquarema;-229292;-425099;0;33;Rio de Janeiro;5909;22;America/Sao_Paulo
-4126256;Sarandi;-234441;-51876;0;41;Paran·;8461;44;America/Sao_Paulo
+4126256;Sarandi;-234441;-51876;0;41;Paran√°;8461;44;America/Sao_Paulo
 4320107;Sarandi;-27942;-529231;0;43;Rio Grande do Sul;8903;54;America/Sao_Paulo
-3551108;SarapuÌ;-236397;-478249;0;35;S„o Paulo;7123;15;America/Sao_Paulo
-3165503;Sardo·;-187828;-423629;0;31;Minas Gerais;5309;33;America/Sao_Paulo
-3551207;Sarutai·;-232721;-494763;0;35;S„o Paulo;7125;14;America/Sao_Paulo
+3551108;Sarapu√≠;-236397;-478249;0;35;S√£o Paulo;7123;15;America/Sao_Paulo
+3165503;Sardo√°;-187828;-423629;0;31;Minas Gerais;5309;33;America/Sao_Paulo
+3551207;Sarutai√°;-232721;-494763;0;35;S√£o Paulo;7125;14;America/Sao_Paulo
 3165537;Sarzedo;-200367;-441446;0;31;Minas Gerais;730;31;America/Sao_Paulo
-2929701;S·tiro Dias;-115929;-385938;0;29;Bahia;3893;75;America/Sao_Paulo
+2929701;S√°tiro Dias;-115929;-385938;0;29;Bahia;3893;75;America/Sao_Paulo
 2708907;Satuba;-956911;-358227;0;27;Alagoas;2877;82;America/Sao_Paulo
-2111722;Satubinha;-404913;-452457;0;21;Maranh„o;248;98;America/Sao_Paulo
+2111722;Satubinha;-404913;-452457;0;21;Maranh√£o;248;98;America/Sao_Paulo
 2929750;Saubara;-127387;-387625;0;29;Bahia;3037;71;America/Sao_Paulo
-4126272;Saudade do IguaÁu;-256917;-526184;0;41;Paran·;5493;46;America/Sao_Paulo
+4126272;Saudade do Igua√ßu;-256917;-526184;0;41;Paran√°;5493;46;America/Sao_Paulo
 4217303;Saudades;-269317;-530021;0;42;Santa Catarina;8341;49;America/Sao_Paulo
-2929800;Sa˙de;-109428;-404155;0;29;Bahia;3895;74;America/Sao_Paulo
+2929800;Sa√∫de;-109428;-404155;0;29;Bahia;3895;74;America/Sao_Paulo
 4217402;Schroeder;-264116;-49074;0;42;Santa Catarina;8343;47;America/Sao_Paulo
 2929909;Seabra;-124169;-417722;0;29;Bahia;3897;75;America/Sao_Paulo
 4217501;Seara;-271564;-52299;0;42;Santa Catarina;8345;49;America/Sao_Paulo
-3551306;SebastianÛpolis do Sul;-206523;-49925;0;35;S„o Paulo;7127;17;America/Sao_Paulo
-2210623;Sebasti„o Barros;-10817;-448337;0;22;PiauÌ;396;89;America/Sao_Paulo
-2930006;Sebasti„o Laranjeiras;-14571;-429434;0;29;Bahia;3899;77;America/Sao_Paulo
-2210631;Sebasti„o Leal;-756803;-4406;0;22;PiauÌ;398;89;America/Sao_Paulo
+3551306;Sebastian√≥polis do Sul;-206523;-49925;0;35;S√£o Paulo;7127;17;America/Sao_Paulo
+2210623;Sebasti√£o Barros;-10817;-448337;0;22;Piau√≠;396;89;America/Sao_Paulo
+2930006;Sebasti√£o Laranjeiras;-14571;-429434;0;29;Bahia;3899;77;America/Sao_Paulo
+2210631;Sebasti√£o Leal;-756803;-4406;0;22;Piau√≠;398;89;America/Sao_Paulo
 4320206;Seberi;-274829;-534026;0;43;Rio Grande do Sul;8905;55;America/Sao_Paulo
 4320230;Sede Nova;-276367;-539493;0;43;Rio Grande do Sul;7335;55;America/Sao_Paulo
 4320263;Segredo;-293523;-529767;0;43;Rio Grande do Sul;7317;51;America/Sao_Paulo
 4320305;Selbach;-286294;-529498;0;43;Rio Grande do Sul;8907;54;America/Sao_Paulo
-5007802;SelvÌria;-203637;-514192;0;50;Mato Grosso do Sul;9811;67;America/Porto_Velho
+5007802;Selv√≠ria;-203637;-514192;0;50;Mato Grosso do Sul;9811;67;America/Porto_Velho
 3165560;Sem-Peixe;-201008;-428483;0;31;Minas Gerais;734;31;America/Sao_Paulo
 1200500;Sena Madureira;-906596;-686571;0;12;Acre;145;68;America/Rio_Branco
-2111748;Senador Alexandre Costa;-525096;-440533;0;21;Maranh„o;250;99;America/Sao_Paulo
+2111748;Senador Alexandre Costa;-525096;-440533;0;21;Maranh√£o;250;99;America/Sao_Paulo
 3165578;Senador Amaral;-225869;-461763;0;31;Minas Gerais;2689;35;America/Sao_Paulo
-5220454;Senador Canedo;-167084;-490914;0;52;Goi·s;9753;62;America/Sao_Paulo
+5220454;Senador Canedo;-167084;-490914;0;52;Goi√°s;9753;62;America/Sao_Paulo
 3165602;Senador Cortes;-217986;-429424;0;31;Minas Gerais;5311;32;America/Sao_Paulo
-2413102;Senador ElÛi de Souza;-603334;-356978;0;24;Rio Grande do Norte;1859;84;America/Sao_Paulo
+2413102;Senador El√≥i de Souza;-603334;-356978;0;24;Rio Grande do Norte;1859;84;America/Sao_Paulo
 3165701;Senador Firmino;-209158;-430904;0;31;Minas Gerais;5313;32;America/Sao_Paulo
 2413201;Senador Georgino Avelino;-61576;-351299;0;24;Rio Grande do Norte;1861;84;America/Sao_Paulo
 1200450;Senador Guiomard;-101497;-677362;0;12;Acre;153;68;America/Rio_Branco
-3165800;Senador JosÈ Bento;-221633;-461792;0;31;Minas Gerais;5315;35;America/Sao_Paulo
-1507805;Senador JosÈ PorfÌrio;-431242;-515764;0;15;Par·;555;91;America/Sao_Paulo
-2111763;Senador La Rocque;-54461;-472959;0;21;Maranh„o;252;99;America/Sao_Paulo
-3165909;Senador Modestino GonÁalves;-179465;-432172;0;31;Minas Gerais;5317;38;America/Sao_Paulo
-2312700;Senador Pompeu;-558244;-393704;0;23;Cear·;1555;88;America/Sao_Paulo
+3165800;Senador Jos√© Bento;-221633;-461792;0;31;Minas Gerais;5315;35;America/Sao_Paulo
+1507805;Senador Jos√© Porf√≠rio;-431242;-515764;0;15;Par√°;555;91;America/Sao_Paulo
+2111763;Senador La Rocque;-54461;-472959;0;21;Maranh√£o;252;99;America/Sao_Paulo
+3165909;Senador Modestino Gon√ßalves;-179465;-432172;0;31;Minas Gerais;5317;38;America/Sao_Paulo
+2312700;Senador Pompeu;-558244;-393704;0;23;Cear√°;1555;88;America/Sao_Paulo
 2708956;Senador Rui Palmeira;-946986;-374576;0;27;Alagoas;2891;82;America/Sao_Paulo
-2312809;Senador S·;-335305;-404662;0;23;Cear·;1557;88;America/Sao_Paulo
+2312809;Senador S√°;-335305;-404662;0;23;Cear√°;1557;88;America/Sao_Paulo
 4320321;Senador Salgado Filho;-28025;-545507;0;43;Rio Grande do Sul;1012;55;America/Sao_Paulo
-4126306;SengÈs;-241129;-494616;0;41;Paran·;7901;43;America/Sao_Paulo
+4126306;Seng√©s;-241129;-494616;0;41;Paran√°;7901;43;America/Sao_Paulo
 2930105;Senhor do Bonfim;-104594;-401865;0;29;Bahia;3901;74;America/Sao_Paulo
 3166006;Senhora de Oliveira;-207972;-433394;0;31;Minas Gerais;5319;31;America/Sao_Paulo
 3166105;Senhora do Porto;-188909;-430799;0;31;Minas Gerais;5321;33;America/Sao_Paulo
-3166204;Senhora dos RemÈdios;-210351;-435812;0;31;Minas Gerais;5323;32;America/Sao_Paulo
+3166204;Senhora dos Rem√©dios;-210351;-435812;0;31;Minas Gerais;5323;32;America/Sao_Paulo
 4320354;Sentinela do Sul;-306107;-515862;0;43;Rio Grande do Sul;5781;51;America/Sao_Paulo
-2930204;Sento SÈ;-974138;-418786;0;29;Bahia;3903;74;America/Sao_Paulo
-4320404;Serafina CorrÍa;-287126;-519352;0;43;Rio Grande do Sul;8909;54;America/Sao_Paulo
+2930204;Sento S√©;-974138;-418786;0;29;Bahia;3903;74;America/Sao_Paulo
+4320404;Serafina Corr√™a;-287126;-519352;0;43;Rio Grande do Sul;8909;54;America/Sao_Paulo
 3166303;Sericita;-204748;-424828;0;31;Minas Gerais;5325;31;America/Sao_Paulo
-1101500;Seringueiras;-118055;-630182;0;11;RondÙnia;699;69;America/Porto_Velho
-4320453;SÈrio;-293904;-522685;0;43;Rio Grande do Sul;6035;51;America/Sao_Paulo
+1101500;Seringueiras;-118055;-630182;0;11;Rond√¥nia;699;69;America/Porto_Velho
+4320453;S√©rio;-293904;-522685;0;43;Rio Grande do Sul;6035;51;America/Sao_Paulo
 3166402;Seritinga;-219134;-44518;0;31;Minas Gerais;5327;35;America/Sao_Paulo
-3305554;SeropÈdica;-227526;-437155;0;33;Rio de Janeiro;786;21;America/Sao_Paulo
-3205002;Serra;-20121;-403074;0;32;EspÌrito Santo;5699;27;America/Sao_Paulo
+3305554;Serop√©dica;-227526;-437155;0;33;Rio de Janeiro;786;21;America/Sao_Paulo
+3205002;Serra;-20121;-403074;0;32;Esp√≠rito Santo;5699;27;America/Sao_Paulo
 4217550;Serra Alta;-267229;-530409;0;42;Santa Catarina;9989;49;America/Sao_Paulo
-3551405;Serra Azul;-213074;-475602;0;35;S„o Paulo;7129;16;America/Sao_Paulo
+3551405;Serra Azul;-213074;-475602;0;35;S√£o Paulo;7129;16;America/Sao_Paulo
 3166501;Serra Azul de Minas;-183602;-431675;0;31;Minas Gerais;5329;38;America/Sao_Paulo
-2515500;Serra Branca;-748034;-36666;0;25;ParaÌba;2211;83;America/Sao_Paulo
+2515500;Serra Branca;-748034;-36666;0;25;Para√≠ba;2211;83;America/Sao_Paulo
 2410306;Serra Caiada;-610478;-357113;0;24;Rio Grande do Norte;1805;84;America/Sao_Paulo
-2515609;Serra da Raiz;-668527;-354379;0;25;ParaÌba;2213;83;America/Sao_Paulo
+2515609;Serra da Raiz;-668527;-354379;0;25;Para√≠ba;2213;83;America/Sao_Paulo
 3166600;Serra da Saudade;-194447;-45795;0;31;Minas Gerais;5331;37;America/Sao_Paulo
-2413300;Serra de S„o Bento;-641762;-357033;0;24;Rio Grande do Norte;1863;84;America/Sao_Paulo
+2413300;Serra de S√£o Bento;-641762;-357033;0;24;Rio Grande do Norte;1863;84;America/Sao_Paulo
 2413359;Serra do Mel;-517725;-370242;0;24;Rio Grande do Norte;1927;84;America/Sao_Paulo
-1600055;Serra do Navio;901357;-520036;0;16;Amap·;665;96;America/Sao_Paulo
+1600055;Serra do Navio;901357;-520036;0;16;Amap√°;665;96;America/Sao_Paulo
 2930154;Serra do Ramalho;-135659;-435929;0;29;Bahia;3039;77;America/Sao_Paulo
 3166808;Serra do Salitre;-191083;-466961;0;31;Minas Gerais;5335;34;America/Sao_Paulo
-3166709;Serra dos AimorÈs;-177872;-402453;0;31;Minas Gerais;5333;33;America/Sao_Paulo
+3166709;Serra dos Aimor√©s;-177872;-402453;0;31;Minas Gerais;5333;33;America/Sao_Paulo
 2930303;Serra Dourada;-12759;-439504;0;29;Bahia;3905;77;America/Sao_Paulo
-2515708;Serra Grande;-720957;-383647;0;25;ParaÌba;2215;83;America/Sao_Paulo
-3551603;Serra Negra;-226139;-467033;0;35;S„o Paulo;7133;19;America/Sao_Paulo
+2515708;Serra Grande;-720957;-383647;0;25;Para√≠ba;2215;83;America/Sao_Paulo
+3551603;Serra Negra;-226139;-467033;0;35;S√£o Paulo;7133;19;America/Sao_Paulo
 2413409;Serra Negra do Norte;-666031;-373996;0;24;Rio Grande do Norte;1865;84;America/Sao_Paulo
 5107883;Serra Nova Dourada;-120896;-514025;0;51;Mato Grosso;1100;66;America/Porto_Velho
 2930402;Serra Preta;-12156;-393305;0;29;Bahia;3907;75;America/Sao_Paulo
-2515807;Serra Redonda;-718622;-356842;0;25;ParaÌba;2217;83;America/Sao_Paulo
+2515807;Serra Redonda;-718622;-356842;0;25;Para√≠ba;2217;83;America/Sao_Paulo
 2613909;Serra Talhada;-798178;-38289;0;26;Pernambuco;2577;87;America/Sao_Paulo
-3551504;Serrana;-212043;-475952;0;35;S„o Paulo;7131;16;America/Sao_Paulo
+3551504;Serrana;-212043;-475952;0;35;S√£o Paulo;7131;16;America/Sao_Paulo
 3166907;Serrania;-215441;-460417;0;31;Minas Gerais;5337;35;America/Sao_Paulo
-2111789;Serrano do Maranh„o;-185229;-451207;0;21;Maranh„o;254;98;America/Sao_Paulo
-5220504;SerranÛpolis;-183067;-519586;0;52;Goi·s;9607;64;America/Sao_Paulo
-3166956;SerranÛpolis de Minas;-158176;-428732;0;31;Minas Gerais;736;38;America/Sao_Paulo
-4126355;SerranÛpolis do IguaÁu;-253799;-540518;0;41;Paran·;882;45;America/Sao_Paulo
+2111789;Serrano do Maranh√£o;-185229;-451207;0;21;Maranh√£o;254;98;America/Sao_Paulo
+5220504;Serran√≥polis;-183067;-519586;0;52;Goi√°s;9607;64;America/Sao_Paulo
+3166956;Serran√≥polis de Minas;-158176;-428732;0;31;Minas Gerais;736;38;America/Sao_Paulo
+4126355;Serran√≥polis do Igua√ßu;-253799;-540518;0;41;Paran√°;882;45;America/Sao_Paulo
 3167004;Serranos;-218857;-445125;0;31;Minas Gerais;5339;35;America/Sao_Paulo
-2515906;Serraria;-681569;-356282;0;25;ParaÌba;2219;83;America/Sao_Paulo
+2515906;Serraria;-681569;-356282;0;25;Para√≠ba;2219;83;America/Sao_Paulo
 2413508;Serrinha;-628181;-355;0;24;Rio Grande do Norte;1867;84;America/Sao_Paulo
 2930501;Serrinha;-116584;-3901;0;29;Bahia;3909;75;America/Sao_Paulo
 2413557;Serrinha dos Pintos;-611087;-379548;0;24;Rio Grande do Norte;432;84;America/Sao_Paulo
 2614006;Serrita;-794041;-392951;0;26;Pernambuco;2579;87;America/Sao_Paulo
 3167103;Serro;-185991;-433744;0;31;Minas Gerais;5341;38;America/Sao_Paulo
-2930600;Serrol‚ndia;-114085;-402983;0;29;Bahia;3911;74;America/Sao_Paulo
-4126405;Sertaneja;-230361;-508317;0;41;Paran·;7903;43;America/Sao_Paulo
-2614105;Sert‚nia;-806847;-372684;0;26;Pernambuco;2581;87;America/Sao_Paulo
-4126504;SertanÛpolis;-230571;-510399;0;41;Paran·;7905;43;America/Sao_Paulo
-4320503;Sert„o;-279798;-522588;0;43;Rio Grande do Sul;8911;54;America/Sao_Paulo
-4320552;Sert„o Santana;-304562;-516017;0;43;Rio Grande do Sul;5761;51;America/Sao_Paulo
-3551702;Sert„ozinho;-211316;-479875;0;35;S„o Paulo;7135;16;America/Sao_Paulo
-2515930;Sert„ozinho;-675127;-354372;0;25;ParaÌba;532;83;America/Sao_Paulo
-3551801;Sete Barras;-24382;-479279;0;35;S„o Paulo;7137;13;America/Sao_Paulo
+2930600;Serrol√¢ndia;-114085;-402983;0;29;Bahia;3911;74;America/Sao_Paulo
+4126405;Sertaneja;-230361;-508317;0;41;Paran√°;7903;43;America/Sao_Paulo
+2614105;Sert√¢nia;-806847;-372684;0;26;Pernambuco;2581;87;America/Sao_Paulo
+4126504;Sertan√≥polis;-230571;-510399;0;41;Paran√°;7905;43;America/Sao_Paulo
+4320503;Sert√£o;-279798;-522588;0;43;Rio Grande do Sul;8911;54;America/Sao_Paulo
+4320552;Sert√£o Santana;-304562;-516017;0;43;Rio Grande do Sul;5761;51;America/Sao_Paulo
+3551702;Sert√£ozinho;-211316;-479875;0;35;S√£o Paulo;7135;16;America/Sao_Paulo
+2515930;Sert√£ozinho;-675127;-354372;0;25;Para√≠ba;532;83;America/Sao_Paulo
+3551801;Sete Barras;-24382;-479279;0;35;S√£o Paulo;7137;13;America/Sao_Paulo
 4320578;Sete de Setembro;-281362;-544637;0;43;Rio Grande do Sul;1014;55;America/Sao_Paulo
 3167202;Sete Lagoas;-194569;-442413;0;31;Minas Gerais;5343;31;America/Sao_Paulo
 5007703;Sete Quedas;-239705;-550398;0;50;Mato Grosso do Sul;9813;67;America/Porto_Velho
 3165552;Setubinha;-176002;-421587;0;31;Minas Gerais;732;33;America/Sao_Paulo
 4320602;Severiano de Almeida;-274362;-521217;0;43;Rio Grande do Sul;8913;54;America/Sao_Paulo
 2413607;Severiano Melo;-577666;-37957;0;24;Rio Grande do Norte;1869;84;America/Sao_Paulo
-3551900;SeverÌnia;-208108;-488054;0;35;S„o Paulo;7139;17;America/Sao_Paulo
-4217600;SiderÛpolis;-285955;-494314;0;42;Santa Catarina;8347;48;America/Sao_Paulo
-5007901;Sidrol‚ndia;-209302;-549692;0;50;Mato Grosso do Sul;9157;67;America/Porto_Velho
-2210656;Sigefredo Pacheco;-491665;-417311;0;22;PiauÌ;1379;86;America/Sao_Paulo
+3551900;Sever√≠nia;-208108;-488054;0;35;S√£o Paulo;7139;17;America/Sao_Paulo
+4217600;Sider√≥polis;-285955;-494314;0;42;Santa Catarina;8347;48;America/Sao_Paulo
+5007901;Sidrol√¢ndia;-209302;-549692;0;50;Mato Grosso do Sul;9157;67;America/Porto_Velho
+2210656;Sigefredo Pacheco;-491665;-417311;0;22;Piau√≠;1379;86;America/Sao_Paulo
 3305604;Silva Jardim;-226574;-423961;0;33;Rio de Janeiro;5911;22;America/Sao_Paulo
-5220603;Silv‚nia;-1666;-486083;0;52;Goi·s;9609;62;America/Sao_Paulo
-1720655;SilvanÛpolis;-111471;-481694;0;17;Tocantins;9659;63;America/Sao_Paulo
+5220603;Silv√¢nia;-1666;-486083;0;52;Goi√°s;9609;62;America/Sao_Paulo
+1720655;Silvan√≥polis;-111471;-481694;0;17;Tocantins;9659;63;America/Sao_Paulo
 4320651;Silveira Martins;-296467;-53591;0;43;Rio Grande do Sul;7315;55;America/Sao_Paulo
-3167301;Silveir‚nia;-211615;-432128;0;31;Minas Gerais;5345;32;America/Sao_Paulo
-3552007;Silveiras;-226638;-448522;0;35;S„o Paulo;7141;12;America/Sao_Paulo
+3167301;Silveir√¢nia;-211615;-432128;0;31;Minas Gerais;5345;32;America/Sao_Paulo
+3552007;Silveiras;-226638;-448522;0;35;S√£o Paulo;7141;12;America/Sao_Paulo
 1304005;Silves;-281748;-58248;0;13;Amazonas;277;92;America/Porto_Velho
-3167400;SilvianÛpolis;-220274;-458385;0;31;Minas Gerais;5347;35;America/Sao_Paulo
-2807105;Sim„o Dias;-107387;-378097;0;28;Sergipe;3241;79;America/Sao_Paulo
-3167509;Sim„o Pereira;-21964;-433088;0;31;Minas Gerais;5349;32;America/Sao_Paulo
-2210706;Simıes;-759109;-408137;0;22;PiauÌ;1213;89;America/Sao_Paulo
-2930709;Simıes Filho;-127866;-384029;0;29;Bahia;3913;71;America/Sao_Paulo
-5220686;Simol‚ndia;-144644;-464847;0;52;Goi·s;9755;62;America/Sao_Paulo
-3167608;SimonÈsia;-201341;-420091;0;31;Minas Gerais;5351;33;America/Sao_Paulo
-2210805;SimplÌcio Mendes;-785294;-419075;0;22;PiauÌ;1215;89;America/Sao_Paulo
+3167400;Silvian√≥polis;-220274;-458385;0;31;Minas Gerais;5347;35;America/Sao_Paulo
+2807105;Sim√£o Dias;-107387;-378097;0;28;Sergipe;3241;79;America/Sao_Paulo
+3167509;Sim√£o Pereira;-21964;-433088;0;31;Minas Gerais;5349;32;America/Sao_Paulo
+2210706;Sim√µes;-759109;-408137;0;22;Piau√≠;1213;89;America/Sao_Paulo
+2930709;Sim√µes Filho;-127866;-384029;0;29;Bahia;3913;71;America/Sao_Paulo
+5220686;Simol√¢ndia;-144644;-464847;0;52;Goi√°s;9755;62;America/Sao_Paulo
+3167608;Simon√©sia;-201341;-420091;0;31;Minas Gerais;5351;33;America/Sao_Paulo
+2210805;Simpl√≠cio Mendes;-785294;-419075;0;22;Piau√≠;1215;89;America/Sao_Paulo
 4320677;Sinimbu;-295357;-525304;0;43;Rio Grande do Sul;5767;51;America/Sao_Paulo
 5107909;Sinop;-118604;-555091;0;51;Mato Grosso;8985;66;America/Porto_Velho
-4126603;Siqueira Campos;-236875;-498304;0;41;Paran·;7907;43;America/Sao_Paulo
-2614204;SirinhaÈm;-858778;-351126;0;26;Pernambuco;2583;81;America/Sao_Paulo
+4126603;Siqueira Campos;-236875;-498304;0;41;Paran√°;7907;43;America/Sao_Paulo
+2614204;Sirinha√©m;-858778;-351126;0;26;Pernambuco;2583;81;America/Sao_Paulo
 2807204;Siriri;-105965;-371131;0;28;Sergipe;3243;79;America/Sao_Paulo
-5220702;SÌtio d'Abadia;-147992;-462506;0;52;Goi·s;9611;62;America/Sao_Paulo
-2930758;SÌtio do Mato;-130801;-434689;0;29;Bahia;3041;77;America/Sao_Paulo
-2930766;SÌtio do Quinto;-103545;-382213;0;29;Bahia;3043;75;America/Sao_Paulo
-2111805;SÌtio Novo;-587601;-467033;0;21;Maranh„o;929;99;America/Sao_Paulo
-2413706;SÌtio Novo;-611132;-35909;0;24;Rio Grande do Norte;1871;84;America/Sao_Paulo
-1720804;SÌtio Novo do Tocantins;-56012;-476381;0;17;Tocantins;9613;63;America/Sao_Paulo
+5220702;S√≠tio d'Abadia;-147992;-462506;0;52;Goi√°s;9611;62;America/Sao_Paulo
+2930758;S√≠tio do Mato;-130801;-434689;0;29;Bahia;3041;77;America/Sao_Paulo
+2930766;S√≠tio do Quinto;-103545;-382213;0;29;Bahia;3043;75;America/Sao_Paulo
+2111805;S√≠tio Novo;-587601;-467033;0;21;Maranh√£o;929;99;America/Sao_Paulo
+2413706;S√≠tio Novo;-611132;-35909;0;24;Rio Grande do Norte;1871;84;America/Sao_Paulo
+1720804;S√≠tio Novo do Tocantins;-56012;-476381;0;17;Tocantins;9613;63;America/Sao_Paulo
 2930774;Sobradinho;-945024;-408145;0;29;Bahia;3045;74;America/Sao_Paulo
 4320701;Sobradinho;-294194;-530326;0;43;Rio Grande do Sul;8917;51;America/Sao_Paulo
-2515971;Sobrado;-714429;-352357;0;25;ParaÌba;534;83;America/Sao_Paulo
-2312908;Sobral;-368913;-403482;0;23;Cear·;1559;88;America/Sao_Paulo
-3167707;Sobr·lia;-192345;-420998;0;31;Minas Gerais;5353;33;America/Sao_Paulo
-3552106;Socorro;-225903;-465251;0;35;S„o Paulo;7143;19;America/Sao_Paulo
-2210904;Socorro do PiauÌ;-786773;-424922;0;22;PiauÌ;1217;89;America/Sao_Paulo
-2516003;Sol‚nea;-675161;-356636;0;25;ParaÌba;2221;83;America/Sao_Paulo
-2516102;Soledade;-705829;-363668;0;25;ParaÌba;2223;83;America/Sao_Paulo
+2515971;Sobrado;-714429;-352357;0;25;Para√≠ba;534;83;America/Sao_Paulo
+2312908;Sobral;-368913;-403482;0;23;Cear√°;1559;88;America/Sao_Paulo
+3167707;Sobr√°lia;-192345;-420998;0;31;Minas Gerais;5353;33;America/Sao_Paulo
+3552106;Socorro;-225903;-465251;0;35;S√£o Paulo;7143;19;America/Sao_Paulo
+2210904;Socorro do Piau√≠;-786773;-424922;0;22;Piau√≠;1217;89;America/Sao_Paulo
+2516003;Sol√¢nea;-675161;-356636;0;25;Para√≠ba;2221;83;America/Sao_Paulo
+2516102;Soledade;-705829;-363668;0;25;Para√≠ba;2223;83;America/Sao_Paulo
 4320800;Soledade;-288306;-525131;0;43;Rio Grande do Sul;8919;54;America/Sao_Paulo
 3167806;Soledade de Minas;-220554;-450464;0;31;Minas Gerais;5355;35;America/Sao_Paulo
-2614402;Solid„o;-759472;-376445;0;26;Pernambuco;2587;87;America/Sao_Paulo
-2313005;SolonÛpole;-571894;-390107;0;23;Cear·;1561;88;America/Sao_Paulo
+2614402;Solid√£o;-759472;-376445;0;26;Pernambuco;2587;87;America/Sao_Paulo
+2313005;Solon√≥pole;-571894;-390107;0;23;Cear√°;1561;88;America/Sao_Paulo
 4217709;Sombrio;-29108;-496328;0;42;Santa Catarina;8349;48;America/Sao_Paulo
 5007935;Sonora;-175698;-547551;0;50;Mato Grosso do Sul;9757;67;America/Porto_Velho
-3205010;Sooretama;-191897;-400974;0;32;EspÌrito Santo;766;27;America/Sao_Paulo
-3552205;Sorocaba;-234969;-474451;0;35;S„o Paulo;7145;15;America/Sao_Paulo
+3205010;Sooretama;-191897;-400974;0;32;Esp√≠rito Santo;766;27;America/Sao_Paulo
+3552205;Sorocaba;-234969;-474451;0;35;S√£o Paulo;7145;15;America/Sao_Paulo
 5107925;Sorriso;-125425;-557211;0;51;Mato Grosso;9907;66;America/Porto_Velho
-2516151;SossÍgo;-677067;-362538;0;25;ParaÌba;536;83;America/Sao_Paulo
-1507904;Soure;-73032;-485015;0;15;Par·;557;91;America/Sao_Paulo
-2516201;Sousa;-675148;-382311;0;25;ParaÌba;2225;83;America/Sao_Paulo
+2516151;Soss√™go;-677067;-362538;0;25;Para√≠ba;536;83;America/Sao_Paulo
+1507904;Soure;-73032;-485015;0;15;Par√°;557;91;America/Sao_Paulo
+2516201;Sousa;-675148;-382311;0;25;Para√≠ba;2225;83;America/Sao_Paulo
 2930808;Souto Soares;-12088;-416427;0;29;Bahia;3915;75;America/Sao_Paulo
 1720853;Sucupira;-11993;-489685;0;17;Tocantins;335;63;America/Sao_Paulo
-2111904;Sucupira do Norte;-647839;-441919;0;21;Maranh„o;931;99;America/Sao_Paulo
-2111953;Sucupira do Riach„o;-640858;-435455;0;21;Maranh„o;256;99;America/Sao_Paulo
-3552304;Sud Mennucci;-206872;-509238;0;35;S„o Paulo;7147;18;America/Sao_Paulo
+2111904;Sucupira do Norte;-647839;-441919;0;21;Maranh√£o;931;99;America/Sao_Paulo
+2111953;Sucupira do Riach√£o;-640858;-435455;0;21;Maranh√£o;256;99;America/Sao_Paulo
+3552304;Sud Mennucci;-206872;-509238;0;35;S√£o Paulo;7147;18;America/Sao_Paulo
 4217758;Sul Brasil;-267351;-52964;0;42;Santa Catarina;5595;49;America/Sao_Paulo
-4126652;Sulina;-257066;-527299;0;41;Paran·;8477;46;America/Sao_Paulo
-3552403;SumarÈ;-228204;-472728;0;35;S„o Paulo;7149;19;America/Sao_Paulo
-2516300;SumÈ;-766206;-36884;0;25;ParaÌba;2227;83;America/Sao_Paulo
+4126652;Sulina;-257066;-527299;0;41;Paran√°;8477;46;America/Sao_Paulo
+3552403;Sumar√©;-228204;-472728;0;35;S√£o Paulo;7149;19;America/Sao_Paulo
+2516300;Sum√©;-766206;-36884;0;25;Para√≠ba;2227;83;America/Sao_Paulo
 3305703;Sumidouro;-220485;-426761;0;33;Rio de Janeiro;5913;22;America/Sao_Paulo
 2614501;Surubim;-784746;-357481;0;26;Pernambuco;2589;81;America/Sao_Paulo
-2210938;Sussuapara;-703687;-413767;0;22;PiauÌ;400;89;America/Sao_Paulo
-3552551;Suzan·polis;-204981;-510268;0;35;S„o Paulo;2945;18;America/Sao_Paulo
-3552502;Suzano;-235448;-463112;0;35;S„o Paulo;7151;11;America/Sao_Paulo
-4320859;TabaÌ;-29643;-516823;0;43;Rio Grande do Sul;1016;51;America/Sao_Paulo
-5107941;Tabapor„;-113007;-568312;0;51;Mato Grosso;125;66;America/Porto_Velho
-3552601;Tabapu„;-209602;-490307;0;35;S„o Paulo;7153;17;America/Sao_Paulo
-3552700;Tabatinga;-217239;-486896;0;35;S„o Paulo;7155;16;America/Sao_Paulo
+2210938;Sussuapara;-703687;-413767;0;22;Piau√≠;400;89;America/Sao_Paulo
+3552551;Suzan√°polis;-204981;-510268;0;35;S√£o Paulo;2945;18;America/Sao_Paulo
+3552502;Suzano;-235448;-463112;0;35;S√£o Paulo;7151;11;America/Sao_Paulo
+4320859;Taba√≠;-29643;-516823;0;43;Rio Grande do Sul;1016;51;America/Sao_Paulo
+5107941;Tabapor√£;-113007;-568312;0;51;Mato Grosso;125;66;America/Porto_Velho
+3552601;Tabapu√£;-209602;-490307;0;35;S√£o Paulo;7153;17;America/Sao_Paulo
+3552700;Tabatinga;-217239;-486896;0;35;S√£o Paulo;7155;16;America/Sao_Paulo
 1304062;Tabatinga;-42416;-699383;0;13;Amazonas;9847;97;America/Rio_Branco
 2614600;Tabira;-758366;-375377;0;26;Pernambuco;2591;87;America/Sao_Paulo
-3552809;Tabo„o da Serra;-236019;-467526;0;35;S„o Paulo;7157;11;America/Sao_Paulo
+3552809;Tabo√£o da Serra;-236019;-467526;0;35;S√£o Paulo;7157;11;America/Sao_Paulo
 2930907;Tabocas do Brejo Velho;-127026;-440075;0;29;Bahia;3917;77;America/Sao_Paulo
 2413805;Taboleiro Grande;-591948;-380367;0;24;Rio Grande do Norte;1873;84;America/Sao_Paulo
 3167905;Tabuleiro;-213632;-432381;0;31;Minas Gerais;5357;32;America/Sao_Paulo
-2313104;Tabuleiro do Norte;-524353;-381282;0;23;Cear·;1563;88;America/Sao_Paulo
-2614709;TacaimbÛ;-830867;-363;0;26;Pernambuco;2593;81;America/Sao_Paulo
+2313104;Tabuleiro do Norte;-524353;-381282;0;23;Cear√°;1563;88;America/Sao_Paulo
+2614709;Tacaimb√≥;-830867;-363;0;26;Pernambuco;2593;81;America/Sao_Paulo
 2614808;Tacaratu;-909798;-381504;0;26;Pernambuco;2595;87;America/Sao_Paulo
-3552908;Taciba;-223866;-512882;0;35;S„o Paulo;7159;18;America/Sao_Paulo
-2516409;Tacima;-648759;-356367;0;25;ParaÌba;2229;83;America/Sao_Paulo
+3552908;Taciba;-223866;-512882;0;35;S√£o Paulo;7159;18;America/Sao_Paulo
+2516409;Tacima;-648759;-356367;0;25;Para√≠ba;2229;83;America/Sao_Paulo
 5007950;Tacuru;-23636;-550141;0;50;Mato Grosso do Sul;9815;67;America/Porto_Velho
-3553005;TaguaÌ;-234452;-494024;0;35;S„o Paulo;7161;14;America/Sao_Paulo
+3553005;Tagua√≠;-234452;-494024;0;35;S√£o Paulo;7161;14;America/Sao_Paulo
 1720903;Taguatinga;-124026;-46437;0;17;Tocantins;9615;63;America/Sao_Paulo
-3553104;TaiaÁu;-211431;-485112;0;35;S„o Paulo;7163;16;America/Sao_Paulo
-1507953;Tail‚ndia;-294584;-489489;0;15;Par·;395;91;America/Sao_Paulo
-4217808;TaiÛ;-27121;-499942;0;42;Santa Catarina;8351;47;America/Sao_Paulo
+3553104;Taia√ßu;-211431;-485112;0;35;S√£o Paulo;7163;16;America/Sao_Paulo
+1507953;Tail√¢ndia;-294584;-489489;0;15;Par√°;395;91;America/Sao_Paulo
+4217808;Tai√≥;-27121;-499942;0;42;Santa Catarina;8351;47;America/Sao_Paulo
 3168002;Taiobeiras;-158106;-422259;0;31;Minas Gerais;5359;38;America/Sao_Paulo
 1720937;Taipas do Tocantins;-121873;-469797;0;17;Tocantins;325;63;America/Sao_Paulo
 2413904;Taipu;-563058;-355918;0;24;Rio Grande do Norte;1875;84;America/Sao_Paulo
-3553203;Tai˙va;-211223;-484528;0;35;S„o Paulo;7165;16;America/Sao_Paulo
-1720978;Talism„;-127949;-490896;0;17;Tocantins;100;63;America/Sao_Paulo
-2614857;TamandarÈ;-875665;-351033;0;26;Pernambuco;558;81;America/Sao_Paulo
-4126678;Tamarana;-237204;-510991;0;41;Paran·;884;43;America/Sao_Paulo
-3553302;Tamba˙;-217029;-472703;0;35;S„o Paulo;7167;19;America/Sao_Paulo
-4126702;Tamboara;-232036;-524743;0;41;Paran·;7909;44;America/Sao_Paulo
-2313203;Tamboril;-483136;-403196;0;23;Cear·;1565;88;America/Sao_Paulo
-2210953;Tamboril do PiauÌ;-840937;-429211;0;22;PiauÌ;402;89;America/Sao_Paulo
-3553401;Tanabi;-206228;-496563;0;35;S„o Paulo;7169;17;America/Sao_Paulo
-2414001;Tangar·;-619649;-357989;0;24;Rio Grande do Norte;1877;84;America/Sao_Paulo
-4217907;Tangar·;-270996;-512473;0;42;Santa Catarina;8353;49;America/Sao_Paulo
-5107958;Tangar· da Serra;-146229;-574933;0;51;Mato Grosso;9185;65;America/Porto_Velho
-3305752;Tangu·;-227423;-427202;0;33;Rio de Janeiro;788;21;America/Sao_Paulo
-2931004;TanhaÁu;-140197;-412473;0;29;Bahia;3919;77;America/Sao_Paulo
+3553203;Tai√∫va;-211223;-484528;0;35;S√£o Paulo;7165;16;America/Sao_Paulo
+1720978;Talism√£;-127949;-490896;0;17;Tocantins;100;63;America/Sao_Paulo
+2614857;Tamandar√©;-875665;-351033;0;26;Pernambuco;558;81;America/Sao_Paulo
+4126678;Tamarana;-237204;-510991;0;41;Paran√°;884;43;America/Sao_Paulo
+3553302;Tamba√∫;-217029;-472703;0;35;S√£o Paulo;7167;19;America/Sao_Paulo
+4126702;Tamboara;-232036;-524743;0;41;Paran√°;7909;44;America/Sao_Paulo
+2313203;Tamboril;-483136;-403196;0;23;Cear√°;1565;88;America/Sao_Paulo
+2210953;Tamboril do Piau√≠;-840937;-429211;0;22;Piau√≠;402;89;America/Sao_Paulo
+3553401;Tanabi;-206228;-496563;0;35;S√£o Paulo;7169;17;America/Sao_Paulo
+2414001;Tangar√°;-619649;-357989;0;24;Rio Grande do Norte;1877;84;America/Sao_Paulo
+4217907;Tangar√°;-270996;-512473;0;42;Santa Catarina;8353;49;America/Sao_Paulo
+5107958;Tangar√° da Serra;-146229;-574933;0;51;Mato Grosso;9185;65;America/Porto_Velho
+3305752;Tangu√°;-227423;-427202;0;33;Rio de Janeiro;788;21;America/Sao_Paulo
+2931004;Tanha√ßu;-140197;-412473;0;29;Bahia;3919;77;America/Sao_Paulo
 2709004;Tanque d'Arca;-953379;-364366;0;27;Alagoas;2879;82;America/Sao_Paulo
-2210979;Tanque do PiauÌ;-659787;-422795;0;22;PiauÌ;404;89;America/Sao_Paulo
+2210979;Tanque do Piau√≠;-659787;-422795;0;22;Piau√≠;404;89;America/Sao_Paulo
 2931053;Tanque Novo;-135485;-424934;0;29;Bahia;3991;77;America/Sao_Paulo
 2931103;Tanquinho;-11968;-391033;0;29;Bahia;3921;75;America/Sao_Paulo
 3168051;Taparuba;-197621;-41608;0;31;Minas Gerais;738;33;America/Sao_Paulo
-1304104;Tapau·;-562085;-631808;0;13;Amazonas;279;97;America/Porto_Velho
-4126801;Tapejara;-237315;-528735;0;41;Paran·;7911;44;America/Sao_Paulo
+1304104;Tapau√°;-562085;-631808;0;13;Amazonas;279;97;America/Porto_Velho
+4126801;Tapejara;-237315;-528735;0;41;Paran√°;7911;44;America/Sao_Paulo
 4320909;Tapejara;-280652;-520097;0;43;Rio Grande do Sul;8921;54;America/Sao_Paulo
 4321006;Tapera;-286277;-528613;0;43;Rio Grande do Sul;8923;54;America/Sao_Paulo
-2931202;Tapero·;-135321;-391009;0;29;Bahia;3923;75;America/Sao_Paulo
-2516508;Tapero·;-720629;-368245;0;25;ParaÌba;2231;83;America/Sao_Paulo
+2931202;Tapero√°;-135321;-391009;0;29;Bahia;3923;75;America/Sao_Paulo
+2516508;Tapero√°;-720629;-368245;0;25;Para√≠ba;2231;83;America/Sao_Paulo
 4321105;Tapes;-306683;-513991;0;43;Rio Grande do Sul;8925;51;America/Sao_Paulo
-4126900;Tapira;-233193;-530684;0;41;Paran·;7973;44;America/Sao_Paulo
+4126900;Tapira;-233193;-530684;0;41;Paran√°;7973;44;America/Sao_Paulo
 3168101;Tapira;-199166;-468264;0;31;Minas Gerais;5361;34;America/Sao_Paulo
-3168200;TapiraÌ;-198936;-460221;0;31;Minas Gerais;5363;37;America/Sao_Paulo
-3553500;TapiraÌ;-239612;-475062;0;35;S„o Paulo;7171;15;America/Sao_Paulo
-2931301;Tapiramut·;-118475;-407927;0;29;Bahia;3925;74;America/Sao_Paulo
-3553609;Tapiratiba;-214713;-467448;0;35;S„o Paulo;7173;19;America/Sao_Paulo
+3168200;Tapira√≠;-198936;-460221;0;31;Minas Gerais;5363;37;America/Sao_Paulo
+3553500;Tapira√≠;-239612;-475062;0;35;S√£o Paulo;7171;15;America/Sao_Paulo
+2931301;Tapiramut√°;-118475;-407927;0;29;Bahia;3925;74;America/Sao_Paulo
+3553609;Tapiratiba;-214713;-467448;0;35;S√£o Paulo;7173;19;America/Sao_Paulo
 5108006;Tapurah;-12695;-565178;0;51;Mato Grosso;9763;66;America/Porto_Velho
 4321204;Taquara;-296505;-507753;0;43;Rio Grande do Sul;8927;51;America/Sao_Paulo
-3168309;TaquaraÁu de Minas;-196652;-436922;0;31;Minas Gerais;5365;31;America/Sao_Paulo
-3553658;Taquaral;-210737;-484126;0;35;S„o Paulo;824;16;America/Sao_Paulo
-5221007;Taquaral de Goi·s;-160521;-496039;0;52;Goi·s;9617;62;America/Sao_Paulo
+3168309;Taquara√ßu de Minas;-196652;-436922;0;31;Minas Gerais;5365;31;America/Sao_Paulo
+3553658;Taquaral;-210737;-484126;0;35;S√£o Paulo;824;16;America/Sao_Paulo
+5221007;Taquaral de Goi√°s;-160521;-496039;0;52;Goi√°s;9617;62;America/Sao_Paulo
 2709103;Taquarana;-964529;-364928;0;27;Alagoas;2881;82;America/Sao_Paulo
 4321303;Taquari;-297943;-518653;0;43;Rio Grande do Sul;8929;51;America/Sao_Paulo
-3553708;Taquaritinga;-214049;-485103;0;35;S„o Paulo;7175;16;America/Sao_Paulo
+3553708;Taquaritinga;-214049;-485103;0;35;S√£o Paulo;7175;16;America/Sao_Paulo
 2615003;Taquaritinga do Norte;-789446;-360423;0;26;Pernambuco;2599;81;America/Sao_Paulo
-3553807;Taquarituba;-235307;-49241;0;35;S„o Paulo;7177;14;America/Sao_Paulo
-3553856;TaquarivaÌ;-239211;-486948;0;35;S„o Paulo;3063;15;America/Sao_Paulo
-4321329;TaquaruÁu do Sul;-274005;-534702;0;43;Rio Grande do Sul;7313;55;America/Sao_Paulo
+3553807;Taquarituba;-235307;-49241;0;35;S√£o Paulo;7177;14;America/Sao_Paulo
+3553856;Taquariva√≠;-239211;-486948;0;35;S√£o Paulo;3063;15;America/Sao_Paulo
+4321329;Taquaru√ßu do Sul;-274005;-534702;0;43;Rio Grande do Sul;7313;55;America/Sao_Paulo
 5007976;Taquarussu;-224898;-533519;0;50;Mato Grosso do Sul;9817;67;America/Porto_Velho
-3553906;Tarabai;-223016;-515621;0;35;S„o Paulo;7179;18;America/Sao_Paulo
-1200609;Tarauac·;-815697;-707722;0;12;Acre;147;68;America/Rio_Branco
-2313252;Tarrafas;-667838;-39753;0;23;Cear·;1275;88;America/Sao_Paulo
-1600709;Tartarugalzinho;150652;-509087;0;16;Amap·;617;96;America/Sao_Paulo
-3553955;Tarum„;-227429;-505786;0;35;S„o Paulo;7267;18;America/Sao_Paulo
+3553906;Tarabai;-223016;-515621;0;35;S√£o Paulo;7179;18;America/Sao_Paulo
+1200609;Tarauac√°;-815697;-707722;0;12;Acre;147;68;America/Rio_Branco
+2313252;Tarrafas;-667838;-39753;0;23;Cear√°;1275;88;America/Sao_Paulo
+1600709;Tartarugalzinho;150652;-509087;0;16;Amap√°;617;96;America/Sao_Paulo
+3553955;Tarum√£;-227429;-505786;0;35;S√£o Paulo;7267;18;America/Sao_Paulo
 3168408;Tarumirim;-192835;-420097;0;31;Minas Gerais;5367;33;America/Sao_Paulo
-2112001;Tasso Fragoso;-84662;-457536;0;21;Maranh„o;933;99;America/Sao_Paulo
-3554003;TatuÌ;-233487;-478461;0;35;S„o Paulo;7181;15;America/Sao_Paulo
-2313302;Tau·;-598585;-402968;0;23;Cear·;1567;88;America/Sao_Paulo
-3554102;TaubatÈ;-230104;-455593;0;35;S„o Paulo;7183;12;America/Sao_Paulo
+2112001;Tasso Fragoso;-84662;-457536;0;21;Maranh√£o;933;99;America/Sao_Paulo
+3554003;Tatu√≠;-233487;-478461;0;35;S√£o Paulo;7181;15;America/Sao_Paulo
+2313302;Tau√°;-598585;-402968;0;23;Cear√°;1567;88;America/Sao_Paulo
+3554102;Taubat√©;-230104;-455593;0;35;S√£o Paulo;7183;12;America/Sao_Paulo
 4321352;Tavares;-312843;-51088;0;43;Rio Grande do Sul;8971;51;America/Sao_Paulo
-2516607;Tavares;-762697;-378712;0;25;ParaÌba;2233;83;America/Sao_Paulo
-1304203;TefÈ;-336822;-647193;0;13;Amazonas;281;97;America/Porto_Velho
-2516706;Teixeira;-722104;-372525;0;25;ParaÌba;2235;83;America/Sao_Paulo
+2516607;Tavares;-762697;-378712;0;25;Para√≠ba;2233;83;America/Sao_Paulo
+1304203;Tef√©;-336822;-647193;0;13;Amazonas;281;97;America/Porto_Velho
+2516706;Teixeira;-722104;-372525;0;25;Para√≠ba;2235;83;America/Sao_Paulo
 2931350;Teixeira de Freitas;-175399;-3974;0;29;Bahia;3993;73;America/Sao_Paulo
-4127007;Teixeira Soares;-253701;-504571;0;41;Paran·;7913;42;America/Sao_Paulo
+4127007;Teixeira Soares;-253701;-504571;0;41;Paran√°;7913;42;America/Sao_Paulo
 3168507;Teixeiras;-206561;-428564;0;31;Minas Gerais;5369;31;America/Sao_Paulo
-1101559;TeixeirÛpolis;-109056;-62242;0;11;RondÙnia;22;69;America/Porto_Velho
-2313351;TejuÁuoca;-398831;-395799;0;23;Cear·;1277;85;America/Sao_Paulo
-3554201;Tejup·;-233425;-493722;0;35;S„o Paulo;7185;14;America/Sao_Paulo
-4127106;TelÍmaco Borba;-243245;-506176;0;41;Paran·;7915;42;America/Sao_Paulo
+1101559;Teixeir√≥polis;-109056;-62242;0;11;Rond√¥nia;22;69;America/Porto_Velho
+2313351;Teju√ßuoca;-398831;-395799;0;23;Cear√°;1277;85;America/Sao_Paulo
+3554201;Tejup√°;-233425;-493722;0;35;S√£o Paulo;7185;14;America/Sao_Paulo
+4127106;Tel√™maco Borba;-243245;-506176;0;41;Paran√°;7915;42;America/Sao_Paulo
 2807303;Telha;-102064;-368818;0;28;Sergipe;3245;79;America/Sao_Paulo
 2414100;Tenente Ananias;-645823;-38182;0;24;Rio Grande do Norte;1879;84;America/Sao_Paulo
 2414159;Tenente Laurentino Cruz;-61378;-367135;0;24;Rio Grande do Norte;434;84;America/Sao_Paulo
 4321402;Tenente Portela;-273711;-537585;0;43;Rio Grande do Sul;8931;55;America/Sao_Paulo
-2516755;TenÛrio;-693855;-366273;0;25;ParaÌba;538;83;America/Sao_Paulo
+2516755;Ten√≥rio;-693855;-366273;0;25;Para√≠ba;538;83;America/Sao_Paulo
 2931400;Teodoro Sampaio;-12295;-386347;0;29;Bahia;3927;75;America/Sao_Paulo
-3554300;Teodoro Sampaio;-225299;-521682;0;35;S„o Paulo;7187;18;America/Sao_Paulo
-2931509;Teofil‚ndia;-114827;-389913;0;29;Bahia;3929;75;America/Sao_Paulo
-3168606;TeÛfilo Otoni;-178595;-415087;0;31;Minas Gerais;5371;33;America/Sao_Paulo
-2931608;Teol‚ndia;-135896;-39484;0;29;Bahia;3931;73;America/Sao_Paulo
-2709152;TeotÙnio Vilela;-991656;-363492;0;27;Alagoas;971;82;America/Sao_Paulo
+3554300;Teodoro Sampaio;-225299;-521682;0;35;S√£o Paulo;7187;18;America/Sao_Paulo
+2931509;Teofil√¢ndia;-114827;-389913;0;29;Bahia;3929;75;America/Sao_Paulo
+3168606;Te√≥filo Otoni;-178595;-415087;0;31;Minas Gerais;5371;33;America/Sao_Paulo
+2931608;Teol√¢ndia;-135896;-39484;0;29;Bahia;3931;73;America/Sao_Paulo
+2709152;Teot√¥nio Vilela;-991656;-363492;0;27;Alagoas;971;82;America/Sao_Paulo
 5008008;Terenos;-204378;-548647;0;50;Mato Grosso do Sul;9159;67;America/Porto_Velho
-2211001;Teresina;-509194;-428034;1;22;PiauÌ;1219;86;America/Sao_Paulo
-5221080;Teresina de Goi·s;-137801;-472659;0;52;Goi·s;9759;62;America/Sao_Paulo
-3305802;TeresÛpolis;-224165;-429752;0;33;Rio de Janeiro;5915;21;America/Sao_Paulo
+2211001;Teresina;-509194;-428034;1;22;Piau√≠;1219;86;America/Sao_Paulo
+5221080;Teresina de Goi√°s;-137801;-472659;0;52;Goi√°s;9759;62;America/Sao_Paulo
+3305802;Teres√≥polis;-224165;-429752;0;33;Rio de Janeiro;5915;21;America/Sao_Paulo
 2615102;Terezinha;-905621;-366272;0;26;Pernambuco;2601;87;America/Sao_Paulo
-5221197;TerezÛpolis de Goi·s;-163945;-490797;0;52;Goi·s;57;62;America/Sao_Paulo
-1507961;Terra Alta;-102963;-479004;0;15;Par·;373;91;America/Sao_Paulo
-4127205;Terra Boa;-237683;-52447;0;41;Paran·;7917;44;America/Sao_Paulo
+5221197;Terez√≥polis de Goi√°s;-163945;-490797;0;52;Goi√°s;57;62;America/Sao_Paulo
+1507961;Terra Alta;-102963;-479004;0;15;Par√°;373;91;America/Sao_Paulo
+4127205;Terra Boa;-237683;-52447;0;41;Paran√°;7917;44;America/Sao_Paulo
 4321436;Terra de Areia;-295782;-500644;0;43;Rio Grande do Sul;7333;51;America/Sao_Paulo
 2931707;Terra Nova;-123888;-386238;0;29;Bahia;3933;75;America/Sao_Paulo
 2615201;Terra Nova;-822244;-393825;0;26;Pernambuco;2603;87;America/Sao_Paulo
 5108055;Terra Nova do Norte;-10517;-55231;0;51;Mato Grosso;9909;66;America/Porto_Velho
-4127304;Terra Rica;-227111;-526188;0;41;Paran·;7919;44;America/Sao_Paulo
-4127403;Terra Roxa;-241575;-540988;0;41;Paran·;7921;44;America/Sao_Paulo
-3554409;Terra Roxa;-20787;-483314;0;35;S„o Paulo;7189;17;America/Sao_Paulo
-1507979;Terra Santa;-210443;-564877;0;15;Par·;637;93;America/Sao_Paulo
+4127304;Terra Rica;-227111;-526188;0;41;Paran√°;7919;44;America/Sao_Paulo
+4127403;Terra Roxa;-241575;-540988;0;41;Paran√°;7921;44;America/Sao_Paulo
+3554409;Terra Roxa;-20787;-483314;0;35;S√£o Paulo;7189;17;America/Sao_Paulo
+1507979;Terra Santa;-210443;-564877;0;15;Par√°;637;93;America/Sao_Paulo
 5108105;Tesouro;-160809;-53559;0;51;Mato Grosso;9161;66;America/Porto_Velho
-4321451;TeutÙnia;-294482;-518044;0;43;Rio Grande do Sul;9821;51;America/Sao_Paulo
-1101609;Theobroma;-102483;-623538;0;11;RondÙnia;975;69;America/Porto_Velho
-2313401;Tiangu·;-372965;-409923;0;23;Cear·;1569;88;America/Sao_Paulo
-4127502;Tibagi;-245153;-504176;0;41;Paran·;7923;42;America/Sao_Paulo
+4321451;Teut√¥nia;-294482;-518044;0;43;Rio Grande do Sul;9821;51;America/Sao_Paulo
+1101609;Theobroma;-102483;-623538;0;11;Rond√¥nia;975;69;America/Porto_Velho
+2313401;Tiangu√°;-372965;-409923;0;23;Cear√°;1569;88;America/Sao_Paulo
+4127502;Tibagi;-245153;-504176;0;41;Paran√°;7923;42;America/Sao_Paulo
 2411056;Tibau;-483729;-372554;0;24;Rio Grande do Norte;428;84;America/Sao_Paulo
 2414209;Tibau do Sul;-619176;-350866;0;24;Rio Grande do Norte;1881;84;America/Sao_Paulo
-3554508;TietÍ;-231101;-477164;0;35;S„o Paulo;7191;15;America/Sao_Paulo
+3554508;Tiet√™;-231101;-477164;0;35;S√£o Paulo;7191;15;America/Sao_Paulo
 4217956;Tigrinhos;-266876;-531545;0;42;Santa Catarina;946;49;America/Sao_Paulo
 4218004;Tijucas;-272354;-486322;0;42;Santa Catarina;8355;48;America/Sao_Paulo
-4127601;Tijucas do Sul;-259311;-49195;0;41;Paran·;7925;41;America/Sao_Paulo
-2615300;Timba˙ba;-750484;-353119;0;26;Pernambuco;2605;81;America/Sao_Paulo
-2414308;Timba˙ba dos Batistas;-645768;-372745;0;24;Rio Grande do Norte;1883;84;America/Sao_Paulo
-4218103;TimbÈ do Sul;-288287;-49842;0;42;Santa Catarina;8393;48;America/Sao_Paulo
-2112100;Timbiras;-425597;-43932;0;21;Maranh„o;935;99;America/Sao_Paulo
-4218202;TimbÛ;-268246;-49269;0;42;Santa Catarina;8357;47;America/Sao_Paulo
-4218251;TimbÛ Grande;-266127;-506607;0;42;Santa Catarina;9971;49;America/Sao_Paulo
-3554607;Timburi;-232057;-496096;0;35;S„o Paulo;7193;14;America/Sao_Paulo
-2112209;Timon;-509769;-428329;0;21;Maranh„o;937;99;America/Sao_Paulo
-3168705;TimÛteo;-195811;-426471;0;31;Minas Gerais;5373;31;America/Sao_Paulo
+4127601;Tijucas do Sul;-259311;-49195;0;41;Paran√°;7925;41;America/Sao_Paulo
+2615300;Timba√∫ba;-750484;-353119;0;26;Pernambuco;2605;81;America/Sao_Paulo
+2414308;Timba√∫ba dos Batistas;-645768;-372745;0;24;Rio Grande do Norte;1883;84;America/Sao_Paulo
+4218103;Timb√© do Sul;-288287;-49842;0;42;Santa Catarina;8393;48;America/Sao_Paulo
+2112100;Timbiras;-425597;-43932;0;21;Maranh√£o;935;99;America/Sao_Paulo
+4218202;Timb√≥;-268246;-49269;0;42;Santa Catarina;8357;47;America/Sao_Paulo
+4218251;Timb√≥ Grande;-266127;-506607;0;42;Santa Catarina;9971;49;America/Sao_Paulo
+3554607;Timburi;-232057;-496096;0;35;S√£o Paulo;7193;14;America/Sao_Paulo
+2112209;Timon;-509769;-428329;0;21;Maranh√£o;937;99;America/Sao_Paulo
+3168705;Tim√≥teo;-195811;-426471;0;31;Minas Gerais;5373;31;America/Sao_Paulo
 4321469;Tio Hugo;-285712;-525955;0;43;Rio Grande do Sul;1174;54;America/Sao_Paulo
 3168804;Tiradentes;-211102;-441744;0;31;Minas Gerais;5375;32;America/Sao_Paulo
 4321477;Tiradentes do Sul;-274022;-540814;0;43;Rio Grande do Sul;6077;55;America/Sao_Paulo
 3168903;Tiros;-190037;-459626;0;31;Minas Gerais;5377;34;America/Sao_Paulo
 2807402;Tobias Barreto;-111798;-379995;0;28;Sergipe;3247;79;America/Sao_Paulo
-1721109;TocantÌnia;-95632;-483741;0;17;Tocantins;9619;63;America/Sao_Paulo
-1721208;TocantinÛpolis;-632447;-474224;0;17;Tocantins;9621;63;America/Sao_Paulo
+1721109;Tocant√≠nia;-95632;-483741;0;17;Tocantins;9619;63;America/Sao_Paulo
+1721208;Tocantin√≥polis;-632447;-474224;0;17;Tocantins;9621;63;America/Sao_Paulo
 3169000;Tocantins;-211774;-430127;0;31;Minas Gerais;5379;32;America/Sao_Paulo
 3169059;Tocos do Moji;-223698;-460971;0;31;Minas Gerais;740;35;America/Sao_Paulo
 3169109;Toledo;-227421;-463728;0;31;Minas Gerais;5381;35;America/Sao_Paulo
-4127700;Toledo;-247246;-537412;0;41;Paran·;7927;45;America/Sao_Paulo
+4127700;Toledo;-247246;-537412;0;41;Paran√°;7927;45;America/Sao_Paulo
 2807501;Tomar do Geru;-113694;-378433;0;28;Sergipe;3249;79;America/Sao_Paulo
-4127809;Tomazina;-237796;-499499;0;41;Paran·;7929;43;America/Sao_Paulo
+4127809;Tomazina;-237796;-499499;0;41;Paran√°;7929;43;America/Sao_Paulo
 3169208;Tombos;-209086;-420228;0;31;Minas Gerais;5383;32;America/Sao_Paulo
-1508001;TomÈ-AÁu;-241302;-481415;0;15;Par·;559;91;America/Sao_Paulo
+1508001;Tom√©-A√ßu;-241302;-481415;0;15;Par√°;559;91;America/Sao_Paulo
 1304237;Tonantins;-286582;-677919;0;13;Amazonas;9851;97;America/Porto_Velho
 2615409;Toritama;-800955;-360637;0;26;Pernambuco;2607;81;America/Sao_Paulo
-5108204;TorixorÈu;-162006;-525571;0;51;Mato Grosso;9163;66;America/Porto_Velho
+5108204;Torixor√©u;-162006;-525571;0;51;Mato Grosso;9163;66;America/Porto_Velho
 4321493;Toropi;-294782;-542244;0;43;Rio Grande do Sul;1018;55;America/Sao_Paulo
-3554656;Torre de Pedra;-232462;-481955;0;35;S„o Paulo;3227;15;America/Sao_Paulo
+3554656;Torre de Pedra;-232462;-481955;0;35;S√£o Paulo;3227;15;America/Sao_Paulo
 4321501;Torres;-293334;-497333;0;43;Rio Grande do Sul;8933;51;America/Sao_Paulo
-3554706;Torrinha;-224237;-481731;0;35;S„o Paulo;7195;14;America/Sao_Paulo
+3554706;Torrinha;-224237;-481731;0;35;S√£o Paulo;7195;14;America/Sao_Paulo
 2414407;Touros;-520182;-354621;0;24;Rio Grande do Norte;1885;84;America/Sao_Paulo
-3554755;Trabiju;-220388;-483342;0;35;S„o Paulo;826;16;America/Sao_Paulo
-1508035;Tracuateua;-107653;-469031;0;15;Par·;68;91;America/Sao_Paulo
-2615508;TracunhaÈm;-780228;-352314;0;26;Pernambuco;2609;81;America/Sao_Paulo
+3554755;Trabiju;-220388;-483342;0;35;S√£o Paulo;826;16;America/Sao_Paulo
+1508035;Tracuateua;-107653;-469031;0;15;Par√°;68;91;America/Sao_Paulo
+2615508;Tracunha√©m;-780228;-352314;0;26;Pernambuco;2609;81;America/Sao_Paulo
 2709202;Traipu;-996262;-370071;0;27;Alagoas;2883;82;America/Sao_Paulo
-1508050;Trair„o;-457347;-559429;0;15;Par·;635;93;America/Sao_Paulo
-2313500;Trairi;-326932;-392681;0;23;Cear·;1571;85;America/Sao_Paulo
+1508050;Trair√£o;-457347;-559429;0;15;Par√°;635;93;America/Sao_Paulo
+2313500;Trairi;-326932;-392681;0;23;Cear√°;1571;85;America/Sao_Paulo
 3305901;Trajano de Moraes;-220638;-420643;0;33;Rio de Janeiro;5917;22;America/Sao_Paulo
-4321600;TramandaÌ;-299841;-501322;0;43;Rio Grande do Sul;8935;51;America/Sao_Paulo
+4321600;Tramanda√≠;-299841;-501322;0;43;Rio Grande do Sul;8935;51;America/Sao_Paulo
 4321626;Travesseiro;-292977;-520532;0;43;Rio Grande do Sul;6037;51;America/Sao_Paulo
 2931806;Tremedal;-149736;-414142;0;29;Bahia;3935;77;America/Sao_Paulo
-3554805;TremembÈ;-229571;-455475;0;35;S„o Paulo;7197;12;America/Sao_Paulo
-4321634;TrÍs Arroios;-275003;-521448;0;43;Rio Grande do Sul;7331;54;America/Sao_Paulo
-4218301;TrÍs Barras;-261056;-503197;0;42;Santa Catarina;8359;47;America/Sao_Paulo
-4127858;TrÍs Barras do Paran·;-254185;-531833;0;41;Paran·;7987;45;America/Sao_Paulo
-4321667;TrÍs Cachoeiras;-294487;-499275;0;43;Rio Grande do Sul;7329;51;America/Sao_Paulo
-3169307;TrÍs CoraÁıes;-216921;-452511;0;31;Minas Gerais;5385;35;America/Sao_Paulo
-4321709;TrÍs Coroas;-295137;-507739;0;43;Rio Grande do Sul;8937;51;America/Sao_Paulo
-4321808;TrÍs de Maio;-2778;-542357;0;43;Rio Grande do Sul;8939;55;America/Sao_Paulo
-4321832;TrÍs Forquilhas;-295384;-500708;0;43;Rio Grande do Sul;5777;51;America/Sao_Paulo
-3554904;TrÍs Fronteiras;-202344;-508905;0;35;S„o Paulo;7199;17;America/Sao_Paulo
-5008305;TrÍs Lagoas;-207849;-517007;0;50;Mato Grosso do Sul;9165;67;America/Porto_Velho
-3169356;TrÍs Marias;-182048;-452473;0;31;Minas Gerais;4115;38;America/Sao_Paulo
-4321857;TrÍs Palmeiras;-276139;-528437;0;43;Rio Grande do Sul;7327;54;America/Sao_Paulo
-4321907;TrÍs Passos;-274555;-539296;0;43;Rio Grande do Sul;8941;55;America/Sao_Paulo
-3169406;TrÍs Pontas;-213694;-455109;0;31;Minas Gerais;5387;35;America/Sao_Paulo
-5221304;TrÍs Ranchos;-183539;-47776;0;52;Goi·s;9623;64;America/Sao_Paulo
-3306008;TrÍs Rios;-221165;-432185;0;33;Rio de Janeiro;5919;24;America/Sao_Paulo
+3554805;Trememb√©;-229571;-455475;0;35;S√£o Paulo;7197;12;America/Sao_Paulo
+4321634;Tr√™s Arroios;-275003;-521448;0;43;Rio Grande do Sul;7331;54;America/Sao_Paulo
+4218301;Tr√™s Barras;-261056;-503197;0;42;Santa Catarina;8359;47;America/Sao_Paulo
+4127858;Tr√™s Barras do Paran√°;-254185;-531833;0;41;Paran√°;7987;45;America/Sao_Paulo
+4321667;Tr√™s Cachoeiras;-294487;-499275;0;43;Rio Grande do Sul;7329;51;America/Sao_Paulo
+3169307;Tr√™s Cora√ß√µes;-216921;-452511;0;31;Minas Gerais;5385;35;America/Sao_Paulo
+4321709;Tr√™s Coroas;-295137;-507739;0;43;Rio Grande do Sul;8937;51;America/Sao_Paulo
+4321808;Tr√™s de Maio;-2778;-542357;0;43;Rio Grande do Sul;8939;55;America/Sao_Paulo
+4321832;Tr√™s Forquilhas;-295384;-500708;0;43;Rio Grande do Sul;5777;51;America/Sao_Paulo
+3554904;Tr√™s Fronteiras;-202344;-508905;0;35;S√£o Paulo;7199;17;America/Sao_Paulo
+5008305;Tr√™s Lagoas;-207849;-517007;0;50;Mato Grosso do Sul;9165;67;America/Porto_Velho
+3169356;Tr√™s Marias;-182048;-452473;0;31;Minas Gerais;4115;38;America/Sao_Paulo
+4321857;Tr√™s Palmeiras;-276139;-528437;0;43;Rio Grande do Sul;7327;54;America/Sao_Paulo
+4321907;Tr√™s Passos;-274555;-539296;0;43;Rio Grande do Sul;8941;55;America/Sao_Paulo
+3169406;Tr√™s Pontas;-213694;-455109;0;31;Minas Gerais;5387;35;America/Sao_Paulo
+5221304;Tr√™s Ranchos;-183539;-47776;0;52;Goi√°s;9623;64;America/Sao_Paulo
+3306008;Tr√™s Rios;-221165;-432185;0;33;Rio de Janeiro;5919;24;America/Sao_Paulo
 4218350;Treviso;-285097;-494634;0;42;Santa Catarina;948;48;America/Sao_Paulo
 4218400;Treze de Maio;-285537;-491565;0;42;Santa Catarina;8361;48;America/Sao_Paulo
-4218509;Treze TÌlias;-270026;-514084;0;42;Santa Catarina;8363;49;America/Sao_Paulo
-5221403;Trindade;-166517;-494927;0;52;Goi·s;9625;62;America/Sao_Paulo
+4218509;Treze T√≠lias;-270026;-514084;0;42;Santa Catarina;8363;49;America/Sao_Paulo
+5221403;Trindade;-166517;-494927;0;52;Goi√°s;9625;62;America/Sao_Paulo
 2615607;Trindade;-7759;-402647;0;26;Pernambuco;2611;87;America/Sao_Paulo
 4321956;Trindade do Sul;-275239;-528956;0;43;Rio Grande do Sul;7325;54;America/Sao_Paulo
 4322004;Triunfo;-299291;-517075;0;43;Rio Grande do Sul;8943;51;America/Sao_Paulo
-2516805;Triunfo;-65713;-385986;0;25;ParaÌba;2237;83;America/Sao_Paulo
+2516805;Triunfo;-65713;-385986;0;25;Para√≠ba;2237;83;America/Sao_Paulo
 2615706;Triunfo;-783272;-380978;0;26;Pernambuco;2613;87;America/Sao_Paulo
 2414456;Triunfo Potiguar;-585408;-371786;0;24;Rio Grande do Norte;436;84;America/Sao_Paulo
-2112233;Trizidela do Vale;-4538;-44628;0;21;Maranh„o;258;99;America/Sao_Paulo
-5221452;Trombas;-135079;-487417;0;52;Goi·s;9761;62;America/Sao_Paulo
+2112233;Trizidela do Vale;-4538;-44628;0;21;Maranh√£o;258;99;America/Sao_Paulo
+5221452;Trombas;-135079;-487417;0;52;Goi√°s;9761;62;America/Sao_Paulo
 4218608;Trombudo Central;-273033;-49793;0;42;Santa Catarina;8365;47;America/Sao_Paulo
-4218707;Tubar„o;-284713;-490144;0;42;Santa Catarina;8367;48;America/Sao_Paulo
+4218707;Tubar√£o;-284713;-490144;0;42;Santa Catarina;8367;48;America/Sao_Paulo
 2931905;Tucano;-109584;-387894;0;29;Bahia;3937;75;America/Sao_Paulo
-1508084;Tucum„;-674687;-511626;0;15;Par·;397;94;America/Sao_Paulo
+1508084;Tucum√£;-674687;-511626;0;15;Par√°;397;94;America/Sao_Paulo
 4322103;Tucunduva;-276573;-544439;0;43;Rio Grande do Sul;8945;55;America/Sao_Paulo
-1508100;TucuruÌ;-37657;-496773;0;15;Par·;561;94;America/Sao_Paulo
-2112274;Tufil‚ndia;-367355;-456238;0;21;Maranh„o;260;98;America/Sao_Paulo
-3554953;Tuiuti;-228193;-466937;0;35;S„o Paulo;2955;11;America/Sao_Paulo
+1508100;Tucuru√≠;-37657;-496773;0;15;Par√°;561;94;America/Sao_Paulo
+2112274;Tufil√¢ndia;-367355;-456238;0;21;Maranh√£o;260;98;America/Sao_Paulo
+3554953;Tuiuti;-228193;-466937;0;35;S√£o Paulo;2955;11;America/Sao_Paulo
 3169505;Tumiritinga;-189844;-416527;0;31;Minas Gerais;5389;33;America/Sao_Paulo
-4218756;Tun·polis;-269681;-536417;0;42;Santa Catarina;9991;49;America/Sao_Paulo
+4218756;Tun√°polis;-269681;-536417;0;42;Santa Catarina;9991;49;America/Sao_Paulo
 4322152;Tunas;-291039;-529538;0;43;Rio Grande do Sul;7323;51;America/Sao_Paulo
-4127882;Tunas do Paran·;-249731;-490879;0;41;Paran·;5455;41;America/Sao_Paulo
-4127908;Tuneiras do Oeste;-238648;-528769;0;41;Paran·;7931;44;America/Sao_Paulo
-2112308;Tuntum;-525476;-446444;0;21;Maranh„o;939;99;America/Sao_Paulo
-3555000;Tup„;-219335;-505191;0;35;S„o Paulo;7201;14;America/Sao_Paulo
+4127882;Tunas do Paran√°;-249731;-490879;0;41;Paran√°;5455;41;America/Sao_Paulo
+4127908;Tuneiras do Oeste;-238648;-528769;0;41;Paran√°;7931;44;America/Sao_Paulo
+2112308;Tuntum;-525476;-446444;0;21;Maranh√£o;939;99;America/Sao_Paulo
+3555000;Tup√£;-219335;-505191;0;35;S√£o Paulo;7201;14;America/Sao_Paulo
 3169604;Tupaciguara;-185866;-486985;0;31;Minas Gerais;5391;34;America/Sao_Paulo
 2615805;Tupanatinga;-874798;-373445;0;26;Pernambuco;2615;87;America/Sao_Paulo
 4322186;Tupanci do Sul;-279241;-515383;0;43;Rio Grande do Sul;5979;54;America/Sao_Paulo
-4322202;Tupanciret„;-290858;-538445;0;43;Rio Grande do Sul;8947;55;America/Sao_Paulo
+4322202;Tupanciret√£;-290858;-538445;0;43;Rio Grande do Sul;8947;55;America/Sao_Paulo
 4322251;Tupandi;-294772;-514174;0;43;Rio Grande do Sul;7321;51;America/Sao_Paulo
 4322301;Tuparendi;-277598;-544814;0;43;Rio Grande do Sul;8949;55;America/Sao_Paulo
 2615904;Tuparetama;-76003;-373165;0;26;Pernambuco;2617;87;America/Sao_Paulo
-4127957;Tup„ssi;-245879;-535105;0;41;Paran·;7993;44;America/Sao_Paulo
-3555109;Tupi Paulista;-213825;-51575;0;35;S„o Paulo;7203;18;America/Sao_Paulo
+4127957;Tup√£ssi;-245879;-535105;0;41;Paran√°;7993;44;America/Sao_Paulo
+3555109;Tupi Paulista;-213825;-51575;0;35;S√£o Paulo;7203;18;America/Sao_Paulo
 1721257;Tupirama;-897168;-481883;0;17;Tocantins;102;63;America/Sao_Paulo
 1721307;Tupiratins;-839388;-481277;0;17;Tocantins;365;63;America/Sao_Paulo
-2112407;TuriaÁu;-165893;-453798;0;21;Maranh„o;941;98;America/Sao_Paulo
-2112456;Turil‚ndia;-221638;-453044;0;21;Maranh„o;262;98;America/Sao_Paulo
-3555208;Turi˙ba;-209428;-501135;0;35;S„o Paulo;7205;18;America/Sao_Paulo
-3555307;Turmalina;-200486;-504792;0;35;S„o Paulo;7207;17;America/Sao_Paulo
+2112407;Turia√ßu;-165893;-453798;0;21;Maranh√£o;941;98;America/Sao_Paulo
+2112456;Turil√¢ndia;-221638;-453044;0;21;Maranh√£o;262;98;America/Sao_Paulo
+3555208;Turi√∫ba;-209428;-501135;0;35;S√£o Paulo;7205;18;America/Sao_Paulo
+3555307;Turmalina;-200486;-504792;0;35;S√£o Paulo;7207;17;America/Sao_Paulo
 3169703;Turmalina;-172828;-427285;0;31;Minas Gerais;5393;38;America/Sao_Paulo
-4322327;TuruÁu;-314173;-521706;0;43;Rio Grande do Sul;1020;53;America/Sao_Paulo
-2313559;Tururu;-358413;-394297;0;23;Cear·;1279;85;America/Sao_Paulo
-5221502;Turv‚nia;-166125;-501369;0;52;Goi·s;9631;64;America/Sao_Paulo
-5221551;Turvel‚ndia;-178502;-503024;0;52;Goi·s;9765;64;America/Sao_Paulo
-4127965;Turvo;-250437;-515282;0;41;Paran·;8453;42;America/Sao_Paulo
+4322327;Turu√ßu;-314173;-521706;0;43;Rio Grande do Sul;1020;53;America/Sao_Paulo
+2313559;Tururu;-358413;-394297;0;23;Cear√°;1279;85;America/Sao_Paulo
+5221502;Turv√¢nia;-166125;-501369;0;52;Goi√°s;9631;64;America/Sao_Paulo
+5221551;Turvel√¢ndia;-178502;-503024;0;52;Goi√°s;9765;64;America/Sao_Paulo
+4127965;Turvo;-250437;-515282;0;41;Paran√°;8453;42;America/Sao_Paulo
 4218806;Turvo;-289272;-496831;0;42;Santa Catarina;8369;48;America/Sao_Paulo
-3169802;Turvol‚ndia;-218733;-457859;0;31;Minas Gerais;5395;35;America/Sao_Paulo
-2112506;TutÛia;-276141;-422755;0;21;Maranh„o;943;98;America/Sao_Paulo
+3169802;Turvol√¢ndia;-218733;-457859;0;31;Minas Gerais;5395;35;America/Sao_Paulo
+2112506;Tut√≥ia;-276141;-422755;0;21;Maranh√£o;943;98;America/Sao_Paulo
 1304260;Uarini;-299609;-651133;0;13;Amazonas;9849;97;America/Porto_Velho
-2932002;Uau·;-983325;-394794;0;29;Bahia;3939;74;America/Sao_Paulo
-3169901;Ub·;-211204;-429359;0;31;Minas Gerais;5397;32;America/Sao_Paulo
-3170008;UbaÌ;-162885;-447783;0;31;Minas Gerais;5399;38;America/Sao_Paulo
-2932101;UbaÌra;-132714;-39666;0;29;Bahia;3941;75;America/Sao_Paulo
+2932002;Uau√°;-983325;-394794;0;29;Bahia;3939;74;America/Sao_Paulo
+3169901;Ub√°;-211204;-429359;0;31;Minas Gerais;5397;32;America/Sao_Paulo
+3170008;Uba√≠;-162885;-447783;0;31;Minas Gerais;5399;38;America/Sao_Paulo
+2932101;Uba√≠ra;-132714;-39666;0;29;Bahia;3941;75;America/Sao_Paulo
 2932200;Ubaitaba;-14303;-393222;0;29;Bahia;3943;73;America/Sao_Paulo
-2313609;Ubajara;-385448;-409204;0;23;Cear·;1573;88;America/Sao_Paulo
+2313609;Ubajara;-385448;-409204;0;23;Cear√°;1573;88;America/Sao_Paulo
 3170057;Ubaporanga;-196351;-421059;0;31;Minas Gerais;2671;33;America/Sao_Paulo
-3555356;Ubarana;-21165;-497198;0;35;S„o Paulo;2971;17;America/Sao_Paulo
-2932309;Ubat„;-142063;-395207;0;29;Bahia;3945;73;America/Sao_Paulo
-3555406;Ubatuba;-234332;-450834;0;35;S„o Paulo;7209;12;America/Sao_Paulo
+3555356;Ubarana;-21165;-497198;0;35;S√£o Paulo;2971;17;America/Sao_Paulo
+2932309;Ubat√£;-142063;-395207;0;29;Bahia;3945;73;America/Sao_Paulo
+3555406;Ubatuba;-234332;-450834;0;35;S√£o Paulo;7209;12;America/Sao_Paulo
 3170107;Uberaba;-197472;-479381;0;31;Minas Gerais;5401;34;America/Sao_Paulo
-3170206;Uberl‚ndia;-189141;-482749;0;31;Minas Gerais;5403;34;America/Sao_Paulo
-3555505;Ubirajara;-225272;-496613;0;35;S„o Paulo;7211;14;America/Sao_Paulo
-4128005;Ubirat„;-245393;-529865;0;41;Paran·;7933;44;America/Sao_Paulo
+3170206;Uberl√¢ndia;-189141;-482749;0;31;Minas Gerais;5403;34;America/Sao_Paulo
+3555505;Ubirajara;-225272;-496613;0;35;S√£o Paulo;7211;14;America/Sao_Paulo
+4128005;Ubirat√£;-245393;-529865;0;41;Paran√°;7933;44;America/Sao_Paulo
 4322343;Ubiretama;-280404;-54686;0;43;Rio Grande do Sul;1022;55;America/Sao_Paulo
-3555604;Uchoa;-209511;-491713;0;35;S„o Paulo;7213;17;America/Sao_Paulo
-2932408;UibaÌ;-113394;-421354;0;29;Bahia;3947;74;America/Sao_Paulo
-1400704;Uiramut„;460314;-601815;0;14;Roraima;38;95;America/Porto_Velho
-5221577;Uirapuru;-142835;-499201;0;52;Goi·s;59;62;America/Sao_Paulo
-2516904;Uira˙na;-651504;-384128;0;25;ParaÌba;2239;83;America/Sao_Paulo
-1508126;UlianÛpolis;-375007;-474892;0;15;Par·;623;91;America/Sao_Paulo
-2313708;Umari;-663893;-387008;0;23;Cear·;1575;88;America/Sao_Paulo
+3555604;Uchoa;-209511;-491713;0;35;S√£o Paulo;7213;17;America/Sao_Paulo
+2932408;Uiba√≠;-113394;-421354;0;29;Bahia;3947;74;America/Sao_Paulo
+1400704;Uiramut√£;460314;-601815;0;14;Roraima;38;95;America/Porto_Velho
+5221577;Uirapuru;-142835;-499201;0;52;Goi√°s;59;62;America/Sao_Paulo
+2516904;Uira√∫na;-651504;-384128;0;25;Para√≠ba;2239;83;America/Sao_Paulo
+1508126;Ulian√≥polis;-375007;-474892;0;15;Par√°;623;91;America/Sao_Paulo
+2313708;Umari;-663893;-387008;0;23;Cear√°;1575;88;America/Sao_Paulo
 2414506;Umarizal;-598238;-37818;0;24;Rio Grande do Norte;1887;84;America/Sao_Paulo
-2807600;Umba˙ba;-113809;-376623;0;28;Sergipe;3251;79;America/Sao_Paulo
+2807600;Umba√∫ba;-113809;-376623;0;28;Sergipe;3251;79;America/Sao_Paulo
 2932457;Umburanas;-107339;-413234;0;29;Bahia;3047;74;America/Sao_Paulo
 3170305;Umburatiba;-172548;-405779;0;31;Minas Gerais;5405;33;America/Sao_Paulo
-2517001;Umbuzeiro;-769199;-356582;0;25;ParaÌba;2241;83;America/Sao_Paulo
-2313757;Umirim;-367654;-393465;0;23;Cear·;9855;85;America/Sao_Paulo
-4128104;Umuarama;-237656;-533201;0;41;Paran·;7935;44;America/Sao_Paulo
+2517001;Umbuzeiro;-769199;-356582;0;25;Para√≠ba;2241;83;America/Sao_Paulo
+2313757;Umirim;-367654;-393465;0;23;Cear√°;9855;85;America/Sao_Paulo
+4128104;Umuarama;-237656;-533201;0;41;Paran√°;7935;44;America/Sao_Paulo
 2932507;Una;-152791;-390765;0;29;Bahia;3949;73;America/Sao_Paulo
-3170404;UnaÌ;-163592;-469022;0;31;Minas Gerais;5407;38;America/Sao_Paulo
-2211100;Uni„o;-458571;-428583;0;22;PiauÌ;1221;86;America/Sao_Paulo
-4322350;Uni„o da Serra;-287833;-520238;0;43;Rio Grande do Sul;5999;54;America/Sao_Paulo
-4128203;Uni„o da VitÛria;-262273;-510873;0;41;Paran·;7937;42;America/Sao_Paulo
-3170438;Uni„o de Minas;-195299;-50338;0;31;Minas Gerais;742;34;America/Sao_Paulo
-4218855;Uni„o do Oeste;-26762;-528541;0;42;Santa Catarina;9973;49;America/Sao_Paulo
-5108303;Uni„o do Sul;-115308;-543616;0;51;Mato Grosso;1048;66;America/Porto_Velho
-2709301;Uni„o dos Palmares;-915921;-360223;0;27;Alagoas;2885;82;America/Sao_Paulo
-3555703;Uni„o Paulista;-208862;-499025;0;35;S„o Paulo;7215;17;America/Sao_Paulo
-4128302;Uniflor;-230868;-521573;0;41;Paran·;7939;44;America/Sao_Paulo
+3170404;Una√≠;-163592;-469022;0;31;Minas Gerais;5407;38;America/Sao_Paulo
+2211100;Uni√£o;-458571;-428583;0;22;Piau√≠;1221;86;America/Sao_Paulo
+4322350;Uni√£o da Serra;-287833;-520238;0;43;Rio Grande do Sul;5999;54;America/Sao_Paulo
+4128203;Uni√£o da Vit√≥ria;-262273;-510873;0;41;Paran√°;7937;42;America/Sao_Paulo
+3170438;Uni√£o de Minas;-195299;-50338;0;31;Minas Gerais;742;34;America/Sao_Paulo
+4218855;Uni√£o do Oeste;-26762;-528541;0;42;Santa Catarina;9973;49;America/Sao_Paulo
+5108303;Uni√£o do Sul;-115308;-543616;0;51;Mato Grosso;1048;66;America/Porto_Velho
+2709301;Uni√£o dos Palmares;-915921;-360223;0;27;Alagoas;2885;82;America/Sao_Paulo
+3555703;Uni√£o Paulista;-208862;-499025;0;35;S√£o Paulo;7215;17;America/Sao_Paulo
+4128302;Uniflor;-230868;-521573;0;41;Paran√°;7939;44;America/Sao_Paulo
 4322376;Unistalda;-2904;-551517;0;43;Rio Grande do Sul;1024;55;America/Sao_Paulo
 2414605;Upanema;-563761;-372635;0;24;Rio Grande do Norte;1889;84;America/Sao_Paulo
-4128401;UraÌ;-232;-507939;0;41;Paran·;7941;43;America/Sao_Paulo
+4128401;Ura√≠;-232;-507939;0;41;Paran√°;7941;43;America/Sao_Paulo
 2932606;Urandi;-147678;-426498;0;29;Bahia;3951;77;America/Sao_Paulo
-3555802;Ur‚nia;-202455;-506455;0;35;S„o Paulo;7217;17;America/Sao_Paulo
-2112605;Urbano Santos;-320642;-433878;0;21;Maranh„o;945;98;America/Sao_Paulo
-3555901;Uru;-217866;-492848;0;35;S„o Paulo;7219;14;America/Sao_Paulo
-5221601;UruaÁu;-145238;-491396;0;52;Goi·s;9633;62;America/Sao_Paulo
-5221700;Uruana;-154993;-496861;0;52;Goi·s;9635;62;America/Sao_Paulo
+3555802;Ur√¢nia;-202455;-506455;0;35;S√£o Paulo;7217;17;America/Sao_Paulo
+2112605;Urbano Santos;-320642;-433878;0;21;Maranh√£o;945;98;America/Sao_Paulo
+3555901;Uru;-217866;-492848;0;35;S√£o Paulo;7219;14;America/Sao_Paulo
+5221601;Urua√ßu;-145238;-491396;0;52;Goi√°s;9633;62;America/Sao_Paulo
+5221700;Uruana;-154993;-496861;0;52;Goi√°s;9635;62;America/Sao_Paulo
 3170479;Uruana de Minas;-160634;-462443;0;31;Minas Gerais;744;38;America/Sao_Paulo
-1508159;Uruar·;-371519;-537396;0;15;Par·;399;93;America/Sao_Paulo
+1508159;Uruar√°;-371519;-537396;0;15;Par√°;399;93;America/Sao_Paulo
 4218905;Urubici;-280157;-495925;0;42;Santa Catarina;8371;49;America/Sao_Paulo
-2313807;Uruburetama;-362316;-395107;0;23;Cear·;1577;85;America/Sao_Paulo
-3170503;Uruc‚nia;-203521;-42737;0;31;Minas Gerais;5409;31;America/Sao_Paulo
-1304302;Urucar·;-252936;-577538;0;13;Amazonas;285;92;America/Porto_Velho
-2932705;UruÁuca;-145963;-392851;0;29;Bahia;3953;73;America/Sao_Paulo
-2211209;UruÁuÌ;-723944;-445577;0;22;PiauÌ;1223;89;America/Sao_Paulo
+2313807;Uruburetama;-362316;-395107;0;23;Cear√°;1577;85;America/Sao_Paulo
+3170503;Uruc√¢nia;-203521;-42737;0;31;Minas Gerais;5409;31;America/Sao_Paulo
+1304302;Urucar√°;-252936;-577538;0;13;Amazonas;285;92;America/Porto_Velho
+2932705;Uru√ßuca;-145963;-392851;0;29;Bahia;3953;73;America/Sao_Paulo
+2211209;Uru√ßu√≠;-723944;-445577;0;22;Piau√≠;1223;89;America/Sao_Paulo
 3170529;Urucuia;-161244;-457352;0;31;Minas Gerais;2699;38;America/Sao_Paulo
 1304401;Urucurituba;-312841;-581496;0;13;Amazonas;287;92;America/Porto_Velho
 4322400;Uruguaiana;-297614;-570853;0;43;Rio Grande do Sul;8951;55;America/Sao_Paulo
-2313906;Uruoca;-330819;-405628;0;23;Cear·;1579;88;America/Sao_Paulo
-1101708;Urup·;-111261;-623639;0;11;RondÙnia;977;69;America/Porto_Velho
+2313906;Uruoca;-330819;-405628;0;23;Cear√°;1579;88;America/Sao_Paulo
+1101708;Urup√°;-111261;-623639;0;11;Rond√¥nia;977;69;America/Porto_Velho
 4218954;Urupema;-279557;-498729;0;42;Santa Catarina;9975;49;America/Sao_Paulo
-3556008;UrupÍs;-212032;-492931;0;35;S„o Paulo;7221;17;America/Sao_Paulo
+3556008;Urup√™s;-212032;-492931;0;35;S√£o Paulo;7221;17;America/Sao_Paulo
 4219002;Urussanga;-28518;-493238;0;42;Santa Catarina;8373;48;America/Sao_Paulo
-5221809;UrutaÌ;-174651;-482015;0;52;Goi·s;9637;64;America/Sao_Paulo
+5221809;Uruta√≠;-174651;-482015;0;52;Goi√°s;9637;64;America/Sao_Paulo
 2932804;Utinga;-120783;-410954;0;29;Bahia;3955;75;America/Sao_Paulo
 4322509;Vacaria;-285079;-509418;0;43;Rio Grande do Sul;8953;54;America/Sao_Paulo
-5108352;Vale de S„o Domingos;-15286;-590683;0;51;Mato Grosso;1102;65;America/Porto_Velho
-1101757;Vale do Anari;-986215;-621876;0;11;RondÙnia;24;69;America/Porto_Velho
-1101807;Vale do ParaÌso;-104465;-621352;0;11;RondÙnia;979;69;America/Porto_Velho
+5108352;Vale de S√£o Domingos;-15286;-590683;0;51;Mato Grosso;1102;65;America/Porto_Velho
+1101757;Vale do Anari;-986215;-621876;0;11;Rond√¥nia;24;69;America/Porto_Velho
+1101807;Vale do Para√≠so;-104465;-621352;0;11;Rond√¥nia;979;69;America/Porto_Velho
 4322533;Vale do Sol;-295967;-526839;0;43;Rio Grande do Sul;5769;51;America/Sao_Paulo
 4322541;Vale Real;-293919;-512559;0;43;Rio Grande do Sul;6049;51;America/Sao_Paulo
 4322525;Vale Verde;-297864;-521857;0;43;Rio Grande do Sul;1026;51;America/Sao_Paulo
-2932903;ValenÁa;-133669;-39073;0;29;Bahia;3957;75;America/Sao_Paulo
-3306107;ValenÁa;-222445;-437129;0;33;Rio de Janeiro;5921;24;America/Sao_Paulo
-2211308;ValenÁa do PiauÌ;-640301;-417375;0;22;PiauÌ;1225;89;America/Sao_Paulo
+2932903;Valen√ßa;-133669;-39073;0;29;Bahia;3957;75;America/Sao_Paulo
+3306107;Valen√ßa;-222445;-437129;0;33;Rio de Janeiro;5921;24;America/Sao_Paulo
+2211308;Valen√ßa do Piau√≠;-640301;-417375;0;22;Piau√≠;1225;89;America/Sao_Paulo
 2933000;Valente;-114062;-39457;0;29;Bahia;3959;75;America/Sao_Paulo
-3556107;Valentim Gentil;-204217;-500889;0;35;S„o Paulo;7223;17;America/Sao_Paulo
-3556206;Valinhos;-229698;-469974;0;35;S„o Paulo;7225;19;America/Sao_Paulo
-3556305;ValparaÌso;-212229;-508699;0;35;S„o Paulo;7227;18;America/Sao_Paulo
-5221858;ValparaÌso de Goi·s;-160651;-479757;0;52;Goi·s;1066;61;America/Sao_Paulo
+3556107;Valentim Gentil;-204217;-500889;0;35;S√£o Paulo;7223;17;America/Sao_Paulo
+3556206;Valinhos;-229698;-469974;0;35;S√£o Paulo;7225;19;America/Sao_Paulo
+3556305;Valpara√≠so;-212229;-508699;0;35;S√£o Paulo;7227;18;America/Sao_Paulo
+5221858;Valpara√≠so de Goi√°s;-160651;-479757;0;52;Goi√°s;1066;61;America/Sao_Paulo
 4322558;Vanini;-284758;-518447;0;43;Rio Grande do Sul;7319;54;America/Sao_Paulo
-4219101;Varge„o;-268621;-521549;0;42;Santa Catarina;8375;49;America/Sao_Paulo
+4219101;Varge√£o;-268621;-521549;0;42;Santa Catarina;8375;49;America/Sao_Paulo
 4219150;Vargem;-274867;-509724;0;42;Santa Catarina;5563;49;America/Sao_Paulo
-3556354;Vargem;-22887;-464124;0;35;S„o Paulo;2957;11;America/Sao_Paulo
+3556354;Vargem;-22887;-464124;0;35;S√£o Paulo;2957;11;America/Sao_Paulo
 3170578;Vargem Alegre;-195988;-422949;0;31;Minas Gerais;746;33;America/Sao_Paulo
-3205036;Vargem Alta;-20669;-410179;0;32;EspÌrito Santo;5727;28;America/Sao_Paulo
+3205036;Vargem Alta;-20669;-410179;0;32;Esp√≠rito Santo;5727;28;America/Sao_Paulo
 3170602;Vargem Bonita;-203333;-463688;0;31;Minas Gerais;5411;37;America/Sao_Paulo
 4219176;Vargem Bonita;-270055;-517402;0;42;Santa Catarina;5565;49;America/Sao_Paulo
-2112704;Vargem Grande;-353639;-43917;0;21;Maranh„o;947;98;America/Sao_Paulo
+2112704;Vargem Grande;-353639;-43917;0;21;Maranh√£o;947;98;America/Sao_Paulo
 3170651;Vargem Grande do Rio Pardo;-153987;-423085;0;31;Minas Gerais;748;38;America/Sao_Paulo
-3556404;Vargem Grande do Sul;-218322;-468913;0;35;S„o Paulo;7231;19;America/Sao_Paulo
-3556453;Vargem Grande Paulista;-235993;-47022;0;35;S„o Paulo;7273;11;America/Sao_Paulo
+3556404;Vargem Grande do Sul;-218322;-468913;0;35;S√£o Paulo;7231;19;America/Sao_Paulo
+3556453;Vargem Grande Paulista;-235993;-47022;0;35;S√£o Paulo;7273;11;America/Sao_Paulo
 3170701;Varginha;-215556;-454364;0;31;Minas Gerais;5413;35;America/Sao_Paulo
-5221908;Varj„o;-170471;-496312;0;52;Goi·s;9639;62;America/Sao_Paulo
-3170750;Varj„o de Minas;-183741;-460313;0;31;Minas Gerais;750;38;America/Sao_Paulo
-2313955;Varjota;-419387;-404741;0;23;Cear·;9857;88;America/Sao_Paulo
+5221908;Varj√£o;-170471;-496312;0;52;Goi√°s;9639;62;America/Sao_Paulo
+3170750;Varj√£o de Minas;-183741;-460313;0;31;Minas Gerais;750;38;America/Sao_Paulo
+2313955;Varjota;-419387;-404741;0;23;Cear√°;9857;88;America/Sao_Paulo
 3306156;Varre-Sai;-209276;-418701;0;33;Rio de Janeiro;2917;22;America/Sao_Paulo
-2414704;V·rzea;-634641;-353732;0;24;Rio Grande do Norte;1891;84;America/Sao_Paulo
-2517100;V·rzea;-676189;-369913;0;25;ParaÌba;2243;83;America/Sao_Paulo
-2314003;V·rzea Alegre;-678264;-392942;0;23;Cear·;1581;88;America/Sao_Paulo
-2211357;V·rzea Branca;-9238;-429692;0;22;PiauÌ;2267;89;America/Sao_Paulo
-3170800;V·rzea da Palma;-175944;-447226;0;31;Minas Gerais;5415;38;America/Sao_Paulo
-2933059;V·rzea da RoÁa;-116005;-401328;0;29;Bahia;3997;74;America/Sao_Paulo
-2933109;V·rzea do PoÁo;-115273;-403149;0;29;Bahia;3961;74;America/Sao_Paulo
-2211407;V·rzea Grande;-654899;-42248;0;22;PiauÌ;1227;89;America/Sao_Paulo
-5108402;V·rzea Grande;-156458;-561322;0;51;Mato Grosso;9167;65;America/Porto_Velho
-2933158;V·rzea Nova;-112557;-409432;0;29;Bahia;3995;74;America/Sao_Paulo
-3556503;V·rzea Paulista;-232136;-468234;0;35;S„o Paulo;7233;11;America/Sao_Paulo
+2414704;V√°rzea;-634641;-353732;0;24;Rio Grande do Norte;1891;84;America/Sao_Paulo
+2517100;V√°rzea;-676189;-369913;0;25;Para√≠ba;2243;83;America/Sao_Paulo
+2314003;V√°rzea Alegre;-678264;-392942;0;23;Cear√°;1581;88;America/Sao_Paulo
+2211357;V√°rzea Branca;-9238;-429692;0;22;Piau√≠;2267;89;America/Sao_Paulo
+3170800;V√°rzea da Palma;-175944;-447226;0;31;Minas Gerais;5415;38;America/Sao_Paulo
+2933059;V√°rzea da Ro√ßa;-116005;-401328;0;29;Bahia;3997;74;America/Sao_Paulo
+2933109;V√°rzea do Po√ßo;-115273;-403149;0;29;Bahia;3961;74;America/Sao_Paulo
+2211407;V√°rzea Grande;-654899;-42248;0;22;Piau√≠;1227;89;America/Sao_Paulo
+5108402;V√°rzea Grande;-156458;-561322;0;51;Mato Grosso;9167;65;America/Porto_Velho
+2933158;V√°rzea Nova;-112557;-409432;0;29;Bahia;3995;74;America/Sao_Paulo
+3556503;V√°rzea Paulista;-232136;-468234;0;35;S√£o Paulo;7233;11;America/Sao_Paulo
 2933174;Varzedo;-129672;-393919;0;29;Bahia;3049;75;America/Sao_Paulo
-3170909;Varzel‚ndia;-156992;-440278;0;31;Minas Gerais;5417;38;America/Sao_Paulo
+3170909;Varzel√¢ndia;-156992;-440278;0;31;Minas Gerais;5417;38;America/Sao_Paulo
 3306206;Vassouras;-224059;-436686;0;33;Rio de Janeiro;5923;24;America/Sao_Paulo
 3171006;Vazante;-179827;-469088;0;31;Minas Gerais;5419;34;America/Sao_Paulo
-4322608;Ven‚ncio Aires;-296143;-521932;0;43;Rio Grande do Sul;8955;51;America/Sao_Paulo
-3205069;Venda Nova do Imigrante;-20327;-411355;0;32;EspÌrito Santo;5729;28;America/Sao_Paulo
+4322608;Ven√¢ncio Aires;-296143;-521932;0;43;Rio Grande do Sul;8955;51;America/Sao_Paulo
+3205069;Venda Nova do Imigrante;-20327;-411355;0;32;Esp√≠rito Santo;5729;28;America/Sao_Paulo
 2414753;Venha-Ver;-632016;-384896;0;24;Rio Grande do Norte;438;84;America/Sao_Paulo
-4128534;Ventania;-242458;-502376;0;41;Paran·;5497;42;America/Sao_Paulo
+4128534;Ventania;-242458;-502376;0;41;Paran√°;5497;42;America/Sao_Paulo
 2616001;Venturosa;-857885;-368742;0;26;Pernambuco;2619;87;America/Sao_Paulo
 5108501;Vera;-123017;-553045;0;51;Mato Grosso;9905;66;America/Porto_Velho
 2414803;Vera Cruz;-604399;-35428;0;24;Rio Grande do Norte;1895;84;America/Sao_Paulo
 2933208;Vera Cruz;-129568;-386153;0;29;Bahia;3963;71;America/Sao_Paulo
 4322707;Vera Cruz;-297184;-525152;0;43;Rio Grande do Sul;8957;51;America/Sao_Paulo
-3556602;Vera Cruz;-222183;-498207;0;35;S„o Paulo;7235;14;America/Sao_Paulo
-4128559;Vera Cruz do Oeste;-250577;-538771;0;41;Paran·;7989;45;America/Sao_Paulo
-2211506;Vera Mendes;-759748;-414673;0;22;PiauÌ;406;89;America/Sao_Paulo
-4322806;VeranÛpolis;-289312;-515516;0;43;Rio Grande do Sul;8959;54;America/Sao_Paulo
+3556602;Vera Cruz;-222183;-498207;0;35;S√£o Paulo;7235;14;America/Sao_Paulo
+4128559;Vera Cruz do Oeste;-250577;-538771;0;41;Paran√°;7989;45;America/Sao_Paulo
+2211506;Vera Mendes;-759748;-414673;0;22;Piau√≠;406;89;America/Sao_Paulo
+4322806;Veran√≥polis;-289312;-515516;0;43;Rio Grande do Sul;8959;54;America/Sao_Paulo
 2616100;Verdejante;-792235;-389701;0;26;Pernambuco;2621;87;America/Sao_Paulo
-3171030;Verdel‚ndia;-155845;-436121;0;31;Minas Gerais;752;38;America/Sao_Paulo
-4128609;VerÍ;-258772;-529051;0;41;Paran·;7945;46;America/Sao_Paulo
+3171030;Verdel√¢ndia;-155845;-436121;0;31;Minas Gerais;752;38;America/Sao_Paulo
+4128609;Ver√™;-258772;-529051;0;41;Paran√°;7945;46;America/Sao_Paulo
 2933257;Vereda;-172183;-400974;0;29;Bahia;3051;73;America/Sao_Paulo
 3171071;Veredinha;-173974;-427307;0;31;Minas Gerais;754;38;America/Sao_Paulo
-3171105;VerÌssimo;-196657;-483118;0;31;Minas Gerais;5423;34;America/Sao_Paulo
+3171105;Ver√≠ssimo;-196657;-483118;0;31;Minas Gerais;5423;34;America/Sao_Paulo
 3171154;Vermelho Novo;-200406;-422688;0;31;Minas Gerais;756;33;America/Sao_Paulo
-2616183;Vertente do LÈrio;-777084;-358491;0;26;Pernambuco;2291;81;America/Sao_Paulo
+2616183;Vertente do L√©rio;-777084;-358491;0;26;Pernambuco;2291;81;America/Sao_Paulo
 2616209;Vertentes;-790158;-359681;0;26;Pernambuco;2623;81;America/Sao_Paulo
 3171204;Vespasiano;-196883;-439239;0;31;Minas Gerais;5425;31;America/Sao_Paulo
-4322855;Vespasiano CorrÍa;-290655;-518625;0;43;Rio Grande do Sul;1028;51;America/Sao_Paulo
+4322855;Vespasiano Corr√™a;-290655;-518625;0;43;Rio Grande do Sul;1028;51;America/Sao_Paulo
 4322905;Viadutos;-275716;-520211;0;43;Rio Grande do Sul;8961;54;America/Sao_Paulo
-4323002;Viam„o;-300819;-510194;0;43;Rio Grande do Sul;8963;51;America/Sao_Paulo
-3205101;Viana;-203825;-404933;0;32;EspÌrito Santo;5701;27;America/Sao_Paulo
-2112803;Viana;-320451;-449912;0;21;Maranh„o;949;98;America/Sao_Paulo
-5222005;VianÛpolis;-167405;-485159;0;52;Goi·s;9641;62;America/Sao_Paulo
-2616308;VicÍncia;-765655;-353139;0;26;Pernambuco;2625;81;America/Sao_Paulo
+4323002;Viam√£o;-300819;-510194;0;43;Rio Grande do Sul;8963;51;America/Sao_Paulo
+3205101;Viana;-203825;-404933;0;32;Esp√≠rito Santo;5701;27;America/Sao_Paulo
+2112803;Viana;-320451;-449912;0;21;Maranh√£o;949;98;America/Sao_Paulo
+5222005;Vian√≥polis;-167405;-485159;0;52;Goi√°s;9641;62;America/Sao_Paulo
+2616308;Vic√™ncia;-765655;-353139;0;26;Pernambuco;2625;81;America/Sao_Paulo
 4323101;Vicente Dutra;-271607;-534022;0;43;Rio Grande do Sul;8965;55;America/Sao_Paulo
 5008404;Vicentina;-224098;-544415;0;50;Mato Grosso do Sul;9187;67;America/Porto_Velho
-5222054;VicentinÛpolis;-177322;-498047;0;52;Goi·s;9657;64;America/Sao_Paulo
-2414902;ViÁosa;-598253;-379462;0;24;Rio Grande do Norte;1897;84;America/Sao_Paulo
-2709400;ViÁosa;-936763;-362431;0;27;Alagoas;2887;82;America/Sao_Paulo
-3171303;ViÁosa;-207559;-428742;0;31;Minas Gerais;5427;31;America/Sao_Paulo
-2314102;ViÁosa do Cear·;-35667;-410916;0;23;Cear·;1583;88;America/Sao_Paulo
+5222054;Vicentin√≥polis;-177322;-498047;0;52;Goi√°s;9657;64;America/Sao_Paulo
+2414902;Vi√ßosa;-598253;-379462;0;24;Rio Grande do Norte;1897;84;America/Sao_Paulo
+2709400;Vi√ßosa;-936763;-362431;0;27;Alagoas;2887;82;America/Sao_Paulo
+3171303;Vi√ßosa;-207559;-428742;0;31;Minas Gerais;5427;31;America/Sao_Paulo
+2314102;Vi√ßosa do Cear√°;-35667;-410916;0;23;Cear√°;1583;88;America/Sao_Paulo
 4323200;Victor Graeff;-285632;-527495;0;43;Rio Grande do Sul;8969;54;America/Sao_Paulo
 4219200;Vidal Ramos;-273886;-493593;0;42;Santa Catarina;8377;47;America/Sao_Paulo
 4219309;Videira;-270086;-511543;0;42;Santa Catarina;8379;49;America/Sao_Paulo
 3171402;Vieiras;-20867;-422401;0;31;Minas Gerais;5429;32;America/Sao_Paulo
-2517209;VieirÛpolis;-650684;-382567;0;25;ParaÌba;540;83;America/Sao_Paulo
-1508209;Vigia;-861194;-481386;0;15;Par·;563;91;America/Sao_Paulo
-5105507;Vila Bela da SantÌssima Trindade;-150068;-599504;0;51;Mato Grosso;9109;65;America/Porto_Velho
-5222203;Vila Boa;-150387;-47052;0;52;Goi·s;67;61;America/Sao_Paulo
+2517209;Vieir√≥polis;-650684;-382567;0;25;Para√≠ba;540;83;America/Sao_Paulo
+1508209;Vigia;-861194;-481386;0;15;Par√°;563;91;America/Sao_Paulo
+5105507;Vila Bela da Sant√≠ssima Trindade;-150068;-599504;0;51;Mato Grosso;9109;65;America/Porto_Velho
+5222203;Vila Boa;-150387;-47052;0;52;Goi√°s;67;61;America/Sao_Paulo
 2415008;Vila Flor;-631287;-35067;0;24;Rio Grande do Norte;1899;84;America/Sao_Paulo
 4323309;Vila Flores;-288598;-515504;0;43;Rio Grande do Sul;7311;54;America/Sao_Paulo
-4323358;Vila L‚ngaro;-281062;-521438;0;43;Rio Grande do Sul;1030;54;America/Sao_Paulo
+4323358;Vila L√¢ngaro;-281062;-521438;0;43;Rio Grande do Sul;1030;54;America/Sao_Paulo
 4323408;Vila Maria;-285359;-521486;0;43;Rio Grande do Sul;7309;54;America/Sao_Paulo
-2211605;Vila Nova do PiauÌ;-713272;-409345;0;22;PiauÌ;408;89;America/Sao_Paulo
+2211605;Vila Nova do Piau√≠;-713272;-409345;0;22;Piau√≠;408;89;America/Sao_Paulo
 4323457;Vila Nova do Sul;-303461;-53876;0;43;Rio Grande do Sul;5795;55;America/Sao_Paulo
-2112852;Vila Nova dos MartÌrios;-518889;-481336;0;21;Maranh„o;264;99;America/Sao_Paulo
-3205150;Vila Pav„o;-186091;-40609;0;32;EspÌrito Santo;2935;27;America/Sao_Paulo
-5222302;Vila PropÌcio;-154542;-488819;0;52;Goi·s;1068;62;America/Sao_Paulo
+2112852;Vila Nova dos Mart√≠rios;-518889;-481336;0;21;Maranh√£o;264;99;America/Sao_Paulo
+3205150;Vila Pav√£o;-186091;-40609;0;32;Esp√≠rito Santo;2935;27;America/Sao_Paulo
+5222302;Vila Prop√≠cio;-154542;-488819;0;52;Goi√°s;1068;62;America/Sao_Paulo
 5108600;Vila Rica;-100137;-511186;0;51;Mato Grosso;9897;66;America/Porto_Velho
-3205176;Vila ValÈrio;-189958;-403849;0;32;EspÌrito Santo;768;27;America/Sao_Paulo
-3205200;Vila Velha;-203417;-402875;0;32;EspÌrito Santo;5703;27;America/Sao_Paulo
-1100304;Vilhena;-127502;-601488;0;11;RondÙnia;13;69;America/Porto_Velho
-3556701;Vinhedo;-230302;-469833;0;35;S„o Paulo;7237;19;America/Sao_Paulo
-3556800;Viradouro;-208734;-48293;0;35;S„o Paulo;7239;17;America/Sao_Paulo
+3205176;Vila Val√©rio;-189958;-403849;0;32;Esp√≠rito Santo;768;27;America/Sao_Paulo
+3205200;Vila Velha;-203417;-402875;0;32;Esp√≠rito Santo;5703;27;America/Sao_Paulo
+1100304;Vilhena;-127502;-601488;0;11;Rond√¥nia;13;69;America/Porto_Velho
+3556701;Vinhedo;-230302;-469833;0;35;S√£o Paulo;7237;19;America/Sao_Paulo
+3556800;Viradouro;-208734;-48293;0;35;S√£o Paulo;7239;17;America/Sao_Paulo
 3171600;Virgem da Lapa;-16807;-423431;0;31;Minas Gerais;5433;33;America/Sao_Paulo
-3171709;VirgÌnia;-223264;-450965;0;31;Minas Gerais;5435;35;America/Sao_Paulo
-3171808;VirginÛpolis;-188154;-427015;0;31;Minas Gerais;5437;33;America/Sao_Paulo
-3171907;Virgol‚ndia;-184738;-423067;0;31;Minas Gerais;5439;33;America/Sao_Paulo
-4128658;Virmond;-253829;-521987;0;41;Paran·;5483;42;America/Sao_Paulo
+3171709;Virg√≠nia;-223264;-450965;0;31;Minas Gerais;5435;35;America/Sao_Paulo
+3171808;Virgin√≥polis;-188154;-427015;0;31;Minas Gerais;5437;33;America/Sao_Paulo
+3171907;Virgol√¢ndia;-184738;-423067;0;31;Minas Gerais;5439;33;America/Sao_Paulo
+4128658;Virmond;-253829;-521987;0;41;Paran√°;5483;42;America/Sao_Paulo
 3172004;Visconde do Rio Branco;-210127;-428361;0;31;Minas Gerais;5441;32;America/Sao_Paulo
-1508308;Viseu;-119124;-461399;0;15;Par·;565;91;America/Sao_Paulo
+1508308;Viseu;-119124;-461399;0;15;Par√°;565;91;America/Sao_Paulo
 4323507;Vista Alegre;-273686;-534919;0;43;Rio Grande do Sul;7307;55;America/Sao_Paulo
-3556909;Vista Alegre do Alto;-211692;-486284;0;35;S„o Paulo;7241;16;America/Sao_Paulo
+3556909;Vista Alegre do Alto;-211692;-486284;0;35;S√£o Paulo;7241;16;America/Sao_Paulo
 4323606;Vista Alegre do Prata;-288052;-517947;0;43;Rio Grande do Sul;7305;54;America/Sao_Paulo
-4323705;Vista Ga˙cha;-272902;-536974;0;43;Rio Grande do Sul;7303;55;America/Sao_Paulo
-2505501;Vista Serrana;-67303;-375704;0;25;ParaÌba;2011;83;America/Sao_Paulo
+4323705;Vista Ga√∫cha;-272902;-536974;0;43;Rio Grande do Sul;7303;55;America/Sao_Paulo
+2505501;Vista Serrana;-67303;-375704;0;25;Para√≠ba;2011;83;America/Sao_Paulo
 4219358;Vitor Meireles;-268782;-498328;0;42;Santa Catarina;9977;47;America/Sao_Paulo
-3205309;VitÛria;-203155;-403128;1;32;EspÌrito Santo;5705;27;America/Sao_Paulo
-3556958;VitÛria Brasil;-201956;-504875;0;35;S„o Paulo;828;17;America/Sao_Paulo
-2933307;VitÛria da Conquista;-148615;-408442;0;29;Bahia;3965;77;America/Sao_Paulo
-4323754;VitÛria das Missıes;-283516;-54504;0;43;Rio Grande do Sul;6053;55;America/Sao_Paulo
-2616407;VitÛria de Santo Ant„o;-812819;-352976;0;26;Pernambuco;2627;81;America/Sao_Paulo
-1600808;VitÛria do Jari;-938;-52424;0;16;Amap·;70;96;America/Sao_Paulo
-2112902;VitÛria do Mearim;-345125;-448643;0;21;Maranh„o;951;98;America/Sao_Paulo
-1508357;VitÛria do Xingu;-287922;-520088;0;15;Par·;641;93;America/Sao_Paulo
-4128708;Vitorino;-262683;-527843;0;41;Paran·;7947;46;America/Sao_Paulo
-2113009;Vitorino Freire;-428184;-452505;0;21;Maranh„o;953;98;America/Sao_Paulo
+3205309;Vit√≥ria;-203155;-403128;1;32;Esp√≠rito Santo;5705;27;America/Sao_Paulo
+3556958;Vit√≥ria Brasil;-201956;-504875;0;35;S√£o Paulo;828;17;America/Sao_Paulo
+2933307;Vit√≥ria da Conquista;-148615;-408442;0;29;Bahia;3965;77;America/Sao_Paulo
+4323754;Vit√≥ria das Miss√µes;-283516;-54504;0;43;Rio Grande do Sul;6053;55;America/Sao_Paulo
+2616407;Vit√≥ria de Santo Ant√£o;-812819;-352976;0;26;Pernambuco;2627;81;America/Sao_Paulo
+1600808;Vit√≥ria do Jari;-938;-52424;0;16;Amap√°;70;96;America/Sao_Paulo
+2112902;Vit√≥ria do Mearim;-345125;-448643;0;21;Maranh√£o;951;98;America/Sao_Paulo
+1508357;Vit√≥ria do Xingu;-287922;-520088;0;15;Par√°;641;93;America/Sao_Paulo
+4128708;Vitorino;-262683;-527843;0;41;Paran√°;7947;46;America/Sao_Paulo
+2113009;Vitorino Freire;-428184;-452505;0;21;Maranh√£o;953;98;America/Sao_Paulo
 3172103;Volta Grande;-217671;-425375;0;31;Minas Gerais;5443;32;America/Sao_Paulo
 3306305;Volta Redonda;-225202;-440996;0;33;Rio de Janeiro;5925;24;America/Sao_Paulo
-3557006;Votorantim;-235446;-474388;0;35;S„o Paulo;7243;15;America/Sao_Paulo
-3557105;Votuporanga;-204237;-499781;0;35;S„o Paulo;7245;17;America/Sao_Paulo
+3557006;Votorantim;-235446;-474388;0;35;S√£o Paulo;7243;15;America/Sao_Paulo
+3557105;Votuporanga;-204237;-499781;0;35;S√£o Paulo;7245;17;America/Sao_Paulo
 2933406;Wagner;-122819;-411715;0;29;Bahia;3967;75;America/Sao_Paulo
-2211704;Wall Ferraz;-723151;-41905;0;22;PiauÌ;410;89;America/Sao_Paulo
-1722081;Wanderl‚ndia;-685274;-479601;0;17;Tocantins;9665;63;America/Sao_Paulo
+2211704;Wall Ferraz;-723151;-41905;0;22;Piau√≠;410;89;America/Sao_Paulo
+1722081;Wanderl√¢ndia;-685274;-479601;0;17;Tocantins;9665;63;America/Sao_Paulo
 2933455;Wanderley;-121144;-438958;0;29;Bahia;3999;77;America/Sao_Paulo
 3172202;Wenceslau Braz;-225368;-453626;0;31;Minas Gerais;5421;35;America/Sao_Paulo
-4128500;Wenceslau Braz;-238742;-498032;0;41;Paran·;7943;43;America/Sao_Paulo
-2933505;Wenceslau Guimar„es;-136908;-394762;0;29;Bahia;3969;73;America/Sao_Paulo
-4323770;Westf·lia;-294263;-517645;0;43;Rio Grande do Sul;1176;51;America/Sao_Paulo
+4128500;Wenceslau Braz;-238742;-498032;0;41;Paran√°;7943;43;America/Sao_Paulo
+2933505;Wenceslau Guimar√£es;-136908;-394762;0;29;Bahia;3969;73;America/Sao_Paulo
+4323770;Westf√°lia;-294263;-517645;0;43;Rio Grande do Sul;1176;51;America/Sao_Paulo
 4219408;Witmarsum;-269275;-497947;0;42;Santa Catarina;8381;47;America/Sao_Paulo
-1722107;Xambio·;-64141;-48532;0;17;Tocantins;9643;63;America/Sao_Paulo
-4128807;XambrÍ;-237364;-534884;0;41;Paran·;7949;44;America/Sao_Paulo
-4323804;Xangri-l·;-298065;-500519;0;43;Rio Grande do Sul;5785;51;America/Sao_Paulo
-4219507;XanxerÍ;-268747;-524036;0;42;Santa Catarina;8383;49;America/Sao_Paulo
+1722107;Xambio√°;-64141;-48532;0;17;Tocantins;9643;63;America/Sao_Paulo
+4128807;Xambr√™;-237364;-534884;0;41;Paran√°;7949;44;America/Sao_Paulo
+4323804;Xangri-l√°;-298065;-500519;0;43;Rio Grande do Sul;5785;51;America/Sao_Paulo
+4219507;Xanxer√™;-268747;-524036;0;42;Santa Catarina;8383;49;America/Sao_Paulo
 1200708;Xapuri;-106516;-684969;0;12;Acre;149;68;America/Rio_Branco
 4219606;Xavantina;-270667;-52343;0;42;Santa Catarina;8385;49;America/Sao_Paulo
 4219705;Xaxim;-269596;-525374;0;42;Santa Catarina;8387;49;America/Sao_Paulo
-2616506;XexÈu;-88046;-356212;0;26;Pernambuco;2293;81;America/Sao_Paulo
-1508407;Xinguara;-70983;-499437;0;15;Par·;571;94;America/Sao_Paulo
+2616506;Xex√©u;-88046;-356212;0;26;Pernambuco;2293;81;America/Sao_Paulo
+1508407;Xinguara;-70983;-499437;0;15;Par√°;571;94;America/Sao_Paulo
 2933604;Xique-Xique;-10823;-427245;0;29;Bahia;3971;74;America/Sao_Paulo
-2517407;ZabelÍ;-807901;-371057;0;25;ParaÌba;542;83;America/Sao_Paulo
-3557154;Zacarias;-210506;-500552;0;35;S„o Paulo;2973;18;America/Sao_Paulo
-2114007;ZÈ Doca;-327014;-456553;0;21;Maranh„o;1287;98;America/Sao_Paulo
-4219853;ZortÈa;-274521;-51552;0;42;Santa Catarina;950;49;America/Sao_Paulo
+2517407;Zabel√™;-807901;-371057;0;25;Para√≠ba;542;83;America/Sao_Paulo
+3557154;Zacarias;-210506;-500552;0;35;S√£o Paulo;2973;18;America/Sao_Paulo
+2114007;Z√© Doca;-327014;-456553;0;21;Maranh√£o;1287;98;America/Sao_Paulo
+4219853;Zort√©a;-274521;-51552;0;42;Santa Catarina;950;49;America/Sao_Paulo

--- a/Conversao_banco_Python/conversao.py
+++ b/Conversao_banco_Python/conversao.py
@@ -303,7 +303,7 @@ def format_coordinate(coord):
         return coord[0:2] + '.' + coord[2:]
 
 def get_coordinates_from_city(city, state):
-    with open('coordenadas.csv', newline='', encoding='ISO-8859-1') as csvfile:
+    with open('coordenadas.csv', newline='', encoding='UTF-8') as csvfile:
         csvReader = csv.reader(csvfile, delimiter=';')
 
         next(csvReader)
@@ -389,7 +389,7 @@ def dictTables():
         "`nome_arquivo` varchar(50) DEFAULT NULL,"
         "`servico` enum('REFLORA','SPECIESLINK') DEFAULT NULL,"
         "PRIMARY KEY (`id`)"
-        ") ENGINE=InnoDB DEFAULT CHARSET=latin1;")
+        ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;")
 
     TABLES['coletores'] = (
         "CREATE TABLE `coletores` ("
@@ -447,14 +447,14 @@ def dictTables():
         "`created_at` datetime DEFAULT CURRENT_TIMESTAMP,"
         "`updated_at` datetime DEFAULT CURRENT_TIMESTAMP,"
         "PRIMARY KEY (`id`)"
-        ") ENGINE=InnoDB DEFAULT CHARSET=latin1;")
+        ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;")
 
     TABLES['estados'] = (
         "CREATE TABLE `estados` ("
         "`id` int unsigned NOT NULL AUTO_INCREMENT,"
-        "`nome` varchar(255) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,"
+        "`nome` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,"
         "`sigla` char(4) DEFAULT NULL,"
-        "`codigo_telefone` varchar(10) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL,"
+        "`codigo_telefone` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,"
         "`pais_id` smallint unsigned NOT NULL,"
         "`created_at` datetime DEFAULT CURRENT_TIMESTAMP,"
         "`updated_at` datetime DEFAULT CURRENT_TIMESTAMP,"
@@ -467,7 +467,7 @@ def dictTables():
         "CREATE TABLE `cidades` ("
         "`id` int unsigned NOT NULL AUTO_INCREMENT,"  
         "`estado_id` int unsigned NOT NULL,"  
-        "`nome` varchar(255) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,"
+        "`nome` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,"
         "`latitude` double DEFAULT NULL,"
         "`longitude` double DEFAULT NULL,"
         "`created_at` datetime DEFAULT CURRENT_TIMESTAMP,"


### PR DESCRIPTION
Resolve [#58] 

Foi identificado que o arquivo coordenadas.csv não estava codificado em UTF-8, o que poderia causar problemas na leitura e inserção correta de caracteres acentuados.

Para verificar a codificação original, foi utilizado o comando:
```bash
file coordenadas.csv
```
Após constatar que a codificação não era UTF-8, foi realizada a conversão com o seguinte comando:

```bash
iconv -f ISO-8859-1 -t UTF-8 coordenadas.csv -o coordenadas_utf8.csv
```
Após renomeado, o arquivo convertido substituiu o original, garantindo que agora o conteúdo esteja em conformidade com a codificação UTF-8.