### PR TITLE
Retirando nome do banco para usar o banco da conexão já estabelecida

### DIFF
--- a/Conversao_banco_Python/Cidades_Estados_Paises/updated_cities_coordinates.sql
+++ b/Conversao_banco_Python/Cidades_Estados_Paises/updated_cities_coordinates.sql
@@ -1,178 +1,178 @@
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -8.45966, c.longitude = -35.9447
 WHERE c.nome = 'Agrestina' AND e.nome = 'Pernambuco';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -8.66852, c.longitude = -47.07333
 WHERE c.nome = 'Recursolândia' AND e.nome = 'Tocantins';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -8.39963, c.longitude = -48.12996
 WHERE c.nome = 'Tupiratins' AND e.nome = 'Tocantins';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -7.94083, c.longitude = -34.87306
 WHERE c.nome = 'Paulista' AND e.nome = 'Pernambuco';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -6.18558, c.longitude = -50.55474
 WHERE c.nome = 'Paraupebas' AND e.nome = 'Pará';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -7.26413, c.longitude = -64.7948
 WHERE c.nome = 'Lábrea' AND e.nome = 'Amazonas';
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -5.85229, c.longitude = -35.3552
 WHERE c.nome = 'Macaíba' AND e.nome = 'Rio Grande do Norte';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -7.25972, c.longitude = -34.9075
 WHERE c.nome = 'Conde' AND e.nome = 'Paraíba';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -6.96396, c.longitude = -35.6977
 WHERE c.nome = 'Areia' AND e.nome = 'Paraíba';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -6.59673, c.longitude = -35.0531
 WHERE c.nome = 'Mataraca' AND e.nome = 'Paraíba';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -7.11724, c.longitude = -34.9753
 WHERE c.nome = 'Santa Rita' AND e.nome = 'Paraíba';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -6.94018, c.longitude = -49.6834
 WHERE c.nome = 'Sapucaia' AND e.nome = 'Pará';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -0.61361, c.longitude = -47.35611
 WHERE c.nome = 'Salinópolis' AND e.nome = 'Pará';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -3.29792, c.longitude = -52.534
 WHERE c.nome = 'Brasil Novo' AND e.nome = 'Pará';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = 3.64571, c.longitude = -61.3692
 WHERE c.nome = 'Amajari' AND e.nome = 'Roraima';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -9.41622, c.longitude = -40.5033
 WHERE c.nome = 'Juazeiro' AND e.nome = 'Bahia';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -6.37161, c.longitude = -35.0033
 WHERE c.nome = 'Baía Formosa' AND e.nome = 'Rio Grande do Norte';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -7.115, c.longitude = -34.8631
 WHERE c.nome = 'João Pessoa' AND e.nome = 'Paraíba';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -9.9133, c.longitude = -63.0408
 WHERE c.nome = 'Ariquemes' AND e.nome = 'Rondônia';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -9.85656, c.longitude = -58.4192
 WHERE c.nome = 'Cotriguaçu' AND e.nome = 'Mato Grosso';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -9.84977, c.longitude = -57.8139
 WHERE c.nome = 'Nova Bandeirantes' AND e.nome = 'Mato Grosso';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -9.665, c.longitude = -56.4769
 WHERE c.nome = 'Paranaíta' AND e.nome = 'Mato Grosso';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -9.86715, c.longitude = -56.08719
 WHERE c.nome = 'Alta Floresta' AND e.nome = 'Mato Grosso';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -9.09798, c.longitude = -38.1504
 WHERE c.nome = 'Tacaratu' AND e.nome = 'Pernambuco';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -8.23333, c.longitude = -35.79694
 WHERE c.nome = 'Bezerros' AND e.nome = 'Pernambuco';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -0.410824, c.longitude = -65.0092
 WHERE c.nome = 'Santa Isabel do Rio Negro' AND e.nome = 'Amazonas';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -8.83543, c.longitude = -48.51143
 WHERE c.nome = 'Guaraí' AND e.nome = 'Tocantins';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -8.72618, c.longitude = -35.7942
 WHERE c.nome = 'Jaqueira' AND e.nome = 'Pernambuco';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -9.66583, c.longitude = -35.73528
 WHERE c.nome = 'Maceió' AND e.nome = 'Alagoas';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -6.18558, c.longitude = -50.55474
 WHERE c.nome = 'Parauapebas' AND e.nome = 'Pará';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -9.11228, c.longitude = -45.9116
 WHERE c.nome = 'Santa Filomena' AND e.nome = 'Piauí';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -3.36822, c.longitude = -64.7193
 WHERE c.nome = 'Tefé' AND e.nome = 'Amazonas';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -3.46985, c.longitude = -51.2003
 WHERE c.nome = 'Anapu' AND e.nome = 'Pará';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -4.24749, c.longitude = -49.9499
 WHERE c.nome = 'Novo Repartimento' AND e.nome = 'Pará';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -3.497016, c.longitude = -42.562452
 WHERE c.nome = 'Santa Quitéria do Maranhão' AND e.nome = 'Maranhão';
 
-UPDATE hcf.cidades c
-JOIN hcf.estados e ON c.estado_id = e.id
+UPDATE cidades c
+JOIN estados e ON c.estado_id = e.id
 SET c.latitude = -8.47222, c.longitude = -35.72972
 WHERE c.nome = 'Bonito' AND e.nome = 'Pernambuco';


### PR DESCRIPTION
Resolve [#56]

Retirado nome do banco do arquivo de atualização das coordenadas das cidades para não usar um nome fixo do banco, e sim usar o nome estabelecido pela conexão.